### PR TITLE
Enabled retained flag MQTT

### DIFF
--- a/CumulusMX/MqttPublisher.cs
+++ b/CumulusMX/MqttPublisher.cs
@@ -80,6 +80,7 @@ namespace CumulusMX
 			var mqttMsg = new MqttApplicationMessageBuilder()
 				.WithTopic(topic)
 				.WithPayload(message)
+				.WithRetainFlag()
 				.Build();
 
 			await mqttClient.PublishAsync(mqttMsg, CancellationToken.None);


### PR DESCRIPTION
Retained messages help newly-subscribed clients get a status update immediately after they subscribe to a topic. The retained message eliminates the wait for the publishing clients to send the next update.

More info:
https://www.hivemq.com/blog/mqtt-essentials-part-8-retained-messages/

Forum topic:
https://cumulus.hosiene.co.uk/viewtopic.php?f=36&t=18488