### PR TITLE
Cleanly compile both components with VS2015

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1931,7 +1931,8 @@ namespace CumulusMX
 			{
 				UpdatingWU = true;
 
-				string URL = station.GetWundergroundURL(out var pwstring, timestamp, false);
+                string pwstring;
+				string URL = station.GetWundergroundURL(out pwstring, timestamp, false);
 
 				string starredpwstring = "&PASSWORD=" + new string('*', WundPW.Length);
 
@@ -1967,7 +1968,8 @@ namespace CumulusMX
 			{
 				UpdatingWindy = true;
 
-				string URL = station.GetWindyURL(out var apistring, timestamp);
+                string apistring;
+                string URL = station.GetWindyURL(out apistring, timestamp);
 				string LogURL = URL.Replace(apistring, "<<API_KEY>>");
 
 				LogDebugMessage("Windy URL: " + LogURL);
@@ -1996,7 +1998,8 @@ namespace CumulusMX
 			{
 				UpdatingAwekas = true;
 
-				string URL = station.GetAwekasURL(out var pwstring, timestamp);
+                string pwstring;
+				string URL = station.GetAwekasURL(out pwstring, timestamp);
 
 				string starredpwstring = "<password>";
 
@@ -2027,7 +2030,8 @@ namespace CumulusMX
 			{
 				UpdatingWCloud = true;
 
-				string URL = station.GetWCloudURL(out var pwstring, timestamp);
+                string pwstring;
+                string URL = station.GetWCloudURL(out pwstring, timestamp);
 
 				string starredpwstring = "<key>";
 
@@ -7247,7 +7251,8 @@ namespace CumulusMX
 			{
 				UpdatingPWS = true;
 
-				string URL = station.GetPWSURL(out var pwstring, timestamp);
+                string pwstring;
+                string URL = station.GetPWSURL(out pwstring, timestamp);
 
 				string starredpwstring = "&PASSWORD=" + new string('*', PWSPW.Length);
 
@@ -7277,7 +7282,8 @@ namespace CumulusMX
 			{
 				UpdatingWOW = true;
 
-				string URL = station.GetWOWURL(out var pwstring, timestamp);
+                string pwstring;
+                string URL = station.GetWOWURL(out pwstring, timestamp);
 
 				string starredpwstring = "&siteAuthenticationKey=" + new string('*', WOWPW.Length);
 
@@ -7307,7 +7313,8 @@ namespace CumulusMX
 			{
 				UpdatingWB = true;
 
-				string URL = station.GetWeatherbugURL(out var pwstring, timestamp);
+                string pwstring;
+                string URL = station.GetWeatherbugURL(out pwstring, timestamp);
 
 				string starredpwstring = "&Key=" + new string('*', WeatherbugPW.Length);
 
@@ -7439,7 +7446,8 @@ namespace CumulusMX
 		{
 			if (WundEnabled && WundCatchUp)
 			{
-				string URL = station.GetWundergroundURL(out var pwstring, timestamp, true);
+                string pwstring;
+                string URL = station.GetWundergroundURL(out pwstring, timestamp, true);
 
 				WundList.Add(URL);
 
@@ -7457,7 +7465,8 @@ namespace CumulusMX
 		{
 			if (WindyEnabled && WindyCatchUp)
 			{
-				string URL = station.GetWindyURL(out var apistring, timestamp);
+                string apistring;
+                string URL = station.GetWindyURL(out apistring, timestamp);
 
 				WindyList.Add(URL);
 
@@ -7473,7 +7482,8 @@ namespace CumulusMX
 		{
 			if (PWSEnabled && PWSCatchUp)
 			{
-				string URL = station.GetPWSURL(out var pwstring, timestamp);
+                string pwstring;
+                string URL = station.GetPWSURL(out pwstring, timestamp);
 
 				PWSList.Add(URL);
 
@@ -7491,7 +7501,8 @@ namespace CumulusMX
 		{
 			if (WOWEnabled && WOWCatchUp)
 			{
-				string URL = station.GetWOWURL(out var pwstring, timestamp);
+                string pwstring;
+                string URL = station.GetWOWURL(out pwstring, timestamp);
 
 				WOWList.Add(URL);
 
@@ -7509,7 +7520,8 @@ namespace CumulusMX
 		{
 			if (WeatherbugEnabled && WeatherbugCatchUp)
 			{
-				string URL = station.GetWeatherbugURL(out var pwstring, timestamp);
+                string pwstring;
+                string URL = station.GetWeatherbugURL(out pwstring, timestamp);
 
 				WeatherbugList.Add(URL);
 

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -1032,8 +1032,9 @@ namespace CumulusMX
 			if (arrOctets.Length != 4)
 				return false;
 
-			//Check each substring checking that parses to byte
-			return arrOctets.All(strOctet => byte.TryParse(strOctet, out _));
+            //Check each substring checking that parses to byte
+            byte result;
+			return arrOctets.All(strOctet => byte.TryParse(strOctet, out result));
 		}
 
 		private void SetTxBatteryStatus(int txId, uint status)

--- a/ExportMySQL/ExportMySQL.csproj
+++ b/ExportMySQL/ExportMySQL.csproj
@@ -47,11 +47,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Devart.Data">
-      <HintPath>..\packages\Devart.Data.dll</HintPath>
+    <Reference Include="Devart.Data, Version=5.0.1181.0, Culture=neutral, PublicKeyToken=09af7300eec23701, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\CumulusMX\CumulusMX\lib\Devart.Data.dll</HintPath>
     </Reference>
-    <Reference Include="Devart.Data.MySql">
-      <HintPath>..\packages\Devart.Data.MySql.dll</HintPath>
+    <Reference Include="Devart.Data.MySql, Version=8.3.389.0, Culture=neutral, PublicKeyToken=09af7300eec23701, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\CumulusMX\CumulusMX\lib\Devart.Data.MySql.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
These changes allow Visual Studio 2015 that deploys C# 6 to compile the project. The changes are minor. Also, fixed is the incomplete reference to DevArt module within the ExportMySql project so the module is correctly referenced and copied on build.