### PR TITLE
v3.9.7

### DIFF
--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -364,6 +364,32 @@ namespace CumulusMX
 							return await this.JsonResponseAsync(Station.GetAqGraphData());
 						case "availabledata.json":
 							return await this.JsonResponseAsync(Station.GetAvailGraphData());
+
+						case "selectachart.json":
+							return await this.JsonResponseAsync(Station.GetSelectaChartOptions());
+					}
+
+					throw new KeyNotFoundException("Key Not Found: " + lastSegment);
+				}
+				catch (Exception ex)
+				{
+					return await HandleError(ex, 404);
+				}
+			}
+
+			[WebApiHandler(HttpVerbs.Post, RelativePath + "graphdata/*")]
+			public async Task<bool> SetGraphData()
+			{
+				try
+				{
+					// read the last segment of the URL to determine what data the caller wants
+					var lastSegment = Request.Url.Segments.Last();
+
+					switch (lastSegment)
+					{
+						case "selectachart.json":
+							return await this.JsonResponseAsync(stationSettings.SetSelectaChartOptions(this));
+
 					}
 
 					throw new KeyNotFoundException("Key Not Found: " + lastSegment);
@@ -411,6 +437,7 @@ namespace CumulusMX
 					return await HandleError(ex, 404);
 				}
 			}
+
 
 			private async Task<bool> HandleError(Exception ex, int statusCode)
 			{

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -362,6 +362,8 @@ namespace CumulusMX
 							return await this.JsonResponseAsync(Station.GetGraphConfig());
 						case "airqualitydata.json":
 							return await this.JsonResponseAsync(Station.GetAqGraphData());
+						case "availabledata.json":
+							return await this.JsonResponseAsync(Station.GetAvailGraphData());
 					}
 
 					throw new KeyNotFoundException("Key Not Found: " + lastSegment);

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -32,8 +32,8 @@ namespace CumulusMX
 	public class Cumulus
 	{
 		/////////////////////////////////
-		public string Version = "3.9.6";
-		public string Build = "3101";
+		public string Version = "3.9.7";
+		public string Build = "3102";
 		/////////////////////////////////
 
 		public static SemaphoreSlim syncInit = new SemaphoreSlim(1);

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -7964,11 +7964,17 @@ namespace CumulusMX
 				parser.SourceFile = template;
 				var output = parser.ToString();
 
-				using (StreamWriter file = new StreamWriter(outputfile, false, encoding))
+				try
 				{
-					file.Write(output);
-
-					file.Close();
+					using (StreamWriter file = new StreamWriter(outputfile, false, encoding))
+					{
+						file.Write(output);
+						file.Close();
+					}
+				}
+				catch (Exception e)
+				{
+					LogMessage($"ProcessTemplateFile: Error writing to file '{outputfile}', error was - {e}");
 				}
 			}
 		}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -489,11 +489,13 @@ namespace CumulusMX
 		private readonly string webRecordFile;
 		private readonly string webTrendsFile;
 		private readonly string webHistoricFile;
+		private readonly string webSelectaChartFile;
 		private readonly string webGaugesFile;
 		private readonly string webThisMonthFile;
 		private readonly string webThisYearFile;
 		private readonly string MonthlyRecordFile;
 
+		private readonly string[] localWebTemplateFiles;
 		private readonly string[] localWebTextFiles;
 		private readonly string[] remoteWebTextFiles;
 
@@ -992,6 +994,7 @@ namespace CumulusMX
 			ThisYearTFile = WebPath + "thisyearT.htm";
 			MonthlyRecordTFile = WebPath + "monthlyrecordT.htm";
 			HistoricTFile = WebPath + "historicT.htm";
+			SelectaChartTFile = WebPath + "selectachartT.htm";
 			RealtimeGaugesTxtTFile = WebPath + "realtimegaugesT.txt";
 
 			webIndexFile = WebPath + "index.htm";
@@ -1004,10 +1007,12 @@ namespace CumulusMX
 			webThisYearFile = WebPath + "thisyear.htm";
 			MonthlyRecordFile = WebPath + "monthlyrecord.htm";
 			webHistoricFile = WebPath + "historic.htm";
+			webSelectaChartFile = WebPath + "selectachart.htm";
 			RealtimeGaugesTxtFile = WebPath + "realtimegauges.txt";
 
-			localWebTextFiles = new[] { webIndexFile, webTodayFile, webYesterFile, webRecordFile, webTrendsFile, webGaugesFile, webThisMonthFile, webThisYearFile, MonthlyRecordFile, webHistoricFile };
-			remoteWebTextFiles = new[] { "index.htm", "today.htm", "yesterday.htm", "record.htm", "trends.htm", "gauges.htm", "thismonth.htm", "thisyear.htm", "monthlyrecord.htm", "historic.htm" };
+			localWebTemplateFiles = new[] { IndexTFile, TodayTFile, YesterdayTFile, RecordTFile, TrendsTFile, GaugesTFile, ThisMonthTFile, ThisYearTFile, MonthlyRecordTFile, HistoricTFile, SelectaChartTFile };
+			localWebTextFiles = new[] { webIndexFile, webTodayFile, webYesterFile, webRecordFile, webTrendsFile, webGaugesFile, webThisMonthFile, webThisYearFile, MonthlyRecordFile, webHistoricFile, webSelectaChartFile };
+			remoteWebTextFiles = new[] { "index.htm", "today.htm", "yesterday.htm", "record.htm", "trends.htm", "gauges.htm", "thismonth.htm", "thisyear.htm", "monthlyrecord.htm", "historic.htm", "selectachart.htm" };
 
 			// Set the default upload intervals for web services
 			Wund.DefaultInterval = 15;
@@ -1124,18 +1129,19 @@ namespace CumulusMX
 
 			remoteGraphdataFiles = new[]
 			{
-				"graphconfig.json",
-				"tempdata.json",
-				"pressdata.json",
-				"winddata.json",
-				"wdirdata.json",
-				"humdata.json",
-				"raindata.json",
-				"dailyrain.json",
-				"dailytemp.json",
-				"solardata.json",
-				"sunhours.json",
-				"airquality.json"
+				"graphconfig.json",		// 0
+				"tempdata.json",		// 1
+				"pressdata.json",		// 2
+				"winddata.json",		// 3
+				"wdirdata.json",		// 4
+				"humdata.json",			// 5
+				"raindata.json",		// 6
+				"dailyrain.json",		// 7
+				"dailytemp.json",		// 8
+				"solardata.json",		// 9
+				"sunhours.json",		// 10
+				"airquality.json",		// 11
+				"availabledata.json"	// 12
 			};
 
 			localGraphdataFiles = new[]
@@ -1151,7 +1157,8 @@ namespace CumulusMX
 				"web" + DirectorySeparator + remoteGraphdataFiles[8],	// 8
 				"web" + DirectorySeparator + remoteGraphdataFiles[9],	// 9
 				"web" + DirectorySeparator + remoteGraphdataFiles[10],	// 10
-				"web" + DirectorySeparator + remoteGraphdataFiles[11]	// 11
+				"web" + DirectorySeparator + remoteGraphdataFiles[11],	// 11
+				"web" + DirectorySeparator + remoteGraphdataFiles[12]	// 12
 			};
 
 			remoteDailyGraphdataFiles = new[]
@@ -1332,11 +1339,14 @@ namespace CumulusMX
 
 			SetupUnitText();
 
-			LogMessage("WindUnit=" + WindUnitText + " RainUnit=" + RainUnitText + " TempUnit=" + TempUnitText + " PressureUnit=" + PressUnitText);
-			LogMessage("YTDRain=" + YTDrain.ToString("F3") + " Year=" + YTDrainyear);
-			LogMessage("RainDayThreshold=" + RainDayThreshold.ToString("F3"));
+			LogMessage($"WindUnit={WindUnitText} RainUnit={RainUnitText} TempUnit={TempUnitText} PressureUnit={PressUnitText}");
+			LogMessage($"YTDRain={YTDrain:F3} Year={YTDrainyear}");
+			LogMessage($"RainDayThreshold={RainDayThreshold:F3}");
+			LogMessage($"Roll over hour={RolloverHour}");
 
 			LogOffsetsMultipliers();
+
+			LogPrimaryAqSensor();
 
 			LogMessage("Cumulus Starting");
 
@@ -1397,6 +1407,7 @@ namespace CumulusMX
 					break;
 				default:
 					LogConsoleMessage("Station type not set");
+					LogMessage("Station type not set");
 					break;
 			}
 
@@ -1413,7 +1424,6 @@ namespace CumulusMX
 					airLinkDataOut = new AirLinkData();
 					airLinkOut = new DavisAirLink(this, false, station);
 				}
-
 			}
 
 			webtags = new WebTags(this, station);
@@ -5669,6 +5679,7 @@ namespace CumulusMX
 		private readonly string MonthlyRecordTFile;
 		private readonly string TrendsTFile;
 		private readonly string HistoricTFile;
+		private readonly string SelectaChartTFile;
 		private readonly string ThisMonthTFile;
 		private readonly string ThisYearTFile;
 		private readonly string GaugesTFile;
@@ -6048,7 +6059,7 @@ namespace CumulusMX
 			// 2-11  Temperature 1-10
 			// 12-21 Humidity 1-10
 			// 22-31 Dew point 1-10
-			// 31-35 Soil temp 1-4
+			// 32-35 Soil temp 1-4
 			// 36-39 Soil moisture 1-4
 			// 40-41 Leaf temp 1-2
 			// 42-43 Leaf wetness 1-2
@@ -6071,87 +6082,87 @@ namespace CumulusMX
 			using (FileStream fs = new FileStream(filename, FileMode.Append, FileAccess.Write, FileShare.Read))
 			using (StreamWriter file = new StreamWriter(fs))
 			{
-				file.Write(timestamp.ToString("dd/MM/yy") + ListSeparator);
-				file.Write(timestamp.ToString("HH:mm") + ListSeparator);
+				file.Write(timestamp.ToString("dd/MM/yy") + ListSeparator);						//0
+				file.Write(timestamp.ToString("HH:mm") + ListSeparator);						//1
 
 				for (int i = 1; i < 11; i++)
 				{
-					file.Write(station.ExtraTemp[i].ToString(TempFormat) + ListSeparator);
+					file.Write(station.ExtraTemp[i].ToString(TempFormat) + ListSeparator);		//2-11
 				}
 				for (int i = 1; i < 11; i++)
 				{
-					file.Write(station.ExtraHum[i].ToString(HumFormat) + ListSeparator);
+					file.Write(station.ExtraHum[i].ToString(HumFormat) + ListSeparator);		//12-21
 				}
 				for (int i = 1; i < 11; i++)
 				{
-					file.Write(station.ExtraDewPoint[i].ToString(TempFormat) + ListSeparator);
+					file.Write(station.ExtraDewPoint[i].ToString(TempFormat) + ListSeparator);	//22-31
 				}
 
-				file.Write(station.SoilTemp1.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp2.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp3.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp4.ToString(TempFormat) + ListSeparator);
+				file.Write(station.SoilTemp1.ToString(TempFormat) + ListSeparator);		//32
+				file.Write(station.SoilTemp2.ToString(TempFormat) + ListSeparator);		//33
+				file.Write(station.SoilTemp3.ToString(TempFormat) + ListSeparator);		//34
+				file.Write(station.SoilTemp4.ToString(TempFormat) + ListSeparator);		//35
 
-				file.Write(station.SoilMoisture1 + ListSeparator);
-				file.Write(station.SoilMoisture2 + ListSeparator);
-				file.Write(station.SoilMoisture3 + ListSeparator);
-				file.Write(station.SoilMoisture4 + ListSeparator);
+				file.Write(station.SoilMoisture1 + ListSeparator);						//36
+				file.Write(station.SoilMoisture2 + ListSeparator);						//37
+				file.Write(station.SoilMoisture3 + ListSeparator);						//38
+				file.Write(station.SoilMoisture4 + ListSeparator);						//39
 
-				file.Write(station.LeafTemp1.ToString(TempFormat) + ListSeparator);
-				file.Write(station.LeafTemp2.ToString(TempFormat) + ListSeparator);
+				file.Write(station.LeafTemp1.ToString(TempFormat) + ListSeparator);		//40
+				file.Write(station.LeafTemp2.ToString(TempFormat) + ListSeparator);		//41
 
-				file.Write(station.LeafWetness1 + ListSeparator);
-				file.Write(station.LeafWetness2 + ListSeparator);
+				file.Write(station.LeafWetness1 + ListSeparator);						//42
+				file.Write(station.LeafWetness2 + ListSeparator);						//43
 
-				file.Write(station.SoilTemp5.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp6.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp7.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp8.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp9.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp10.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp11.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp12.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp13.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp14.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp15.ToString(TempFormat) + ListSeparator);
-				file.Write(station.SoilTemp16.ToString(TempFormat) + ListSeparator);
+				file.Write(station.SoilTemp5.ToString(TempFormat) + ListSeparator);		//44
+				file.Write(station.SoilTemp6.ToString(TempFormat) + ListSeparator);		//45
+				file.Write(station.SoilTemp7.ToString(TempFormat) + ListSeparator);		//46
+				file.Write(station.SoilTemp8.ToString(TempFormat) + ListSeparator);		//47
+				file.Write(station.SoilTemp9.ToString(TempFormat) + ListSeparator);		//48
+				file.Write(station.SoilTemp10.ToString(TempFormat) + ListSeparator);	//49
+				file.Write(station.SoilTemp11.ToString(TempFormat) + ListSeparator);	//50
+				file.Write(station.SoilTemp12.ToString(TempFormat) + ListSeparator);	//51
+				file.Write(station.SoilTemp13.ToString(TempFormat) + ListSeparator);	//52
+				file.Write(station.SoilTemp14.ToString(TempFormat) + ListSeparator);	//53
+				file.Write(station.SoilTemp15.ToString(TempFormat) + ListSeparator);	//54
+				file.Write(station.SoilTemp16.ToString(TempFormat) + ListSeparator);	//55
 
-				file.Write(station.SoilMoisture5 + ListSeparator);
-				file.Write(station.SoilMoisture6 + ListSeparator);
-				file.Write(station.SoilMoisture7 + ListSeparator);
-				file.Write(station.SoilMoisture8 + ListSeparator);
-				file.Write(station.SoilMoisture9 + ListSeparator);
-				file.Write(station.SoilMoisture10 + ListSeparator);
-				file.Write(station.SoilMoisture11 + ListSeparator);
-				file.Write(station.SoilMoisture12 + ListSeparator);
-				file.Write(station.SoilMoisture13 + ListSeparator);
-				file.Write(station.SoilMoisture14 + ListSeparator);
-				file.Write(station.SoilMoisture15 + ListSeparator);
-				file.Write(station.SoilMoisture16 + ListSeparator);
+				file.Write(station.SoilMoisture5 + ListSeparator);		//56
+				file.Write(station.SoilMoisture6 + ListSeparator);		//57
+				file.Write(station.SoilMoisture7 + ListSeparator);		//58
+				file.Write(station.SoilMoisture8 + ListSeparator);		//59
+				file.Write(station.SoilMoisture9 + ListSeparator);		//60
+				file.Write(station.SoilMoisture10 + ListSeparator);		//61
+				file.Write(station.SoilMoisture11 + ListSeparator);		//62
+				file.Write(station.SoilMoisture12 + ListSeparator);		//63
+				file.Write(station.SoilMoisture13 + ListSeparator);		//64
+				file.Write(station.SoilMoisture14 + ListSeparator);		//65
+				file.Write(station.SoilMoisture15 + ListSeparator);		//66
+				file.Write(station.SoilMoisture16 + ListSeparator);		//67
 
-				file.Write(station.AirQuality1.ToString("F1") + ListSeparator);
-				file.Write(station.AirQuality2.ToString("F1") + ListSeparator);
-				file.Write(station.AirQuality3.ToString("F1") + ListSeparator);
-				file.Write(station.AirQuality4.ToString("F1") + ListSeparator);
-				file.Write(station.AirQualityAvg1.ToString("F1") + ListSeparator);
-				file.Write(station.AirQualityAvg2.ToString("F1") + ListSeparator);
-				file.Write(station.AirQualityAvg3.ToString("F1") + ListSeparator);
-				file.Write(station.AirQualityAvg4.ToString("F1") + ListSeparator);
+				file.Write(station.AirQuality1.ToString("F1") + ListSeparator);		//68
+				file.Write(station.AirQuality2.ToString("F1") + ListSeparator);		//69
+				file.Write(station.AirQuality3.ToString("F1") + ListSeparator);		//70
+				file.Write(station.AirQuality4.ToString("F1") + ListSeparator);		//71
+				file.Write(station.AirQualityAvg1.ToString("F1") + ListSeparator);	//72
+				file.Write(station.AirQualityAvg2.ToString("F1") + ListSeparator);	//73
+				file.Write(station.AirQualityAvg3.ToString("F1") + ListSeparator);	//74
+				file.Write(station.AirQualityAvg4.ToString("F1") + ListSeparator);	//75
 
 				for (int i = 1; i < 8; i++)
 				{
-					file.Write(station.UserTemp[i].ToString(TempFormat) + ListSeparator);
+					file.Write(station.UserTemp[i].ToString(TempFormat) + ListSeparator);	//76-82
 				}
-				file.Write(station.UserTemp[8].ToString(TempFormat) + ListSeparator);
+				file.Write(station.UserTemp[8].ToString(TempFormat) + ListSeparator);		//83
 
-				file.Write(station.CO2 + ListSeparator);
-				file.Write(station.CO2_24h + ListSeparator);
-				file.Write(station.CO2_pm2p5.ToString("F1") + ListSeparator);
-				file.Write(station.CO2_pm2p5_24h.ToString("F1") + ListSeparator);
-				file.Write(station.CO2_pm10.ToString("F1") + ListSeparator);
-				file.Write(station.CO2_pm10_24h.ToString("F1") + ListSeparator);
-				file.Write(station.CO2_temperature.ToString(TempFormat) + ListSeparator);
-				file.Write(station.CO2_humidity);
+				file.Write(station.CO2 + ListSeparator);									//84
+				file.Write(station.CO2_24h + ListSeparator);								//85
+				file.Write(station.CO2_pm2p5.ToString("F1") + ListSeparator);				//86
+				file.Write(station.CO2_pm2p5_24h.ToString("F1") + ListSeparator);			//87
+				file.Write(station.CO2_pm10.ToString("F1") + ListSeparator);				//88
+				file.Write(station.CO2_pm10_24h.ToString("F1") + ListSeparator);			//89
+				file.Write(station.CO2_temperature.ToString(TempFormat) + ListSeparator);	//90
+				file.Write(station.CO2_humidity);											//91
 
 				file.WriteLine();
 				file.Close();
@@ -6936,23 +6947,21 @@ namespace CumulusMX
 					CreateRealtimeFile(999);
 				}
 
-				//LogDebugMessage("Creating standard HTML files");
-				ProcessTemplateFile(IndexTFile, webIndexFile, tokenParser);
-				ProcessTemplateFile(TodayTFile, webTodayFile, tokenParser);
-				ProcessTemplateFile(YesterdayTFile, webYesterFile, tokenParser);
-				ProcessTemplateFile(RecordTFile, webRecordFile, tokenParser);
-				ProcessTemplateFile(MonthlyRecordTFile, MonthlyRecordFile, tokenParser);
-				ProcessTemplateFile(TrendsTFile, webTrendsFile, tokenParser);
-				ProcessTemplateFile(HistoricTFile, webHistoricFile, tokenParser);
-				ProcessTemplateFile(ThisMonthTFile, webThisMonthFile, tokenParser);
-				ProcessTemplateFile(ThisYearTFile, webThisYearFile, tokenParser);
-				ProcessTemplateFile(GaugesTFile, webGaugesFile, tokenParser);
-				//LogDebugMessage("Done creating standard HTML files");
+				if (IncludeStandardFiles)
+				{
+					LogDebugMessage("Creating standard HTML files");
+					for (var i = 0; i < localWebTextFiles.Length; i++)
+					{
+						ProcessTemplateFile(localWebTemplateFiles[i], localWebTextFiles[i], tokenParser);
+					}
+					LogDebugMessage("Done creating standard HTML files");
+				}
+
 				if (IncludeGraphDataFiles)
 				{
-					//LogDebugMessage("Creating graph data files");
+					LogDebugMessage("Creating graph data files");
 					station.CreateGraphDataFiles();
-					//LogDebugMessage("Done creating graph data files");
+					LogDebugMessage("Done creating graph data files");
 				}
 
 				//LogDebugMessage("Creating extra files");
@@ -9119,6 +9128,31 @@ namespace CumulusMX
 			LogMessage("Limits:");
 			LogMessage($"TH={Limit.TempHigh.ToString(TempFormat)} TL={Limit.TempLow.ToString(TempFormat)} DH={Limit.DewHigh.ToString(TempFormat)} PH={Limit.PressHigh.ToString(PressFormat)} PL={Limit.PressLow.ToString(PressFormat)} GH={Limit.WindHigh:F3}");
 
+		}
+
+		private void LogPrimaryAqSensor()
+		{
+			switch (StationOptions.PrimaryAqSensor)
+			{
+				case (int)PrimaryAqSensor.Undefined:
+					LogMessage("Primary AQ Sensor = Undefined");
+					break;
+				case (int)PrimaryAqSensor.Ecowitt1:
+				case (int)PrimaryAqSensor.Ecowitt2:
+				case (int)PrimaryAqSensor.Ecowitt3:
+				case (int)PrimaryAqSensor.Ecowitt4:
+					LogMessage("Primary AQ Sensor = Ecowitt" + StationOptions.PrimaryAqSensor);
+					break;
+				case (int)PrimaryAqSensor.EcowittCO2:
+					LogMessage("Primary AQ Sensor = Ecowitt CO2");
+					break;
+				case (int)PrimaryAqSensor.AirLinkIndoor:
+					LogMessage("Primary AQ Sensor = Airlink Indoor");
+					break;
+				case (int)PrimaryAqSensor.AirLinkOutdoor:
+					LogMessage("Primary AQ Sensor = Airlink Outdoor");
+					break;
+			}
 		}
 	}
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1531,11 +1531,11 @@ namespace CumulusMX
 			}
 
 			// If enabled generate the daily graph data files, and upload at first opportunity
-			if ((station != null) && IncludeGraphDataFiles)
+			if (station != null)
 			{
 				LogDebugMessage("Generating the daily graph data files");
 				station.CreateEodGraphDataFiles();
-				DailyGraphDataFilesNeedFTP = true;
+				DailyGraphDataFilesNeedFTP = IncludeGraphDataFiles;
 			}
 
 			LogDebugMessage("Lock: Cumulus releasing the lock");
@@ -6947,22 +6947,23 @@ namespace CumulusMX
 					CreateRealtimeFile(999);
 				}
 
-				if (IncludeStandardFiles)
-				{
+				//TODO: Sort out the mess of options for generating and FTPing all the standard files.
+				//if (IncludeStandardFiles)
+				//{
 					LogDebugMessage("Creating standard HTML files");
 					for (var i = 0; i < localWebTextFiles.Length; i++)
 					{
 						ProcessTemplateFile(localWebTemplateFiles[i], localWebTextFiles[i], tokenParser);
 					}
 					LogDebugMessage("Done creating standard HTML files");
-				}
+				//}
 
-				if (IncludeGraphDataFiles)
-				{
+				//if (IncludeGraphDataFiles)
+				//{
 					LogDebugMessage("Creating graph data files");
 					station.CreateGraphDataFiles();
 					LogDebugMessage("Done creating graph data files");
-				}
+				//}
 
 				//LogDebugMessage("Creating extra files");
 				// handle any extra files

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -534,7 +534,7 @@ namespace CumulusMX
 			int attempt = 0;
 
 			// Creating the new TCP socket effectively opens it - specify IP address or domain name and port
-			while (attempt < 5 && client == null)
+			while (attempt < 5 && client == null && !stop)
 			{
 				attempt++;
 				cumulus.LogDebugMessage("OpenTcpPort: TCP Logger Connect attempt " + attempt);

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -228,6 +228,7 @@ namespace CumulusMX
 				{
 					using (var udpClient = new UdpClient())
 					{
+						udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
 						udpClient.Client.Bind(new IPEndPoint(IPAddress.Any, port));
 						udpClient.Client.ReceiveTimeout = 4000;  // We should get a message every 2.5 seconds
 						var from = new IPEndPoint(0, 0);

--- a/CumulusMX/ProgramSettings.cs
+++ b/CumulusMX/ProgramSettings.cs
@@ -26,6 +26,7 @@ namespace CumulusMX
 			var options = new JsonProgramSettingsOptions()
 			{
 				startuphostping = cumulus.ProgramOptions.StartupPingHost,
+				startuppingescape = cumulus.ProgramOptions.StartupPingEscapeTime,
 				startupdelay = cumulus.ProgramOptions.StartupDelaySecs,
 				startupdelaymaxuptime = cumulus.ProgramOptions.StartupDelayMaxUptime,
 				debuglogging = cumulus.ProgramOptions.DebugLogging,
@@ -78,6 +79,7 @@ namespace CumulusMX
 				try
 				{
 					cumulus.ProgramOptions.StartupPingHost = settings.startuphostping;
+					cumulus.ProgramOptions.StartupPingEscapeTime = settings.startuppingescape;
 					cumulus.ProgramOptions.StartupDelaySecs = settings.startupdelay;
 					cumulus.ProgramOptions.StartupDelayMaxUptime = settings.startupdelaymaxuptime;
 					cumulus.ProgramOptions.DebugLogging = settings.debuglogging;
@@ -109,6 +111,7 @@ namespace CumulusMX
 	public class JsonProgramSettingsOptions
 	{
 		public string startuphostping { get; set; }
+		public int startuppingescape { get; set; }
 		public int startupdelay { get; set; }
 		public int startupdelaymaxuptime { get; set; }
 		public bool debuglogging { get; set; }

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("CumulusMX")]
-[assembly: AssemblyDescription("Build 3105")]
+[assembly: AssemblyTitle("Cumulus MX")]
+[assembly: AssemblyDescription("Build 3107")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CumulusMX")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyProduct("Cumulus MX")]
+[assembly: AssemblyCopyright("Copyright ©  2015-2021 Cumulus MX")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.7.3105")]
-[assembly: AssemblyFileVersion("3.9.7.3105")]
+[assembly: AssemblyVersion("3.9.7.3107")]
+[assembly: AssemblyFileVersion("3.9.7.3107")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CumulusMX")]
-[assembly: AssemblyDescription("Build 3102")]
+[assembly: AssemblyDescription("Build 3104")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CumulusMX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.7.3102")]
-[assembly: AssemblyFileVersion("3.9.7.3102")]
+[assembly: AssemblyVersion("3.9.7.3104")]
+[assembly: AssemblyFileVersion("3.9.7.3104")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CumulusMX")]
-[assembly: AssemblyDescription("Build 3104")]
+[assembly: AssemblyDescription("Build 3105")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CumulusMX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.7.3104")]
-[assembly: AssemblyFileVersion("3.9.7.3104")]
+[assembly: AssemblyVersion("3.9.7.3105")]
+[assembly: AssemblyFileVersion("3.9.7.3105")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CumulusMX")]
-[assembly: AssemblyDescription("Build 3101")]
+[assembly: AssemblyDescription("Build 3102")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("CumulusMX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.9.6.3101")]
-[assembly: AssemblyFileVersion("3.9.6.3101")]
+[assembly: AssemblyVersion("3.9.7.3102")]
+[assembly: AssemblyFileVersion("3.9.7.3102")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -709,6 +709,50 @@ namespace CumulusMX
 			}
 		}
 
+		internal string SetSelectaChartOptions(IHttpContext context)
+		{
+			var errorMsg = "";
+			context.Response.StatusCode = 200;
+			// get the response
+			try
+			{
+				cumulus.LogMessage("Updating select-a-chart settings");
+
+				var data = new StreamReader(context.Request.InputStream).ReadToEnd();
+
+				var json = WebUtility.UrlDecode(data);
+
+				// de-serialize it to the settings structure
+				var settings = JsonSerializer.DeserializeFromString<JsonSelectaChartSettings>(json);
+
+				// process the settings
+				try
+				{
+					cumulus.SelectaChartOptions.series = settings.series;
+					cumulus.SelectaChartOptions.colours = settings.colours;
+				}
+				catch (Exception ex)
+				{
+					var msg = "Error select-a-chart Options: " + ex.Message;
+					cumulus.LogMessage(msg);
+					errorMsg += msg + "\n\n";
+					context.Response.StatusCode = 500;
+				}
+
+				// Save the settings
+				cumulus.WriteIniFile();
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage(ex.Message);
+				context.Response.StatusCode = 500;
+				return ex.Message;
+			}
+
+			return context.Response.StatusCode == 200 ? "success" : errorMsg;
+		}
+
+
 		internal string GetWSport()
 		{
 			return "{\"wsport\":\"" + cumulus.wsPort + "\"}";
@@ -944,5 +988,11 @@ namespace CumulusMX
 		public bool graphUvVis { get; set; }
 		public bool graphSolarVis { get; set; }
 		public bool graphSunshineVis { get; set; }
+	}
+
+	public class JsonSelectaChartSettings
+	{
+		public string[] series { get; set; }
+		public string[] colours { get; set; }
 	}
 }

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2187,6 +2187,22 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage($"Error writing {cumulus.localGraphdataFiles[11]}: {ex.Message}");
 			}
+
+			// Available graph data
+			json = GetAvailGraphData();
+			try
+			{
+				using (var file = new StreamWriter(cumulus.localGraphdataFiles[12], false))
+				{
+					file.WriteLine(json);
+					file.Close();
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage($"Error writing {cumulus.localGraphdataFiles[12]}: {ex.Message}");
+			}
+
 		}
 
 		public void CreateEodGraphDataFiles()
@@ -6782,8 +6798,8 @@ namespace CumulusMX
 										}
 										else if (cumulus.StationOptions.PrimaryAqSensor >= (int)Cumulus.PrimaryAqSensor.Ecowitt1 && cumulus.StationOptions.PrimaryAqSensor <= (int)Cumulus.PrimaryAqSensor.Ecowitt4)
 										{
-											// Ecowitt sensor 1-4
-											pm2p5 = Convert.ToDouble(st[66 + cumulus.StationOptions.PrimaryAqSensor]);
+											// Ecowitt sensor 1-4 - fields 68 -> 71
+											pm2p5 = Convert.ToDouble(st[67 + cumulus.StationOptions.PrimaryAqSensor]);
 											pm10 = -1;
 										}
 										else
@@ -6829,7 +6845,9 @@ namespace CumulusMX
 					{
 						logFile = cumulus.GetAirLinkLogFileName(filedate);
 					}
-					else if (cumulus.StationOptions.PrimaryAqSensor > 0 && cumulus.StationOptions.PrimaryAqSensor <= 4) // Ecowitt
+					else if ((cumulus.StationOptions.PrimaryAqSensor >= (int)Cumulus.PrimaryAqSensor.Ecowitt1
+						&& cumulus.StationOptions.PrimaryAqSensor <= (int)Cumulus.PrimaryAqSensor.Ecowitt4)
+						|| cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.EcowittCO2) // Ecowitt
 					{
 						logFile = cumulus.GetExtraLogFileName(filedate);
 					}

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -5260,6 +5260,22 @@ namespace CumulusMX
 					cumulus.LogMessage("NOAA reports will be uploaded at next web update");
 				}
 
+				// Do the End of day Extra files
+				// This will set a flag to transfer on next FTP if required
+				cumulus.DoExtraEndOfDayFiles();
+				if (cumulus.EODfilesNeedFTP)
+				{
+					cumulus.LogMessage("Extra files will be uploaded at next web update");
+				}
+
+				// Do the Daily graph data files
+				CreateEodGraphDataFiles();
+				if (cumulus.IncludeGraphDataFiles)
+				{
+					cumulus.DailyGraphDataFilesNeedFTP = true;
+					cumulus.LogMessage("Daily graph data files will be uploaded at next web update");
+				}
+
 				if (!string.IsNullOrEmpty(cumulus.DailyProgram))
 				{
 					cumulus.LogMessage("Executing daily program: " + cumulus.DailyProgram + " params: " + cumulus.DailyParams);
@@ -5281,24 +5297,6 @@ namespace CumulusMX
 						cumulus.LogMessage("Error executing external program: " + ex.Message);
 					}
 				}
-
-				// Do the End of day Extra files
-				// This will set a flag to transfer on next FTP if required
-				cumulus.DoExtraEndOfDayFiles();
-				if (cumulus.EODfilesNeedFTP)
-				{
-					cumulus.LogMessage("Extra files will be uploaded at next web update");
-				}
-
-				// Do the Daily graph data files
-				if (cumulus.IncludeGraphDataFiles)
-				{
-					//LogDebugMessage("Creating daily graph data files");
-					CreateEodGraphDataFiles();
-					cumulus.DailyGraphDataFilesNeedFTP = true;
-					//LogDebugMessage("Done creating daily graph data files");
-				}
-
 
 				CurrentDay = timestamp.Day;
 				CurrentMonth = timestamp.Month;
@@ -7109,165 +7107,166 @@ namespace CumulusMX
 		public dayfilerec ParseDayFileRec(string data)
 		{
 			var st = new List<string>(Regex.Split(data, CultureInfo.CurrentCulture.TextInfo.ListSeparator));
-			string[] time;
 			double varDbl;
 			int varInt;
+			int idx = 0;
 
 			var rec = new dayfilerec();
+			try
+			{
+				rec.Date = ddmmyyStrToDate(st[idx++]);
+				rec.HighGust = Convert.ToDouble(st[idx++]);
+				rec.HighGustBearing = Convert.ToInt32(st[idx++]);
+				rec.HighGustTime = GetDateTime(rec.Date, st[idx++]);
+				rec.LowTemp = Convert.ToDouble(st[idx++]);
+				rec.LowTempTime = GetDateTime(rec.Date, st[idx++]);
+				rec.HighTemp = Convert.ToDouble(st[idx++]);
+				rec.HighTempTime = GetDateTime(rec.Date, st[idx++]);
+				rec.LowPress = Convert.ToDouble(st[idx++]);
+				rec.LowPressTime = GetDateTime(rec.Date, st[idx++]);
+				rec.HighPress = Convert.ToDouble(st[idx++]);
+				rec.HighPressTime = GetDateTime(rec.Date, st[idx++]);
+				rec.HighRainRate = Convert.ToDouble(st[idx++]);
+				rec.HighRainRateTime = GetDateTime(rec.Date, st[idx++]);
+				rec.TotalRain = Convert.ToDouble(st[idx++]);
+				rec.AvgTemp = Convert.ToDouble(st[idx++]);
 
-			rec.Date = ddmmyyStrToDate(st[0]);
-			rec.HighGust = Convert.ToDouble(st[1]);
-			rec.HighGustBearing = Convert.ToInt32(st[2]);
-			time = st[3].Split(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator.ToCharArray()[0]);
-			rec.HighGustTime = rec.Date.AddHours(Convert.ToInt32(time[0]) + Convert.ToInt32(time[1]) / 60);
-			rec.LowTemp = Convert.ToDouble(st[4]);
-			time = st[5].Split(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator.ToCharArray()[0]);
-			rec.LowTempTime = rec.Date.AddHours(Convert.ToInt32(time[0]) + Convert.ToInt32(time[1]) / 60);
-			rec.HighTemp = Convert.ToDouble(st[6]);
-			time = st[7].Split(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator.ToCharArray()[0]);
-			rec.HighTempTime = rec.Date.AddHours(Convert.ToInt32(time[0]) + Convert.ToInt32(time[1]) / 60);
-			rec.LowPress = Convert.ToDouble(st[8]);
-			time = st[9].Split(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator.ToCharArray()[0]);
-			rec.LowPressTime = rec.Date.AddHours(Convert.ToInt32(time[0]) + Convert.ToInt32(time[1]) / 60);
-			rec.HighPress = Convert.ToDouble(st[10]);
-			time = st[11].Split(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator.ToCharArray()[0]);
-			rec.HighPressTime = rec.Date.AddHours(Convert.ToInt32(time[0]) + Convert.ToInt32(time[1]) / 60);
-			rec.HighRainRate = Convert.ToDouble(st[12]);
-			time = st[13].Split(CultureInfo.CurrentCulture.DateTimeFormat.TimeSeparator.ToCharArray()[0]);
-			rec.HighRainRateTime = rec.Date.AddHours(Convert.ToInt32(time[0]) + Convert.ToInt32(time[1]) / 60);
-			rec.TotalRain = Convert.ToDouble(st[14]);
-			rec.AvgTemp = Convert.ToDouble(st[15]);
+				if (st.Count > idx++ && double.TryParse(st[16], out varDbl))
+					rec.WindRun = varDbl;
 
-			if (st.Count > 16 && double.TryParse(st[16], out varDbl))
-				rec.WindRun = varDbl;
+				if (st.Count > idx++ && double.TryParse(st[17], out varDbl))
+					rec.HighAvgWind = varDbl;
 
-			if (st.Count > 17 && double.TryParse(st[17], out varDbl))
-				rec.HighAvgWind = varDbl;
+				if (st.Count > idx++ && st[18].Length == 5)
+					rec.HighAvgWindTime = GetDateTime(rec.Date, st[18]);
 
-			if (st.Count > 18 && st[18].Length == 5)
-				rec.HighAvgWindTime = GetDateTime(rec.Date, st[18]);
+				if (st.Count > idx++ && int.TryParse(st[19], out varInt))
+					rec.LowHumidity = varInt;
+				else
+					rec.LowHumidity = 9999;
 
-			if (st.Count > 19 && int.TryParse(st[19], out varInt))
-				rec.LowHumidity = varInt;
-			else
-				rec.LowHumidity = 9999;
+				if (st.Count > idx++ && st[20].Length == 5)
+					rec.LowHumidityTime = GetDateTime(rec.Date, st[20]);
 
-			if (st.Count > 20 && st[20].Length == 5)
-				rec.LowHumidityTime = GetDateTime(rec.Date, st[18]);
+				if (st.Count > idx++ && int.TryParse(st[21], out varInt))
+					rec.HighHumidity = varInt;
+				else
+					rec.HighHumidity = -9999;
 
-			if (st.Count > 21 && int.TryParse(st[21], out varInt))
-				rec.HighHumidity = varInt;
-			else
-				rec.HighHumidity = -9999;
+				if (st.Count > idx++ && st[22].Length == 5)
+					rec.HighHumidityTime = GetDateTime(rec.Date, st[22]);
 
-			if (st.Count > 22 && st[22].Length == 5)
-				rec.HighHumidityTime = GetDateTime(rec.Date, st[22]);
+				if (st.Count > idx++ && double.TryParse(st[23], out varDbl))
+					rec.ET = varDbl;
 
-			if (st.Count > 23 && double.TryParse(st[23], out varDbl))
-				rec.ET = varDbl;
+				if (st.Count > idx++ && double.TryParse(st[24], out varDbl))
+					rec.SunShineHours = varDbl;
 
-			if (st.Count > 24 && double.TryParse(st[24], out varDbl))
-				rec.SunShineHours = varDbl;
+				if (st.Count > idx++ && double.TryParse(st[25], out varDbl))
+					rec.HighHeatIndex = varDbl;
+				else
+					rec.HighHeatIndex = -9999;
 
-			if (st.Count > 25 && double.TryParse(st[25], out varDbl))
-				rec.HighHeatIndex = varDbl;
-			else
-				rec.HighHeatIndex = -9999;
+				if (st.Count > idx++ && st[26].Length == 5)
+					rec.HighHeatIndexTime = GetDateTime(rec.Date, st[26]);
 
-			if (st.Count > 26 && st[26].Length == 5)
-				rec.HighHeatIndexTime = GetDateTime(rec.Date, st[26]);
+				if (st.Count > idx++ && double.TryParse(st[27], out varDbl))
+					rec.HighAppTemp = varDbl;
+				else
+					rec.HighAppTemp = -9999;
 
-			if (st.Count > 27 && double.TryParse(st[27], out varDbl))
-				rec.HighAppTemp = varDbl;
-			else
-				rec.HighAppTemp = -9999;
+				if (st.Count > idx++ && st[28].Length == 5)
+					rec.HighAppTempTime = GetDateTime(rec.Date, st[28]);
 
-			if (st.Count > 28 && st[28].Length == 5)
-				rec.HighAppTempTime = GetDateTime(rec.Date, st[28]);
+				if (st.Count > idx++ && double.TryParse(st[29], out varDbl))
+					rec.LowAppTemp = varDbl;
+				else
+					rec.LowAppTemp = 9999;
 
-			if (st.Count > 29 && double.TryParse(st[29], out varDbl))
-				rec.LowAppTemp = varDbl;
-			else
-				rec.LowAppTemp = 9999;
+				if (st.Count > idx++ && st[30].Length == 5)
+					rec.LowAppTempTime = GetDateTime(rec.Date, st[30]);
 
-			if (st.Count > 30 && st[30].Length == 5)
-				rec.LowAppTempTime = GetDateTime(rec.Date, st[30]);
+				if (st.Count > idx++ && double.TryParse(st[31], out varDbl))
+					rec.HighHourlyRain = varDbl;
 
-			if (st.Count > 31 && double.TryParse(st[31], out varDbl))
-				rec.HighHourlyRain = varDbl;
+				if (st.Count > idx++ && st[32].Length == 5)
+					rec.HighHourlyRainTime = GetDateTime(rec.Date, st[32]);
 
-			if (st.Count > 32 && st[32].Length == 5)
-				rec.HighHourlyRainTime = GetDateTime(rec.Date, st[32]);
+				if (st.Count > idx++ && double.TryParse(st[33], out varDbl))
+					rec.LowWindChill = varDbl;
+				else
+					rec.LowWindChill = 9999;
 
-			if (st.Count > 33 && double.TryParse(st[33], out varDbl))
-				rec.LowWindChill = varDbl;
-			else
-				rec.LowWindChill = 9999;
+				if (st.Count > idx++ && st[34].Length == 5)
+					rec.LowWindChillTime = GetDateTime(rec.Date, st[34]);
 
-			if (st.Count > 34 && st[34].Length == 5)
-				rec.LowWindChillTime = GetDateTime(rec.Date, st[34]);
+				if (st.Count > idx++ && double.TryParse(st[35], out varDbl))
+					rec.HighDewPoint = varDbl;
+				else
+					rec.HighDewPoint = -9999;
 
-			if (st.Count > 35 && double.TryParse(st[35], out varDbl))
-				rec.HighDewPoint = varDbl;
-			else
-				rec.HighDewPoint = -9999;
+				if (st.Count > idx++ && st[36].Length == 5)
+					rec.HighDewPointTime = GetDateTime(rec.Date, st[36]);
 
-			if (st.Count > 36 && st[36].Length == 5)
-				rec.HighDewPointTime = GetDateTime(rec.Date, st[36]);
+				if (st.Count > idx++ && double.TryParse(st[37], out varDbl))
+					rec.LowDewPoint = varDbl;
+				else
+					rec.LowDewPoint = 9999;
 
-			if (st.Count > 37 && double.TryParse(st[37], out varDbl))
-				rec.LowDewPoint = varDbl;
-			else
-				rec.LowDewPoint = 9999;
+				if (st.Count > idx++ && st[38].Length == 5)
+					rec.LowDewPointTime = GetDateTime(rec.Date, st[38]);
 
-			if (st.Count > 38 && st[38].Length == 5)
-				rec.LowDewPointTime = GetDateTime(rec.Date, st[38]);
+				if (st.Count > idx++ && int.TryParse(st[39], out varInt))
+					rec.DominantWindBearing = varInt;
 
-			if (st.Count > 39 && int.TryParse(st[39], out varInt))
-				rec.DominantWindBearing = varInt;
+				if (st.Count > idx++ && double.TryParse(st[40], out varDbl))
+					rec.HeatingDegreeDays = varDbl;
 
-			if (st.Count > 40 && double.TryParse(st[40], out varDbl))
-				rec.HeatingDegreeDays = varDbl;
+				if (st.Count > idx++ && double.TryParse(st[41], out varDbl))
+					rec.CoolingDegreeDays = varDbl;
 
-			if (st.Count > 41 && double.TryParse(st[41], out varDbl))
-				rec.CoolingDegreeDays = varDbl;
+				if (st.Count > idx++ && int.TryParse(st[42], out varInt))
+					rec.HighSolar = varInt;
 
-			if (st.Count > 42 && int.TryParse(st[42], out varInt))
-				rec.HighSolar = varInt;
+				if (st.Count > idx++ && st[43].Length == 5)
+					rec.HighSolarTime = GetDateTime(rec.Date, st[43]);
 
-			if (st.Count > 43 && st[43].Length == 5)
-				rec.HighSolarTime = GetDateTime(rec.Date, st[43]);
+				if (st.Count > idx++ && double.TryParse(st[44], out varDbl))
+					rec.HighUv = varDbl;
 
-			if (st.Count > 44 && double.TryParse(st[44], out varDbl))
-				rec.HighUv = varDbl;
+				if (st.Count > idx++ && st[45].Length == 5)
+					rec.HighUvTime = GetDateTime(rec.Date, st[45]);
 
-			if (st.Count > 45 && st[45].Length == 5)
-				rec.HighUvTime = GetDateTime(rec.Date, st[45]);
+				if (st.Count > idx++ && double.TryParse(st[46], out varDbl))
+					rec.HighFeelsLike = varDbl;
+				else
+					rec.HighFeelsLike = -9999;
 
-			if (st.Count > 46 && double.TryParse(st[46], out varDbl))
-				rec.HighFeelsLike = varDbl;
-			else
-				rec.HighFeelsLike = -9999;
+				if (st.Count > idx++ && st[47].Length == 5)
+					rec.HighFeelsLikeTime = GetDateTime(rec.Date, st[47]);
 
-			if (st.Count > 47 && st[47].Length == 5)
-				rec.HighFeelsLikeTime = GetDateTime(rec.Date, st[47]);
+				if (st.Count > idx++ && double.TryParse(st[48], out varDbl))
+					rec.LowFeelsLike = varDbl;
+				else
+					rec.LowFeelsLike = 9999;
 
-			if (st.Count > 48 && double.TryParse(st[48], out varDbl))
-				rec.LowFeelsLike = varDbl;
-			else
-				rec.LowFeelsLike = 9999;
+				if (st.Count > idx++ && st[49].Length == 5)
+					rec.LowFeelsLikeTime = GetDateTime(rec.Date, st[49]);
 
-			if (st.Count > 49 && st[49].Length == 5)
-				rec.LowFeelsLikeTime = GetDateTime(rec.Date, st[49]);
+				if (st.Count > idx++ && double.TryParse(st[50], out varDbl))
+					rec.HighHumidex = varDbl;
+				else
+					rec.HighHumidex = -9999;
 
-			if (st.Count > 50 && double.TryParse(st[50], out varDbl))
-				rec.HighHumidex = varDbl;
-			else
-				rec.HighHumidex = -9999;
-
-			if (st.Count > 51 && st[51].Length == 5)
-				rec.HighHumidexTime = GetDateTime(rec.Date, st[51]);
-
+				if (st.Count > idx++ && st[51].Length == 5)
+					rec.HighHumidexTime = GetDateTime(rec.Date, st[51]);
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogDebugMessage($"ParseDayFileRec: Error at record {idx} - {ex.Message}");
+				var e = new Exception($"Error at record {idx} = \"{st[idx-1]}\" - {ex.Message}");
+				throw e;
+			}
 			return rec;
 		}
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -19,6 +19,7 @@ using Devart.Data.MySql;
 using SQLite;
 using Timer = System.Timers.Timer;
 using System.Security.Cryptography;
+using ServiceStack.Text;
 
 namespace CumulusMX
 {
@@ -10484,36 +10485,6 @@ namespace CumulusMX
 			if (json.ToString().EndsWith(","))
 				json.Length--;
 
-			// solar values
-			json.Append("],\"Solar\":[");
-
-			if (cumulus.GraphOptions.SolarVisible)
-				json.Append("\"Solar Rad\",");
-
-			if (cumulus.GraphOptions.UVVisible)
-				json.Append("\"UV Index\",");
-
-			if (json.ToString().EndsWith(","))
-				json.Length--;
-
-			// air quality
-			// Check if we are to generate AQ data at all. Only if a primary sensor is defined and it isn't the Indoor AirLink
-			if (cumulus.StationOptions.PrimaryAqSensor > (int)Cumulus.PrimaryAqSensor.Undefined
-				&& cumulus.StationOptions.PrimaryAqSensor != (int)Cumulus.PrimaryAqSensor.AirLinkIndoor)
-			{
-				json.Append("],\"Air Quality\":[");
-				json.Append("\"PM 2.5\"");
-
-				// Only the AirLink and Ecowitt CO2 servers provide PM10 values at the moment
-				if (cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.AirLinkOutdoor ||
-					cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.AirLinkIndoor ||
-					cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.EcowittCO2)
-				{
-					json.Append(",\"PM 10\"");
-				}
-			}
-
-
 			// fixed values
 			// pressure
 			json.Append("],\"Pressure\":[\"Pressure\"],");
@@ -10524,12 +10495,54 @@ namespace CumulusMX
 			// rain
 			json.Append("\"Rain\":[\"Rainfall\",\"Rainfall Rate\"]");
 
+			// solar values
+			if (cumulus.GraphOptions.SolarVisible || cumulus.GraphOptions.UVVisible)
+			{
+				json.Append(",\"Solar\":[");
+
+				if (cumulus.GraphOptions.SolarVisible)
+					json.Append("\"Solar Rad\",");
+
+				if (cumulus.GraphOptions.UVVisible)
+					json.Append("\"UV Index\",");
+
+				if (json.ToString().EndsWith(","))
+					json.Length--;
+
+				json.Append("]");
+			}
+
+
+			// air quality
+			// Check if we are to generate AQ data at all. Only if a primary sensor is defined and it isn't the Indoor AirLink
+			if (cumulus.StationOptions.PrimaryAqSensor > (int)Cumulus.PrimaryAqSensor.Undefined
+				&& cumulus.StationOptions.PrimaryAqSensor != (int)Cumulus.PrimaryAqSensor.AirLinkIndoor)
+			{
+				json.Append(",\"Air Quality\":[");
+				json.Append("\"PM 2.5\"");
+
+				// Only the AirLink and Ecowitt CO2 servers provide PM10 values at the moment
+				if (cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.AirLinkOutdoor ||
+					cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.AirLinkIndoor ||
+					cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.EcowittCO2)
+				{
+					json.Append(",\"PM 10\"");
+				}
+				json.Append("]");
+			}
+
 			json.Append("}");
 			return json.ToString();
 		}
 
 
-		public string GetDailyRainGraphData()
+		public string GetSelectaChartOptions()
+		{
+			return JsonSerializer.SerializeToString(cumulus.SelectaChartOptions);
+		}
+
+
+	public string GetDailyRainGraphData()
 		{
 			var datefrom = DateTime.Now.AddDays(-cumulus.GraphDays - 1);
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -10438,6 +10438,97 @@ namespace CumulusMX
 			return json.ToString();
 		}
 
+		public string GetAvailGraphData()
+		{
+			var json = new StringBuilder(200);
+
+			// Temp values
+			json.Append("{\"Temperature\":[");
+
+			if (cumulus.GraphOptions.TempVisible)
+				json.Append("\"Temperature\",");
+
+			if (cumulus.GraphOptions.InTempVisible)
+				json.Append("\"Indoor Temp\",");
+
+			if (cumulus.GraphOptions.HIVisible)
+				json.Append("\"Heat Index\",");
+
+			if (cumulus.GraphOptions.DPVisible)
+				json.Append("\"Dew Point\",");
+
+			if (cumulus.GraphOptions.WCVisible)
+				json.Append("\"Wind Chill\",");
+
+			if (cumulus.GraphOptions.AppTempVisible)
+				json.Append("\"Apparent Temp\",");
+
+			if (cumulus.GraphOptions.FeelsLikeVisible)
+				json.Append("\"Feels Like\",");
+
+			//if (cumulus.GraphOptions.HumidexVisible)
+			//	json.Append("\"Humidex\",");
+
+			if (json.ToString().EndsWith(","))
+				json.Length--;
+
+			// humidity values
+			json.Append("],\"Humidity\":[");
+
+			if (cumulus.GraphOptions.OutHumVisible)
+				json.Append("\"Humidity\",");
+
+			if (cumulus.GraphOptions.InHumVisible)
+				json.Append("\"Indoor Hum\",");
+
+			if (json.ToString().EndsWith(","))
+				json.Length--;
+
+			// solar values
+			json.Append("],\"Solar\":[");
+
+			if (cumulus.GraphOptions.SolarVisible)
+				json.Append("\"Solar Rad\",");
+
+			if (cumulus.GraphOptions.UVVisible)
+				json.Append("\"UV Index\",");
+
+			if (json.ToString().EndsWith(","))
+				json.Length--;
+
+			// air quality
+			// Check if we are to generate AQ data at all. Only if a primary sensor is defined and it isn't the Indoor AirLink
+			if (cumulus.StationOptions.PrimaryAqSensor > (int)Cumulus.PrimaryAqSensor.Undefined
+				&& cumulus.StationOptions.PrimaryAqSensor != (int)Cumulus.PrimaryAqSensor.AirLinkIndoor)
+			{
+				json.Append("],\"Air Quality\":[");
+				json.Append("\"PM 2.5\"");
+
+				// Only the AirLink and Ecowitt CO2 servers provide PM10 values at the moment
+				if (cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.AirLinkOutdoor ||
+					cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.AirLinkIndoor ||
+					cumulus.StationOptions.PrimaryAqSensor == (int)Cumulus.PrimaryAqSensor.EcowittCO2)
+				{
+					json.Append(",\"PM 10\"");
+				}
+			}
+
+
+			// fixed values
+			// pressure
+			json.Append("],\"Pressure\":[\"Pressure\"],");
+
+			// wind
+			json.Append("\"Wind\":[\"Wind Speed\",\"Wind Gust\",\"Wind Bearing\"],");
+
+			// rain
+			json.Append("\"Rain\":[\"Rainfall\",\"Rainfall Rate\"]");
+
+			json.Append("}");
+			return json.ToString();
+		}
+
+
 		public string GetDailyRainGraphData()
 		{
 			var datefrom = DateTime.Now.AddDays(-cumulus.GraphDays - 1);

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,6 +2,9 @@
 —————————————
 - Fix: Unhandled exception in ProcessTemplateFile if output file cannot be written to
 
+- New: Adds a SelectaChart for recent data so you cam plot different data on the same chart
+- New: Adds hot link to the Upgrade alarm on the dashboard
+
 
 3.9.6 - b3101
 —————————————

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,6 @@
 3.9.7 - b3102
 —————————————
-
+- Fix: Unhandled exception in ProcessTemplateFile if output file cannot be written to
 
 
 3.9.6 - b3101

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,40 +1,16 @@
-3.9.7 - b3104
+3.9.7 - b3105
 —————————————
 - Fix: Unhandled exception in ProcessTemplateFile if cumulus cannot write to the output file
 - Fix: Davis IP logger prevents Cumulus exiting if no station is found on the network
+- Fix: Ecowitt AQ sensors not loading graph data from the log files on start-up
 
-- New: Adds a Select-a-Chart for recent data so you can plot different data on the same chart
+- New: Adds a Select-a-Chart to the dashboard for recent data so you can plot different data on the same chart
+- New: Adds a Select-a-Chart to the default web site for recent data
+	- Creates a new json data file - availabledata.json - that is uploaded to the remote site
 - New: Adds a hot link to the Upgrade alarm on the dashboard
 - New: Adds a start-up host ping escape time. Allows Cumulus to continue loading even if no ping response is received for the specified time
 
-TESTING
-b3 - Changed series order in dropdown
-b3 - Now 6 series dropdowns
-b3 - Colours now selectable
-b3 - "Select Series" changes to "Clear Series" and vice versa
-b3 - Settings now saved to Cumulus.ini
-	[Select-a-Chart]
-	Series0=0
-	Colour0=
-	Series1=0
-	Colour1=
-	Series2=0
-	Colour2=
-	Series3=0
-	Colour3=
-	Series4=0
-	Colour4=
-	Series5=0
-	Colour5=
-
-b4 - Fixes y-axis balancing
-b4 - Fixes dropdowns with values on page load still showing "Select Series" rather than "Clear Series"
-b4 - Fixes first time page load not setting the default colours
-
-b5 - Fixes random issues on initial page load
-b5 - Fixes left-hand y-Axis label alignment issues
-b5 - Adds a start-up host ping escape time.
-
+- Change: If you do not enable "Include standard files" in the Web/FTP settings, the default web site template files will no longer be processed locally
 
 
 3.9.6 - b3101

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,8 +1,11 @@
-3.9.7 - b3105
+3.9.7 - b3107
 —————————————
 - Fix: Unhandled exception in ProcessTemplateFile if cumulus cannot write to the output file
 - Fix: Davis IP logger prevents Cumulus exiting if no station is found on the network
 - Fix: Ecowitt AQ sensors not loading graph data from the log files on start-up
+- Fix: Bug in dayfile parser that was using the time of highest wind speed as time of lowest humidity.
+	- The dayfile parser now outputs the first field number in a line that has failed to parse along with the field contents
+- Fix: THe GW1000 retains the previous lightning time/distance if the station resets the values to defaults
 
 - New: Adds a Select-a-Chart to the dashboard for recent data so you can plot different data on the same chart
 - New: Adds a Select-a-Chart to the default web site for recent data
@@ -10,7 +13,8 @@
 - New: Adds a hot link to the Upgrade alarm on the dashboard
 - New: Adds a start-up host ping escape time. Allows Cumulus to continue loading even if no ping response is received for the specified time
 
-- Change: If you do not enable "Include standard files" in the Web/FTP settings, the default web site template files will no longer be processed locally
+- Change: The default web site gets a CSS change that dynamically alters the "content" width depending on the screen size. On smaller screens the white space either side will reduce in size.
+- Change: The graph JSON data files are now always created locally, regardless of the Include Graph Data Files setting. That now setting only controls FTP like the standard files.
 
 
 3.9.6 - b3101

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,10 +1,40 @@
-3.9.7 - b3102
+3.9.7 - b3104
 —————————————
 - Fix: Unhandled exception in ProcessTemplateFile if cumulus cannot write to the output file
 - Fix: Davis IP logger prevents Cumulus exiting if no station is found on the network
 
-- New: Adds a SelectaChart for recent data so you cam plot different data on the same chart
+- New: Adds a Select-a-Chart for recent data so you can plot different data on the same chart
 - New: Adds a hot link to the Upgrade alarm on the dashboard
+- New: Adds a start-up host ping escape time. Allows Cumulus to continue loading even if no ping response is received for the specified time
+
+TESTING
+b3 - Changed series order in dropdown
+b3 - Now 6 series dropdowns
+b3 - Colours now selectable
+b3 - "Select Series" changes to "Clear Series" and vice versa
+b3 - Settings now saved to Cumulus.ini
+	[Select-a-Chart]
+	Series0=0
+	Colour0=
+	Series1=0
+	Colour1=
+	Series2=0
+	Colour2=
+	Series3=0
+	Colour3=
+	Series4=0
+	Colour4=
+	Series5=0
+	Colour5=
+
+b4 - Fixes y-axis balancing
+b4 - Fixes dropdowns with values on page load still showing "Select Series" rather than "Clear Series"
+b4 - Fixes first time page load not setting the default colours
+
+b5 - Fixes random issues on initial page load
+b5 - Fixes left-hand y-Axis label alignment issues
+b5 - Adds a start-up host ping escape time.
+
 
 
 3.9.6 - b3101

--- a/Updates.txt
+++ b/Updates.txt
@@ -5,7 +5,9 @@
 - Fix: Ecowitt AQ sensors not loading graph data from the log files on start-up
 - Fix: Bug in dayfile parser that was using the time of highest wind speed as time of lowest humidity.
 	- The dayfile parser now outputs the first field number in a line that has failed to parse along with the field contents
-- Fix: THe GW1000 retains the previous lightning time/distance if the station resets the values to defaults
+- Fix: The GW1000 retains the previous lightning time/distance if the station resets the values to defaults
+- Fix: Now opens the Davis WLL multi-cast listening port in shared mode to allow multiple copies of Cumulus to run on the same computer.
+       Only tested on Windows, may not work on macOS.
 
 - New: Adds a Select-a-Chart to the dashboard for recent data so you can plot different data on the same chart
 - New: Adds a Select-a-Chart to the default web site for recent data

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,9 +1,10 @@
 3.9.7 - b3102
 —————————————
-- Fix: Unhandled exception in ProcessTemplateFile if output file cannot be written to
+- Fix: Unhandled exception in ProcessTemplateFile if cumulus cannot write to the output file
+- Fix: Davis IP logger prevents Cumulus exiting if no station is found on the network
 
 - New: Adds a SelectaChart for recent data so you cam plot different data on the same chart
-- New: Adds hot link to the Upgrade alarm on the dashboard
+- New: Adds a hot link to the Upgrade alarm on the dashboard
 
 
 3.9.6 - b3101

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,8 @@
+3.9.7 - b3102
+—————————————
+
+
+
 3.9.6 - b3101
 —————————————
 - Fix: NOAA monthly report min temp/rain not formatting in dot decimal correctly


### PR DESCRIPTION
- Fix: Unhandled exception in ProcessTemplateFile if cumulus cannot write to the output file
- Fix: Davis IP logger prevents Cumulus exiting if no station is found on the network
- Fix: Ecowitt AQ sensors not loading graph data from the log files on start-up
- Fix: Bug in dayfile parser that was using the time of highest wind speed as time of lowest humidity.
	- The dayfile parser now outputs the first field number in a line that has failed to parse along with the field contents
- Fix: The GW1000 retains the previous lightning time/distance if the station resets the values to defaults
- Fix: Now opens the Davis WLL multi-cast listening port in shared mode to allow multiple copies of Cumulus to run on the same computer.
       Only tested on Windows, may not work on macOS.

- New: Adds a Select-a-Chart to the dashboard for recent data so you can plot different data on the same chart
- New: Adds a Select-a-Chart to the default web site for recent data
	- Creates a new json data file - availabledata.json - that is uploaded to the remote site
- New: Adds a hot link to the Upgrade alarm on the dashboard
- New: Adds a start-up host ping escape time. Allows Cumulus to continue loading even if no ping response is received for the specified time

- Change: The default web site gets a CSS change that dynamically alters the "content" width depending on the screen size. On smaller screens the white space either side will reduce in size.
- Change: The graph JSON data files are now always created locally, regardless of the Include Graph Data Files setting. That now setting only controls FTP like the standard files.
