### PR TITLE
Fix Object reference not set to an instance of an object fault

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1482,7 +1482,7 @@ namespace CumulusMX
 			}
 
 			// If enabled generate the daily graph data files, and upload at first opportunity
-			if (IncludeGraphDataFiles)
+			if ((station != null) && IncludeGraphDataFiles)
 			{
 				LogDebugMessage("Generating the daily graph data files");
 				station.CreateEodGraphDataFiles();


### PR DESCRIPTION
This fixes "Object reference not set to an instance of an object." fault with a clean installation on startup.