### PR TITLE
B3057

### DIFF
--- a/CumulusMX/CalibrationSettings.cs
+++ b/CumulusMX/CalibrationSettings.cs
@@ -45,6 +45,7 @@ namespace CumulusMX
 				cumulus.InTempoffset = Convert.ToDouble(settings.offsets.indoortemp, InvC);
 				cumulus.HumOffset = settings.offsets.humidity;
 				cumulus.WindDirOffset = settings.offsets.winddir;
+				cumulus.SolarOffset = Convert.ToDouble(settings.offsets.solar);
 				cumulus.UVOffset = Convert.ToDouble(settings.offsets.uv, InvC);
 				cumulus.WetBulbOffset = Convert.ToDouble(settings.offsets.wetbulb, InvC);
 
@@ -55,6 +56,7 @@ namespace CumulusMX
 				cumulus.TempMult = Convert.ToDouble(settings.multipliers.outdoortemp, InvC);
 				cumulus.HumMult = Convert.ToDouble(settings.multipliers.humidity, InvC);
 				cumulus.RainMult = Convert.ToDouble(settings.multipliers.rainfall, InvC);
+				cumulus.SolarMult = Convert.ToDouble(settings.multipliers.solar, InvC);
 				cumulus.UVMult = Convert.ToDouble(settings.multipliers.uv, InvC);
 				cumulus.WetBulbMult = Convert.ToDouble(settings.multipliers.wetbulb, InvC);
 
@@ -92,6 +94,7 @@ namespace CumulusMX
 						indoortemp = cumulus.InTempoffset,
 						humidity = cumulus.HumOffset,
 						winddir = cumulus.WindDirOffset,
+						solar = cumulus.SolarOffset,
 						uv = cumulus.UVOffset,
 						wetbulb = cumulus.WetBulbOffset
 					};
@@ -103,6 +106,7 @@ namespace CumulusMX
 						humidity = cumulus.HumMult,
 						outdoortemp = cumulus.TempMult,
 						rainfall = cumulus.RainMult,
+						solar = cumulus.SolarMult,
 						uv = cumulus.UVMult,
 						wetbulb = cumulus.WetBulbMult
 					};
@@ -162,6 +166,7 @@ namespace CumulusMX
 		public double indoortemp { get; set; }
 		public int humidity { get; set; }
 		public int winddir { get; set; }
+		public double solar { get; set; }
 		public double uv { get; set; }
 		public double wetbulb { get; set; }
 	}
@@ -174,6 +179,7 @@ namespace CumulusMX
 		public double outdoortemp { get; set; }
 		public double humidity { get; set; }
 		public double rainfall { get; set; }
+		public double solar { get; set; }
 		public double uv { get; set; }
 		public double wetbulb { get; set; }
 	}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -29,8 +29,8 @@ namespace CumulusMX
 	public class Cumulus
 	{
 		/////////////////////////////////
-		public string Version = "3.2.0";
-		public string Build = "3056";
+		public string Version = "3.2.1";
+		public string Build = "3057";
 		/////////////////////////////////
 
 		private static string appGuid = "57190d2e-7e45-4efb-8c09-06a176cef3f3";
@@ -505,6 +505,7 @@ namespace CumulusMX
 		public int HumOffset = 0;
 		public int WindDirOffset = 0;
 		public double InTempoffset = 0.0;
+		public double SolarOffset = 0.0;
 		public double UVOffset = 0.0;
 		public double WetBulbOffset = 0.0;
 
@@ -516,6 +517,7 @@ namespace CumulusMX
 		public double HumMult = 1.0;
 		public double HumMult2 = 0.0;
 		public double RainMult = 1.0;
+		public double SolarMult = 1.0;
 		public double UVMult = 1.0;
 		public double WetBulbMult = 1.0;
 
@@ -1289,9 +1291,9 @@ namespace CumulusMX
 			LogMessage("RainDayThreshold=" + RainDayThreshold.ToString("F3"));
 			LogMessage("Offsets and Multipliers:");
 			LogMessage("PO=" + PressOffset.ToString("F3") + " TO=" + TempOffset.ToString("F3") + " HO=" + HumOffset + " WDO=" + WindDirOffset + " ITO=" +
-						InTempoffset.ToString("F3") + " UVO=" + UVOffset.ToString("F3"));
+						InTempoffset.ToString("F3") + "SO=" + SolarOffset.ToString("F3") + " UVO=" + UVOffset.ToString("F3"));
 			LogMessage("PM=" + PressMult.ToString("F3") + " WSM=" + WindSpeedMult.ToString("F3") + " WGM=" + WindGustMult.ToString("F3") + " TM=" + TempMult.ToString("F3") + " TM2=" + TempMult2.ToString("F3") +
-						" HM=" + HumMult.ToString("F3") + " HM2=" + HumMult2.ToString("F3") + " RM=" + RainMult.ToString("F3") + " UVM=" + UVMult.ToString("F3"));
+						" HM=" + HumMult.ToString("F3") + " HM2=" + HumMult2.ToString("F3") + " RM=" + RainMult.ToString("F3") + "SM=" + SolarMult.ToString("F3") + " UVM=" + UVMult.ToString("F3"));
 			LogMessage("Spike removal:");
 			LogMessage("TD=" + EWtempdiff.ToString("F3") + " GD=" + EWgustdiff.ToString("F3") + " WD=" + EWwinddiff.ToString("F3") + " HD=" + EWhumiditydiff.ToString("F3") + " PD=" +
 						EWpressurediff.ToString("F3"));
@@ -3382,6 +3384,7 @@ namespace CumulusMX
 			HumOffset = ini.GetValue("Offsets", "HumOffset", 0);
 			WindDirOffset = ini.GetValue("Offsets", "WindDirOffset", 0);
 			InTempoffset = ini.GetValue("Offsets", "InTempOffset", 0.0);
+			SolarOffset = ini.GetValue("Offsers", "SolarOffset", 0.0);
 			UVOffset = ini.GetValue("Offsets", "UVOffset", 0.0);
 			WetBulbOffset = ini.GetValue("Offsets", "WetBulbOffset", 0.0);
 
@@ -3393,6 +3396,7 @@ namespace CumulusMX
 			HumMult = ini.GetValue("Offsets", "HumMult", 1.0);
 			HumMult2 = ini.GetValue("Offsets", "HumMult2", 0.0);
 			RainMult = ini.GetValue("Offsets", "RainMult", 1.0);
+			SolarMult = ini.GetValue("Offsets", "SolarMult", 1.0);
 			UVMult = ini.GetValue("Offsets", "UVMult", 1.0);
 			WetBulbMult = ini.GetValue("Offsets", "WetBulbMult", 1.0);
 
@@ -3911,6 +3915,7 @@ namespace CumulusMX
 			ini.SetValue("Offsets", "WindDirOffset", WindDirOffset);
 			ini.SetValue("Offsets", "InTempOffset", InTempoffset);
 			ini.SetValue("Offsets", "UVOffset", UVOffset);
+			ini.SetValue("Offsets", "SolarOffset", SolarOffset);
 			ini.SetValue("Offsets", "WetBulbOffset", WetBulbOffset);
 			//ini.SetValue("Offsets", "DavisCalcAltPressOffset", DavisCalcAltPressOffset);
 
@@ -3921,6 +3926,7 @@ namespace CumulusMX
 			ini.SetValue("Offsets", "TempMult", TempMult);
 			ini.SetValue("Offsets", "HumMult", HumMult);
 			ini.SetValue("Offsets", "RainMult", RainMult);
+			ini.SetValue("Offsets", "SolarMult", SolarMult);
 			ini.SetValue("Offsets", "UVMult", UVMult);
 			ini.SetValue("Offsets", "WetBulbMult", WetBulbMult);
 

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -24,8 +24,8 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>3056</ApplicationRevision>
-    <ApplicationVersion>3.2.0.3056</ApplicationVersion>
+    <ApplicationRevision>3057</ApplicationRevision>
+    <ApplicationVersion>3.2.1.3057</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <ExcludeDeploymentUrl>true</ExcludeDeploymentUrl>
     <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -90,8 +90,8 @@
     <Reference Include="FluentFTP, Version=21.0.0.0, Culture=neutral, PublicKeyToken=f4af092b1d8df44f, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentFTP.21.0.0\lib\net45\FluentFTP.dll</HintPath>
     </Reference>
-    <Reference Include="HidSharp, Version=2.0.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\HidSharp.2.0.8\lib\net35\HidSharp.dll</HintPath>
+    <Reference Include="HidSharp, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HidSharp.2.1.0\lib\net35\HidSharp.dll</HintPath>
     </Reference>
     <Reference Include="LinqToTwitter.AspNet, Version=3.1.1.15391, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -905,7 +905,8 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogDataMessage("Error sending LOOP command: " + ex.Message);
+				cumulus.LogMessage("Error sending LOOP command [" + commandString.Replace("\n", "") + "]: " + ex.Message);
+				WakeVP(tcpPort);
 			}
 
 			// return result to indicate success or otherwise
@@ -2476,10 +2477,7 @@ namespace CumulusMX
 			int passCount = 1, maxPasses = 4;
 			NetworkStream theStream;
 
-			if (cumulus.DataLogging)
-			{
-				cumulus.LogMessage("Wake VP");
-			}
+			cumulus.LogDataMessage("Wake VP");
 
 			try
 			{

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CumulusMX")]
-[assembly: AssemblyDescription("Build 3056")]
+[assembly: AssemblyDescription("Build 3057")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CumulusMX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.2.0.3056")]
-[assembly: AssemblyFileVersion("3.2.0.3056")]
+[assembly: AssemblyVersion("3.2.1.3057")]
+[assembly: AssemblyFileVersion("3.2.1.3057")]

--- a/CumulusMX/WMR200Station.cs
+++ b/CumulusMX/WMR200Station.cs
@@ -1628,14 +1628,14 @@ namespace CumulusMX
 			// just to calculate theoretical max for consistency
 			DoSolarRad(0, timestamp);
 
+			DoApparentTemp(timestamp);
+
 			cumulus.DoLogFile(timestamp,false);
 
 			if (cumulus.LogExtraSensors)
 			{
 				cumulus.DoExtraLogFile(timestamp);
 			}
-
-			DoApparentTemp(timestamp);
 
 			AddLastHourDataEntry(timestamp, Raincounter, OutdoorTemperature);
 			AddLast3HourDataEntry(timestamp, Pressure, OutdoorTemperature);

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -3727,7 +3727,7 @@ namespace CumulusMX
 
 		protected void DoSolarRad(int value, DateTime timestamp)
 		{
-			SolarRad = value;
+			SolarRad = (value * cumulus.SolarMult) + cumulus.SolarOffset;
 			// Update display
 
 			if (SolarRad > HighSolarToday)

--- a/CumulusMX/packages.config
+++ b/CumulusMX/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="EmbedIO" version="2.1.1" targetFramework="net452" />
   <package id="FluentFTP" version="21.0.0" targetFramework="net452" />
-  <package id="HidSharp" version="2.0.8" targetFramework="net452" />
+  <package id="HidSharp" version="2.1.0" targetFramework="net452" />
   <package id="linqtotwitter" version="3.1.1" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net452" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,21 @@
+3.2.1 - b3057
+=============
+- Fix for WMR200 stations writing a zero value Apparent Temperature to the log files when retrieving logger data
+- Fix the dashboard for Internet Explorer
+- Fix default website index page header not wrapping on small screens
+- Fix for Davis stations connected via TCP/IP to detect failures and reopen the connection more quickly during loop data processing
+- Adds Solar calibration settings offset and multiplier
+- Updates the SampleStrings.ini file with the extra captions added in b3056
+
+- Updated files
+	\CumulusMX.exe
+	\SampleStrings.ini
+	\HidSharp.dll
+	\interface\js\dashboard.js
+	\interface\json\CalibrationSchema.json
+	\web\indexT.htm
+
+
 3.2.0 - b3056
 =============
 - Adds support for Ecowitt GW1000 WiFi gateway
@@ -37,7 +55,7 @@
 - Changes All Time Records editor to only load data from the Day File by default. Monthly log file
   processing is now optional as it can take a very long time on a slow machine e.g. Raspberry Pi
 - Fix to catch badly formed Davis WLL broadcast messages
-- Fix for Davis WLL edge cases producing an intial zero value wind chill on startup
+- Fix for Davis WLL edge cases producing an initial zero value wind chill on startup
 
 - Updated files
 	\CumulusMX.exe


### PR DESCRIPTION
- Fix for WMR200 stations writing a zero value Apparent Temperature to the log files when retrieving logger data
- Fix the dashboard for Internet Explorer
- Fix for Davis stations connected via TCP/IP to detect failures and reopen the connection more quickly during loop data processing
- Adds Solar calibration settings offset and multiplier