### PR TITLE
v3.10.4

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -2382,7 +2382,7 @@ namespace CumulusMX
 				// Process any files
 				if (RealtimeCopyInProgress)
 				{
-					LogDebugMessage($"Realtime[{cycle}]: Warning, a previous cycle is still processing local files. Skipping this interval.");
+					LogMessage($"Realtime[{cycle}]: Warning, a previous cycle is still processing local files. Skipping this interval.");
 				}
 				else
 				{
@@ -2396,8 +2396,17 @@ namespace CumulusMX
 						// Is a previous cycle still running?
 						if (RealtimeFtpInProgress)
 						{
-							LogDebugMessage($"Realtime[{cycle}]: Warning, a previous cycle is still trying to connect to FTP server, skip count = {++realtimeFTPRetries}");
-							LogDebugMessage($"Realtime[{cycle}]: No FTP attempted this cycle");
+							LogMessage($"Realtime[{cycle}]: Warning, a previous cycle is still trying to connect to FTP server, skip count = {++realtimeFTPRetries}");
+							// realtimeinvertval is in ms, if a session has been uploading for 5 minutes - abort it and reconnect
+							if (realtimeFTPRetries * RealtimeInterval / 1000 > 5 * 60)
+							{
+								LogMessage($"Realtime[{cycle}]: Realtime has been in progress for more than 5 minutes, attempting to reconnect.");
+								RealtimeFTPConnectionTest(cycle);
+							}
+							else
+							{
+								LogMessage($"Realtime[{cycle}]: No FTP attempted this cycle");
+							}
 						}
 						else
 						{
@@ -2536,7 +2545,7 @@ namespace CumulusMX
 				{
 					RealtimeFTP.Connect();
 				}
-				LogDebugMessage($"Realtime[{cycle}]: Reconnected with server OK");
+				LogMessage($"Realtime[{cycle}]: Reconnected with server OK");
 			}
 			catch (Exception ex)
 			{

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -1034,7 +1034,7 @@ namespace CumulusMX
 								break;
 							case 0x4C: //All sensor lowbatt 16 char
 									   // This has been deprecated since v1.6.5 - now use CMD_READ_SENSOR_ID_NEW
-								if (tenMinuteChanged && fwVersion.CompareTo("1.6.5") >= 0)
+								if (tenMinuteChanged && fwVersion.CompareTo(new Version("1.6.5")) >= 0)
 								{
 									batteryLow = batteryLow || DoBatteryStatus(data, idx);
 								}

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.10.3 - Build 3120")]
+[assembly: AssemblyDescription("Version 3.10.4 - Build 3121")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.10.3.3120")]
-[assembly: AssemblyFileVersion("3.10.3.3120")]
+[assembly: AssemblyVersion("3.10.4.3121")]
+[assembly: AssemblyFileVersion("3.10.4.3121")]

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,10 @@
+3.10.4 - b3121
+——————————————
+- Fix: Issue introduced in v3.10.3 decoding Ecowitt live data
+- Fix: Catch real time FTP updates that have hung for more than 5 minutes and restart them.
+
+
+
 3.10.3 - b3120
 ——————————————
 - Fix: Problem with setpagedata.js in "/legacy-webfiles"


### PR DESCRIPTION
- Fix: Issue introduced in v3.10.3 decoding Ecowitt live data
- Fix: Catch real time FTP updates that have hung for more than 5 minutes and restart them.