### PR TITLE
b3052

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -29,8 +29,8 @@ namespace CumulusMX
 	public class Cumulus
 	{
 		/////////////////////////////////
-		public string Version = "3.0.1";
-		public string Build = "3051";
+		public string Version = "3.0.2";
+		public string Build = "3052";
 		/////////////////////////////////
 
 		private static string appGuid = "57190d2e-7e45-4efb-8c09-06a176cef3f3";
@@ -3022,10 +3022,11 @@ namespace CumulusMX
 			solar_logging = ini.GetValue("Station", "SolarLog", false);
 #if DEBUG
 			logging = true;
+			DataLogging = true;
 #else
 			logging = ini.GetValue("Station", "Logging", false);
-#endif
 			DataLogging = ini.GetValue("Station", "DataLogging", false);
+#endif
 
 			VP2ConnectionType = ini.GetValue("Station", "VP2ConnectionType", VP2SERIALCONNECTION);
 			VP2TCPPort = ini.GetValue("Station", "VP2TCPPort", 22222);

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CumulusMX")]
-[assembly: AssemblyDescription("Build 3051")]
+[assembly: AssemblyDescription("Build 3052")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CumulusMX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.1.3051")]
-[assembly: AssemblyFileVersion("3.0.1.3051")]
+[assembly: AssemblyVersion("3.0.2.3052")]
+[assembly: AssemblyFileVersion("3.0.2.3052")]

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,14 @@
+3.0.2 - b3052
+=============
+- Fixes Davis archive downloads from the the logger when the day rollover processing takes longer than 10 seconds.
+  This can happen on slow processors - Pi Zero for example - or if lengthy procedures are included
+  An extra archive processing run is scheduled for each day rollover that takes longer than 10 seconds
+
+- Updated files
+	\CumulusMX.exe
+	\CumulusMX.exe.config
+	\CumulusMX.pdb
+
 
 3.0.1 - b3051
 =============


### PR DESCRIPTION
- Fixes Davis archive downloads from the the logger when the day rollover processing takes longer than 10 seconds.
