### PR TITLE
v3.11.1

### DIFF
--- a/CumulusMX/AlarmSettings.cs
+++ b/CumulusMX/AlarmSettings.cs
@@ -421,9 +421,16 @@ namespace CumulusMX
 					}
 				}
 
-				cumulus.emailer.SendTestEmail(dest, from, "Cumulus MX Test Email", "A test email from Cumulus MX.", result.useHtml);
+				var ret = cumulus.emailer.SendTestEmail(dest, from, "Cumulus MX Test Email", "A test email from Cumulus MX.", result.useHtml);
 
-				cumulus.LogMessage("Test email sent without error");
+				if (ret == "OK")
+				{
+					cumulus.LogMessage("Test email sent without error");
+				}
+				else
+				{
+					return ret;
+				}
 			}
 			catch (Exception ex)
 			{

--- a/CumulusMX/CalibrationSettings.cs
+++ b/CumulusMX/CalibrationSettings.cs
@@ -167,6 +167,7 @@ namespace CumulusMX
 
 			var data = new JsonCalibrationSettingsData()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				offsets = offsets,
 				multipliers = multipliers,
 				spikeremoval = spikeremoval,
@@ -198,6 +199,7 @@ namespace CumulusMX
 
 	public class JsonCalibrationSettingsData
 	{
+		public bool accessible { get; set; }
 		public JsonCalibrationSettingsOffsets offsets { get; set; }
 		public JsonCalibrationSettingsMultipliers multipliers { get; set; }
 		public JsonCalibrationSettingsSpikeRemoval spikeremoval { get; set; }

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -26,6 +26,7 @@ using Unosquare.Labs.EmbedIO.Constants;
 using Timer = System.Timers.Timer;
 using SQLite;
 using Renci.SshNet;
+using FluentFTP.Helpers;
 
 namespace CumulusMX
 {
@@ -3498,6 +3499,7 @@ namespace CumulusMX
 				}
 			}
 
+			ProgramOptions.EnableAccessibility = ini.GetValue("Program", "EnableAccessibility", false);
 			ProgramOptions.StartupPingHost = ini.GetValue("Program", "StartupPingHost", "");
 			ProgramOptions.StartupPingEscapeTime = ini.GetValue("Program", "StartupPingEscapeTime", 999);
 			ProgramOptions.StartupDelaySecs = ini.GetValue("Program", "StartupDelaySecs", 0);
@@ -4549,6 +4551,8 @@ namespace CumulusMX
 			LogMessage("Writing Cumulus.ini file");
 
 			IniFile ini = new IniFile("Cumulus.ini");
+
+			ini.SetValue("Program", "EnableAccessibility", ProgramOptions.EnableAccessibility);
 
 			ini.SetValue("Program", "StartupPingHost", ProgramOptions.StartupPingHost);
 			ini.SetValue("Program", "StartupPingEscapeTime", ProgramOptions.StartupPingEscapeTime);
@@ -9401,6 +9405,7 @@ namespace CumulusMX
 
 	public class ProgramOptionsClass
 	{
+		public bool EnableAccessibility { get; set; }
 		public string StartupPingHost { get; set; }
 		public int StartupPingEscapeTime { get; set; }
 		public int StartupDelaySecs { get; set; }

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -85,8 +85,8 @@
     <Reference Include="BouncyCastle.Crypto, Version=1.8.10.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
       <HintPath>..\packages\Portable.BouncyCastle.1.8.10\lib\net40\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
-    <Reference Include="FluentFTP, Version=33.1.5.0, Culture=neutral, PublicKeyToken=f4af092b1d8df44f, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentFTP.33.1.5\lib\net45\FluentFTP.dll</HintPath>
+    <Reference Include="FluentFTP, Version=32.3.1.0, Culture=neutral, PublicKeyToken=f4af092b1d8df44f, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentFTP.32.3.1\lib\net45\FluentFTP.dll</HintPath>
     </Reference>
     <Reference Include="HidSharp, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HidSharp.2.1.0\lib\net35\HidSharp.dll</HintPath>

--- a/CumulusMX/EmailSender.cs
+++ b/CumulusMX/EmailSender.cs
@@ -80,8 +80,10 @@ namespace CumulusMX
 			}
 		}
 
-		public void SendTestEmail(string[] to, string from, string subject, string message, bool isHTML)
+		public string SendTestEmail(string[] to, string from, string subject, string message, bool isHTML)
 		{
+			string retVal;
+
 			try
 			{
 				cumulus.LogDebugMessage($"SendEmail: Waiting for lock...");
@@ -128,17 +130,21 @@ namespace CumulusMX
 					client.Send(m);
 					client.Disconnect(true);
 				}
+
+				retVal = "OK";
 			}
 			catch (Exception e)
 			{
 				cumulus.LogMessage("SendEmail: Error - " + e);
-
+				retVal = e.Message;
 			}
 			finally
 			{
 				cumulus.LogDebugMessage($"SendEmail: Releasing lock...");
 				_writeLock.Release();
 			}
+
+			return retVal;
 		}
 
 

--- a/CumulusMX/ExtraSensorSettings.cs
+++ b/CumulusMX/ExtraSensorSettings.cs
@@ -84,6 +84,7 @@ namespace CumulusMX
 
 			var data = new JsonExtraSensorSettings()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				airquality = aq,
 				airLink = airlink,
 				blakeLarsen = bl,
@@ -257,6 +258,7 @@ namespace CumulusMX
 
 	public class JsonExtraSensorSettings
 	{
+		public bool accessible { get; set; }
 		public JsonExtraSensorAirQuality airquality { get; set; }
 		public JsonExtraSensorAirLinkSettings airLink { get; set; }
 		public JsonExtraSensorBlakeLarsen blakeLarsen { get; set; }

--- a/CumulusMX/InternetSettings.cs
+++ b/CumulusMX/InternetSettings.cs
@@ -491,6 +491,7 @@ namespace CumulusMX
 
 			var data = new JsonInternetSettingsData()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				website = websitesettings,
 				websettings = websettings,
 				externalprograms = externalprograms,
@@ -618,6 +619,7 @@ namespace CumulusMX
 
 	public class JsonInternetSettingsData
 	{
+		public bool accessible { get; set; }
 		public JsonInternetSettingsWebsite website { get; set; }
 		public JsonInternetSettingsWebSettings websettings { get; set; }
 		public JsonInternetSettingsExternalPrograms externalprograms { get; set; }

--- a/CumulusMX/MysqlSettings.cs
+++ b/CumulusMX/MysqlSettings.cs
@@ -71,6 +71,7 @@ namespace CumulusMX
 
 			var data = new JsonMysqlSettings()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				server = server,
 				monthenabled = cumulus.MonthlyMySqlEnabled,
 				monthly = monthly,
@@ -241,7 +242,7 @@ namespace CumulusMX
 			using (MySqlCommand cmd = new MySqlCommand(createSQL, mySqlConn))
 			{
 				cumulus.LogMessage($"MySQL Create Table: {createSQL}");
-				
+
 				try
 				{
 					mySqlConn.Open();
@@ -295,6 +296,7 @@ namespace CumulusMX
 
 	public class JsonMysqlSettings
 	{
+		public bool accessible {get; set;}
 		public JsonMysqlSettingsServer server { get; set; }
 		public bool monthenabled { get; set; }
 		public JsonMysqlSettingsMonthly monthly { get; set; }

--- a/CumulusMX/NOAASettings.cs
+++ b/CumulusMX/NOAASettings.cs
@@ -96,6 +96,7 @@ namespace CumulusMX
 
 			var data = new JsonNOAASettingsData()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				autosave = cumulus.NOAAAutoSave,
 
 				sitedetails = site,
@@ -234,6 +235,7 @@ namespace CumulusMX
 
 	public class JsonNOAASettingsData
 	{
+		public bool accessible { get; set; }
 		public bool autosave {get; set; }
 		public JsonNOAASettingsSite sitedetails { get; set; }
 		public JsonNOAASettingsOutput outputfiles { get; set; }

--- a/CumulusMX/ProgramSettings.cs
+++ b/CumulusMX/ProgramSettings.cs
@@ -42,6 +42,7 @@ namespace CumulusMX
 
 			var settings = new JsonProgramSettings()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				startup = startup,
 				options = options
 			};
@@ -101,6 +102,7 @@ namespace CumulusMX
 			// process the settings
 			try
 			{
+				cumulus.ProgramOptions.EnableAccessibility = settings.accessible;
 				cumulus.ProgramOptions.StartupPingHost = settings.startup.startuphostping;
 				cumulus.ProgramOptions.StartupPingEscapeTime = settings.startup.startuppingescape;
 				cumulus.ProgramOptions.StartupDelaySecs = settings.startup.startupdelay;
@@ -134,6 +136,7 @@ namespace CumulusMX
 
 	public class JsonProgramSettings
 	{
+		public bool accessible { get; set; }
 		public JsonProgramSettingsStartupOptions startup { get; set; }
 		public JsonProgramSettingsGeneralOptions options { get; set; }
 	}

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.11.0.3130")]
-[assembly: AssemblyFileVersion("3.11.0.3130")]
+[assembly: AssemblyVersion("3.11.1.3130")]
+[assembly: AssemblyFileVersion("3.11.1.3130")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.11.0 - Build 3129")]
+[assembly: AssemblyDescription("Version 3.11.1 - Build 3130")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.11.0.3129")]
-[assembly: AssemblyFileVersion("3.11.0.3129")]
+[assembly: AssemblyVersion("3.11.0.3130")]
+[assembly: AssemblyFileVersion("3.11.0.3130")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -405,6 +405,7 @@ namespace CumulusMX
 
 			var data = new JsonStationSettingsData()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				stationid = cumulus.StationType,
 				general = general,
 				davisvp2 = davisvp2,
@@ -1030,6 +1031,20 @@ namespace CumulusMX
 					context.Response.StatusCode = 500;
 				}
 
+				// Accessible
+				try
+				{
+					cumulus.ProgramOptions.EnableAccessibility = settings.accessible;
+				}
+				catch (Exception ex)
+				{
+					var msg = "Error processing Accessibility setting: " + ex.Message;
+					cumulus.LogMessage(msg);
+					errorMsg += msg + "\n\n";
+					context.Response.StatusCode = 500;
+				}
+
+
 				// Save the settings
 				cumulus.WriteIniFile();
 
@@ -1176,6 +1191,7 @@ namespace CumulusMX
 
 	internal class JsonStationSettingsData
 	{
+		public bool accessible { get; set; }
 		public int stationid { get; set; }
 		public JsonStationGeneral general { get; set; }
 		public JsonStationSettingsDavisVp2 davisvp2 { get; set; }

--- a/CumulusMX/ThirdPartySettings.cs
+++ b/CumulusMX/ThirdPartySettings.cs
@@ -488,6 +488,7 @@ namespace CumulusMX
 
 			var data = new JsonThirdPartySettings()
 			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				twitter = twittersettings,
 				wunderground = wusettings,
 				windy = windysettings,
@@ -526,6 +527,7 @@ namespace CumulusMX
 
 	public class JsonThirdPartySettings
 	{
+		public bool accessible { get; set; }
 		public JsonThirdPartySettingsTwitterSettings twitter { get; set; }
 		public JsonThirdPartySettingsWunderground wunderground { get; set; }
 		public JsonThirdPartySettingsWindy windy { get; set; }

--- a/CumulusMX/packages.config
+++ b/CumulusMX/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EmbedIO" version="2.1.1" targetFramework="net452" />
-  <package id="FluentFTP" version="33.1.5" targetFramework="net452" />
+  <package id="FluentFTP" version="32.3.1" targetFramework="net452" />
   <package id="HidSharp" version="2.1.0" targetFramework="net452" />
   <package id="linqtotwitter" version="3.1.1" targetFramework="net45" />
   <package id="MailKit" version="2.11.1" targetFramework="net452" />

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -459,10 +459,16 @@ namespace CumulusMX
 			return CheckRcDp(station.presstrendval, tagParams, cumulus.PressDPlaces);
 		}
 
-		private string TagTempChangeLastHour(Dictionary<string,string> tagParams)
+		private string TagPressChangeLast3Hours(Dictionary<string,string> tagParams)
+		{
+			return CheckRcDp(station.presstrendval * 3, tagParams, cumulus.PressDPlaces);
+		}
+
+		private string TagTempChangeLastHour(Dictionary<string, string> tagParams)
 		{
 			return CheckRc(station.TempChangeLastHour.ToString("+##0.0;-##0.0;0"), tagParams);
 		}
+
 
 		private string Tagdew(Dictionary<string,string> tagParams)
 		{
@@ -5139,6 +5145,7 @@ namespace CumulusMX
 				{ "dew", Tagdew },
 				{ "wetbulb", Tagwetbulb },
 				{ "presstrendval", Tagpresstrendval },
+				{ "PressChangeLast3Hours", TagPressChangeLast3Hours },
 				{ "windrunY", TagwindrunY },
 				{ "domwindbearingY", TagdomwindbearingY },
 				{ "domwinddirY", TagdomwinddirY },

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,8 +1,21 @@
 3.11.1 - b3130
 ——————————————
-- Fix: Change Test email logging success on failure
+- Fix: Fix Test email logging "success" on failure
+- Fix: Rollback FluentFTP package to previous 32.3.1 version due to crashes in Mono with newer versions
 
 - New: Pressure change in last 3 hours web tag - <#PressChangeLast3Hours>
+- New: Enable additional Accessibility feature - configured via either Station Settings or Program Settings
+	The following pages now have some enhanced accessibility features:
+	- Program Settings
+	- Station Settings
+	- Internet Settings
+	- Third Party Settings
+	- Extra Sensor Settings
+	- Calibration Settings
+	- NOAA Settings
+	- MySQL Settings
+	Adds a new entry in Cumulus.ini
+
 
 
 3.11.0 - b3129

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,10 @@
+3.11.1 - b3130
+——————————————
+- Fix: Change Test email logging success on failure
+
+- New: Pressure change in last 3 hours web tag - <#PressChangeLast3Hours>
+
+
 3.11.0 - b3129
 ——————————————
 - Fix: Remove THW Index in /web/websitedataT.json, and default web site index.htm


### PR DESCRIPTION
- Fix: Fix Test email logging "success" on failure
- Fix: Rollback FluentFTP package to previous 32.3.1 version due to crashes in Mono with newer versions

- New: Pressure change in last 3 hours web tag - <#PressChangeLast3Hours>
- New: Enable additional Accessibility feature - configured via either Station Settings or Program Settings
