### PR TITLE
v3.11.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
-* text=auto
+#* text=auto
 
 ###############################################################################
 # Set default behavior for command prompt diff.
@@ -17,7 +17,7 @@
 #
 # Merging from the command prompt will add diff markers to the files if there
 # are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following 
+# the diff markers are never inserted). Diff markers may cause the following
 # file extensions to fail to load in VS. An alternative would be to treat
 # these files as binary and thus will always conflict and require user
 # intervention with every merge. To do so, just uncomment the entries below
@@ -46,9 +46,9 @@
 
 ###############################################################################
 # diff behavior for common document formats
-# 
+#
 # Convert binary document formats to text before diffing them. This feature
-# is only available from the command line. Turn it on by uncommenting the 
+# is only available from the command line. Turn it on by uncommenting the
 # entries below.
 ###############################################################################
 #*.doc   diff=astextplain

--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CumulusMX
+{
+	public class Alarm
+	{
+		public Cumulus cumulus { get; set; }
+
+		public bool Enabled { get; set; }
+		public double Value { get; set; }
+		public bool Sound { get; set; }
+		public string SoundFile { get; set; }
+
+		bool triggered;
+		public bool Triggered
+		{
+			get => triggered;
+			set
+			{
+				if (value)
+				{
+					triggerCount++;
+					TriggeredTime = DateTime.Now;
+
+					// do we have a threshold value
+					if (triggerCount >= TriggerThreshold)
+					{
+						// If we were not set before, so we need to send an email?
+						if (!triggered && Enabled && Email && cumulus.SmtpOptions.Enabled)
+						{
+							// Construct the message - preamble, plus values
+							var msg = cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsg, Value, Units);
+							if (!string.IsNullOrEmpty(LastError))
+							{
+								msg += "\r\nLast error: " + LastError;
+							}
+							cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
+						}
+
+						// If we get a new trigger, record the time
+						triggered = true;
+					}
+				}
+				else
+				{
+					// If the trigger is cleared, check if we should be latching the value
+					if (Latch)
+					{
+						if (DateTime.Now > TriggeredTime.AddHours(LatchHours))
+						{
+							// We are latching, but the latch period has expired, clear the trigger
+							triggered = false;
+							triggerCount = 0;
+						}
+					}
+					else
+					{
+						// No latch, just clear the trigger
+						triggered = false;
+						triggerCount = 0;
+					}
+				}
+			}
+		}
+		public DateTime TriggeredTime { get; set; }
+		public bool Notify { get; set; }
+		public bool Email { get; set; }
+		public bool Latch { get; set; }
+		public int LatchHours { get; set; }
+		public string EmailMsg { get; set; }
+		public string Units { get; set; }
+		public string LastError { get; set; }
+		int triggerCount = 0;
+		public int TriggerThreshold { get; set; }
+	}
+
+	public class AlarmChange : Alarm
+	{
+		//public bool changeUp { get; set; }
+		//public bool changeDown { get; set; }
+
+		bool upTriggered;
+		public bool UpTriggered
+		{
+			get => upTriggered;
+			set
+			{
+				if (value)
+				{
+					// If we were not set before, so we need to send an email?
+					if (!upTriggered && Enabled && Email && cumulus.SmtpOptions.Enabled)
+					{
+						// Construct the message - preamble, plus values
+						var msg = Program.cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsgUp, Value, Units);
+						cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
+					}
+
+					// If we get a new trigger, record the time
+					upTriggered = true;
+					UpTriggeredTime = DateTime.Now;
+				}
+				else
+				{
+					// If the trigger is cleared, check if we should be latching the value
+					if (Latch)
+					{
+						if (DateTime.Now > UpTriggeredTime.AddHours(LatchHours))
+						{
+							// We are latching, but the latch period has expired, clear the trigger
+							upTriggered = false;
+						}
+					}
+					else
+					{
+						// No latch, just clear the trigger
+						upTriggered = false;
+					}
+				}
+			}
+		}
+		public DateTime UpTriggeredTime { get; set; }
+
+
+		bool downTriggered;
+		public bool DownTriggered
+		{
+			get => downTriggered;
+			set
+			{
+				if (value)
+				{
+					// If we were not set before, so we need to send an email?
+					if (!downTriggered && Enabled && Email && cumulus.SmtpOptions.Enabled)
+					{
+						// Construct the message - preamble, plus values
+						var msg = Program.cumulus.AlarmEmailPreamble + "\n" + string.Format(EmailMsgDn, Value, Units);
+						cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
+					}
+
+					// If we get a new trigger, record the time
+					downTriggered = true;
+					DownTriggeredTime = DateTime.Now;
+				}
+				else
+				{
+					// If the trigger is cleared, check if we should be latching the value
+					if (Latch)
+					{
+						if (DateTime.Now > DownTriggeredTime.AddHours(LatchHours))
+						{
+							// We are latching, but the latch period has expired, clear the trigger
+							downTriggered = false;
+						}
+					}
+					else
+					{
+						// No latch, just clear the trigger
+						downTriggered = false;
+					}
+				}
+			}
+		}
+
+		public DateTime DownTriggeredTime { get; set; }
+
+		public string EmailMsgUp { get; set; }
+		public string EmailMsgDn { get; set; }
+	}
+}

--- a/CumulusMX/AlarmSettings.cs
+++ b/CumulusMX/AlarmSettings.cs
@@ -29,151 +29,189 @@ namespace CumulusMX
 
 			var data = new JsonAlarmSettingsData()
 			{
-				tempBelowEnabled = cumulus.LowTempAlarm.Enabled,
-				tempBelowVal = cumulus.LowTempAlarm.Value,
-				tempBelowSoundEnabled = cumulus.LowTempAlarm.Sound,
-				tempBelowSound = cumulus.LowTempAlarm.SoundFile,
-				tempBelowNotify = cumulus.LowTempAlarm.Notify,
-				tempBelowEmail = cumulus.LowTempAlarm.Email,
-				tempBelowLatches = cumulus.LowTempAlarm.Latch,
-				tempBelowLatchHrs = cumulus.LowTempAlarm.LatchHours,
-
-				tempAboveEnabled = cumulus.HighTempAlarm.Enabled,
-				tempAboveVal = cumulus.HighTempAlarm.Value,
-				tempAboveSoundEnabled = cumulus.HighTempAlarm.Sound,
-				tempAboveSound = cumulus.HighTempAlarm.SoundFile,
-				tempAboveNotify = cumulus.HighTempAlarm.Notify,
-				tempAboveEmail = cumulus.HighTempAlarm.Email,
-				tempAboveLatches = cumulus.HighTempAlarm.Latch,
-				tempAboveLatchHrs = cumulus.HighTempAlarm.LatchHours,
-
-				tempChangeEnabled = cumulus.TempChangeAlarm.Enabled,
-				tempChangeVal = cumulus.TempChangeAlarm.Value,
-				tempChangeSoundEnabled = cumulus.TempChangeAlarm.Sound,
-				tempChangeSound = cumulus.TempChangeAlarm.SoundFile,
-				tempChangeNotify = cumulus.TempChangeAlarm.Notify,
-				tempChangeEmail = cumulus.TempChangeAlarm.Email,
-				tempChangeLatches = cumulus.TempChangeAlarm.Latch,
-				tempChangeLatchHrs = cumulus.TempChangeAlarm.LatchHours,
-
-				pressBelowEnabled = cumulus.LowPressAlarm.Enabled,
-				pressBelowVal = cumulus.LowPressAlarm.Value,
-				pressBelowSoundEnabled = cumulus.LowPressAlarm.Sound,
-				pressBelowSound = cumulus.LowPressAlarm.SoundFile,
-				pressBelowNotify = cumulus.LowPressAlarm.Notify,
-				pressBelowEmail = cumulus.LowPressAlarm.Email,
-				pressBelowLatches = cumulus.LowPressAlarm.Latch,
-				pressBelowLatchHrs = cumulus.LowPressAlarm.LatchHours,
-
-				pressAboveEnabled = cumulus.HighPressAlarm.Enabled,
-				pressAboveVal = cumulus.HighPressAlarm.Value,
-				pressAboveSoundEnabled = cumulus.HighPressAlarm.Sound,
-				pressAboveSound = cumulus.HighPressAlarm.SoundFile,
-				pressAboveNotify = cumulus.HighPressAlarm.Notify,
-				pressAboveEmail = cumulus.HighPressAlarm.Email,
-				pressAboveLatches = cumulus.HighPressAlarm.Latch,
-				pressAboveLatchHrs = cumulus.HighPressAlarm.LatchHours,
-
-				pressChangeEnabled = cumulus.PressChangeAlarm.Enabled,
-				pressChangeVal = cumulus.PressChangeAlarm.Value,
-				pressChangeSoundEnabled = cumulus.PressChangeAlarm.Sound,
-				pressChangeSound = cumulus.PressChangeAlarm.SoundFile,
-				pressChangeNotify = cumulus.PressChangeAlarm.Notify,
-				pressChangeEmail = cumulus.PressChangeAlarm.Email,
-				pressChangeLatches = cumulus.PressChangeAlarm.Latch,
-				pressChangeLatchHrs = cumulus.PressChangeAlarm.LatchHours,
-
-				rainAboveEnabled = cumulus.HighRainTodayAlarm.Enabled,
-				rainAboveVal = cumulus.HighRainTodayAlarm.Value,
-				rainAboveSoundEnabled = cumulus.HighRainTodayAlarm.Sound,
-				rainAboveSound = cumulus.HighRainTodayAlarm.SoundFile,
-				rainAboveNotify = cumulus.HighRainTodayAlarm.Notify,
-				rainAboveEmail = cumulus.HighRainTodayAlarm.Email,
-				rainAboveLatches = cumulus.HighRainTodayAlarm.Latch,
-				rainAboveLatchHrs = cumulus.HighRainTodayAlarm.LatchHours,
-
-				rainRateAboveEnabled = cumulus.HighRainRateAlarm.Enabled,
-				rainRateAboveVal = cumulus.HighRainRateAlarm.Value,
-				rainRateAboveSoundEnabled = cumulus.HighRainRateAlarm.Sound,
-				rainRateAboveSound = cumulus.HighRainRateAlarm.SoundFile,
-				rainRateAboveNotify = cumulus.HighRainRateAlarm.Notify,
-				rainRateAboveEmail = cumulus.HighRainRateAlarm.Email,
-				rainRateAboveLatches = cumulus.HighRainRateAlarm.Latch,
-				rainRateAboveLatchHrs = cumulus.HighRainRateAlarm.LatchHours,
-
-				gustAboveEnabled = cumulus.HighGustAlarm.Enabled,
-				gustAboveVal = cumulus.HighGustAlarm.Value,
-				gustAboveSoundEnabled = cumulus.HighGustAlarm.Sound,
-				gustAboveSound = cumulus.HighGustAlarm.SoundFile,
-				gustAboveNotify = cumulus.HighGustAlarm.Notify,
-				gustAboveEmail = cumulus.HighGustAlarm.Email,
-				gustAboveLatches = cumulus.HighGustAlarm.Latch,
-				gustAboveLatchHrs = cumulus.HighGustAlarm.LatchHours,
-
-				windAboveEnabled = cumulus.HighWindAlarm.Enabled,
-				windAboveVal = cumulus.HighWindAlarm.Value,
-				windAboveSoundEnabled = cumulus.HighWindAlarm.Sound,
-				windAboveSound = cumulus.HighWindAlarm.SoundFile,
-				windAboveNotify = cumulus.HighWindAlarm.Notify,
-				windAboveEmail = cumulus.HighWindAlarm.Email,
-				windAboveLatches = cumulus.HighWindAlarm.Latch,
-				windAboveLatchHrs = cumulus.HighWindAlarm.LatchHours,
-
-				contactLostEnabled = cumulus.SensorAlarm.Enabled,
-				contactLostSoundEnabled = cumulus.SensorAlarm.Sound,
-				contactLostSound = cumulus.SensorAlarm.SoundFile,
-				contactLostNotify = cumulus.SensorAlarm.Notify,
-				contactLostEmail = cumulus.SensorAlarm.Email,
-				contactLostLatches = cumulus.SensorAlarm.Latch,
-				contactLostLatchHrs = cumulus.SensorAlarm.LatchHours,
-
-				dataStoppedEnabled = cumulus.DataStoppedAlarm.Enabled,
-				dataStoppedSoundEnabled = cumulus.DataStoppedAlarm.Sound,
-				dataStoppedSound = cumulus.DataStoppedAlarm.SoundFile,
-				dataStoppedNotify = cumulus.DataStoppedAlarm.Notify,
-				dataStoppedEmail = cumulus.DataStoppedAlarm.Email,
-				dataStoppedLatches = cumulus.DataStoppedAlarm.Latch,
-				dataStoppedLatchHrs = cumulus.DataStoppedAlarm.LatchHours,
-
-				batteryLowEnabled = cumulus.BatteryLowAlarm.Enabled,
-				batteryLowSoundEnabled = cumulus.BatteryLowAlarm.Sound,
-				batteryLowSound = cumulus.BatteryLowAlarm.SoundFile,
-				batteryLowNotify = cumulus.BatteryLowAlarm.Notify,
-				batteryLowEmail = cumulus.BatteryLowAlarm.Email,
-				batteryLowLatches = cumulus.BatteryLowAlarm.Latch,
-				batteryLowLatchHrs = cumulus.BatteryLowAlarm.LatchHours,
-
-				spikeEnabled = cumulus.SpikeAlarm.Enabled,
-				spikeSoundEnabled = cumulus.SpikeAlarm.Sound,
-				spikeSound = cumulus.SpikeAlarm.SoundFile,
-				spikeNotify = cumulus.SpikeAlarm.Notify,
-				spikeEmail = cumulus.SpikeAlarm.Email,
-				spikeLatches = cumulus.SpikeAlarm.Latch,
-				spikeLatchHrs = cumulus.SpikeAlarm.LatchHours,
-
-				upgradeEnabled = cumulus.UpgradeAlarm.Enabled,
-				upgradeSoundEnabled = cumulus.UpgradeAlarm.Sound,
-				upgradeSound = cumulus.UpgradeAlarm.SoundFile,
-				upgradeNotify = cumulus.UpgradeAlarm.Notify,
-				upgradeEmail = cumulus.UpgradeAlarm.Email,
-				upgradeLatches = cumulus.UpgradeAlarm.Latch,
-				upgradeLatchHrs = cumulus.UpgradeAlarm.LatchHours,
-
-				httpStoppedEnabled = cumulus.HttpUploadAlarm.Enabled,
-				httpStoppedSoundEnabled = cumulus.HttpUploadAlarm.Sound,
-				httpStoppedSound = cumulus.HttpUploadAlarm.SoundFile,
-				httpStoppedNotify = cumulus.HttpUploadAlarm.Notify,
-				httpStoppedEmail = cumulus.HttpUploadAlarm.Email,
-				httpStoppedLatches = cumulus.HttpUploadAlarm.Latch,
-				httpStoppedLatchHrs = cumulus.HttpUploadAlarm.LatchHours,
-
-				mySqlStoppedEnabled = cumulus.MySqlUploadAlarm.Enabled,
-				mySqlStoppedSoundEnabled = cumulus.MySqlUploadAlarm.Sound,
-				mySqlStoppedSound = cumulus.MySqlUploadAlarm.SoundFile,
-				mySqlStoppedNotify = cumulus.MySqlUploadAlarm.Notify,
-				mySqlStoppedEmail = cumulus.MySqlUploadAlarm.Email,
-				mySqlStoppedLatches = cumulus.MySqlUploadAlarm.Latch,
-				mySqlStoppedLatchHrs = cumulus.MySqlUploadAlarm.LatchHours
+				tempBelow = new JsonAlarmValues()
+				{
+					Enabled = cumulus.LowTempAlarm.Enabled,
+					Val = cumulus.LowTempAlarm.Value,
+					SoundEnabled = cumulus.LowTempAlarm.Sound,
+					Sound = cumulus.LowTempAlarm.SoundFile,
+					Notify = cumulus.LowTempAlarm.Notify,
+					Email = cumulus.LowTempAlarm.Email,
+					Latches = cumulus.LowTempAlarm.Latch,
+					LatchHrs = cumulus.LowTempAlarm.LatchHours
+				},
+				tempAbove = new JsonAlarmValues()
+				{
+					Enabled = cumulus.HighTempAlarm.Enabled,
+					Val = cumulus.HighTempAlarm.Value,
+					SoundEnabled = cumulus.HighTempAlarm.Sound,
+					Sound = cumulus.HighTempAlarm.SoundFile,
+					Notify = cumulus.HighTempAlarm.Notify,
+					Email = cumulus.HighTempAlarm.Email,
+					Latches = cumulus.HighTempAlarm.Latch,
+					LatchHrs = cumulus.HighTempAlarm.LatchHours
+				},
+				tempChange = new JsonAlarmValues()
+				{
+					Enabled = cumulus.TempChangeAlarm.Enabled,
+					Val = cumulus.TempChangeAlarm.Value,
+					SoundEnabled = cumulus.TempChangeAlarm.Sound,
+					Sound = cumulus.TempChangeAlarm.SoundFile,
+					Notify = cumulus.TempChangeAlarm.Notify,
+					Email = cumulus.TempChangeAlarm.Email,
+					Latches = cumulus.TempChangeAlarm.Latch,
+					LatchHrs = cumulus.TempChangeAlarm.LatchHours
+				},
+				pressBelow = new JsonAlarmValues()
+				{
+					Enabled = cumulus.LowPressAlarm.Enabled,
+					Val = cumulus.LowPressAlarm.Value,
+					SoundEnabled = cumulus.LowPressAlarm.Sound,
+					Sound = cumulus.LowPressAlarm.SoundFile,
+					Notify = cumulus.LowPressAlarm.Notify,
+					Email = cumulus.LowPressAlarm.Email,
+					Latches = cumulus.LowPressAlarm.Latch,
+					LatchHrs = cumulus.LowPressAlarm.LatchHours
+				},
+				pressAbove = new JsonAlarmValues()
+				{
+					Enabled = cumulus.HighPressAlarm.Enabled,
+					Val = cumulus.HighPressAlarm.Value,
+					SoundEnabled = cumulus.HighPressAlarm.Sound,
+					Sound = cumulus.HighPressAlarm.SoundFile,
+					Notify = cumulus.HighPressAlarm.Notify,
+					Email = cumulus.HighPressAlarm.Email,
+					Latches = cumulus.HighPressAlarm.Latch,
+					LatchHrs = cumulus.HighPressAlarm.LatchHours
+				},
+				pressChange = new JsonAlarmValues()
+				{
+					Enabled = cumulus.PressChangeAlarm.Enabled,
+					Val = cumulus.PressChangeAlarm.Value,
+					SoundEnabled = cumulus.PressChangeAlarm.Sound,
+					Sound = cumulus.PressChangeAlarm.SoundFile,
+					Notify = cumulus.PressChangeAlarm.Notify,
+					Email = cumulus.PressChangeAlarm.Email,
+					Latches = cumulus.PressChangeAlarm.Latch,
+					LatchHrs = cumulus.PressChangeAlarm.LatchHours
+				},
+				rainAbove = new JsonAlarmValues()
+				{
+					Enabled = cumulus.HighRainTodayAlarm.Enabled,
+					Val = cumulus.HighRainTodayAlarm.Value,
+					SoundEnabled = cumulus.HighRainTodayAlarm.Sound,
+					Sound = cumulus.HighRainTodayAlarm.SoundFile,
+					Notify = cumulus.HighRainTodayAlarm.Notify,
+					Email = cumulus.HighRainTodayAlarm.Email,
+					Latches = cumulus.HighRainTodayAlarm.Latch,
+					LatchHrs = cumulus.HighRainTodayAlarm.LatchHours
+				},
+				rainRateAbove = new JsonAlarmValues()
+				{
+					Enabled = cumulus.HighRainRateAlarm.Enabled,
+					Val = cumulus.HighRainRateAlarm.Value,
+					SoundEnabled = cumulus.HighRainRateAlarm.Sound,
+					Sound = cumulus.HighRainRateAlarm.SoundFile,
+					Notify = cumulus.HighRainRateAlarm.Notify,
+					Email = cumulus.HighRainRateAlarm.Email,
+					Latches = cumulus.HighRainRateAlarm.Latch,
+					LatchHrs = cumulus.HighRainRateAlarm.LatchHours
+				},
+				gustAbove = new JsonAlarmValues()
+				{
+					Enabled = cumulus.HighGustAlarm.Enabled,
+					Val = cumulus.HighGustAlarm.Value,
+					SoundEnabled = cumulus.HighGustAlarm.Sound,
+					Sound = cumulus.HighGustAlarm.SoundFile,
+					Notify = cumulus.HighGustAlarm.Notify,
+					Email = cumulus.HighGustAlarm.Email,
+					Latches = cumulus.HighGustAlarm.Latch,
+					LatchHrs = cumulus.HighGustAlarm.LatchHours
+				},
+				windAbove = new JsonAlarmValues()
+				{
+					Enabled = cumulus.HighWindAlarm.Enabled,
+					Val = cumulus.HighWindAlarm.Value,
+					SoundEnabled = cumulus.HighWindAlarm.Sound,
+					Sound = cumulus.HighWindAlarm.SoundFile,
+					Notify = cumulus.HighWindAlarm.Notify,
+					Email = cumulus.HighWindAlarm.Email,
+					Latches = cumulus.HighWindAlarm.Latch,
+					LatchHrs = cumulus.HighWindAlarm.LatchHours
+				},
+				contactLost = new JsonAlarmValues()
+				{
+					Enabled = cumulus.SensorAlarm.Enabled,
+					SoundEnabled = cumulus.SensorAlarm.Sound,
+					Sound = cumulus.SensorAlarm.SoundFile,
+					Notify = cumulus.SensorAlarm.Notify,
+					Email = cumulus.SensorAlarm.Email,
+					Latches = cumulus.SensorAlarm.Latch,
+					LatchHrs = cumulus.SensorAlarm.LatchHours
+				},
+				dataStopped = new JsonAlarmValues()
+				{
+					Enabled = cumulus.DataStoppedAlarm.Enabled,
+					SoundEnabled = cumulus.DataStoppedAlarm.Sound,
+					Sound = cumulus.DataStoppedAlarm.SoundFile,
+					Notify = cumulus.DataStoppedAlarm.Notify,
+					Email = cumulus.DataStoppedAlarm.Email,
+					Latches = cumulus.DataStoppedAlarm.Latch,
+					LatchHrs = cumulus.DataStoppedAlarm.LatchHours
+				},
+				batteryLow = new JsonAlarmValues()
+				{
+					Enabled = cumulus.BatteryLowAlarm.Enabled,
+					SoundEnabled = cumulus.BatteryLowAlarm.Sound,
+					Sound = cumulus.BatteryLowAlarm.SoundFile,
+					Notify = cumulus.BatteryLowAlarm.Notify,
+					Email = cumulus.BatteryLowAlarm.Email,
+					Latches = cumulus.BatteryLowAlarm.Latch,
+					LatchHrs = cumulus.BatteryLowAlarm.LatchHours
+				},
+				spike = new JsonAlarmValues()
+				{
+					Enabled = cumulus.SpikeAlarm.Enabled,
+					SoundEnabled = cumulus.SpikeAlarm.Sound,
+					Sound = cumulus.SpikeAlarm.SoundFile,
+					Notify = cumulus.SpikeAlarm.Notify,
+					Email = cumulus.SpikeAlarm.Email,
+					Latches = cumulus.SpikeAlarm.Latch,
+					LatchHrs = cumulus.SpikeAlarm.LatchHours,
+					Threshold = cumulus.SpikeAlarm.TriggerThreshold
+				},
+				upgrade = new JsonAlarmValues()
+				{
+					Enabled = cumulus.UpgradeAlarm.Enabled,
+					SoundEnabled = cumulus.UpgradeAlarm.Sound,
+					Sound = cumulus.UpgradeAlarm.SoundFile,
+					Notify = cumulus.UpgradeAlarm.Notify,
+					Email = cumulus.UpgradeAlarm.Email,
+					Latches = cumulus.UpgradeAlarm.Latch,
+					LatchHrs = cumulus.UpgradeAlarm.LatchHours
+				},
+				httpUpload = new JsonAlarmValues()
+				{
+					Enabled = cumulus.HttpUploadAlarm.Enabled,
+					SoundEnabled = cumulus.HttpUploadAlarm.Sound,
+					Sound = cumulus.HttpUploadAlarm.SoundFile,
+					Notify = cumulus.HttpUploadAlarm.Notify,
+					Email = cumulus.HttpUploadAlarm.Email,
+					Latches = cumulus.HttpUploadAlarm.Latch,
+					LatchHrs = cumulus.HttpUploadAlarm.LatchHours,
+					Threshold = cumulus.HttpUploadAlarm.TriggerThreshold
+				},
+				mySqlUpload = new JsonAlarmValues()
+				{
+					Enabled = cumulus.MySqlUploadAlarm.Enabled,
+					SoundEnabled = cumulus.MySqlUploadAlarm.Sound,
+					Sound = cumulus.MySqlUploadAlarm.SoundFile,
+					Notify = cumulus.MySqlUploadAlarm.Notify,
+					Email = cumulus.MySqlUploadAlarm.Email,
+					Latches = cumulus.MySqlUploadAlarm.Latch,
+					LatchHrs = cumulus.MySqlUploadAlarm.LatchHours,
+					Threshold = cumulus.MySqlUploadAlarm.TriggerThreshold
+				}
 			};
 
 			var email = new JsonAlarmEmail()
@@ -227,152 +265,155 @@ namespace CumulusMX
 				// process the settings
 				cumulus.LogMessage("Updating Alarm settings");
 
-				cumulus.LowTempAlarm.Enabled = settings.tempBelowEnabled;
-				cumulus.LowTempAlarm.Value = settings.tempBelowVal;
-				cumulus.LowTempAlarm.Sound = settings.tempBelowSoundEnabled;
-				cumulus.LowTempAlarm.SoundFile = settings.tempBelowSound;
-				cumulus.LowTempAlarm.Notify = settings.tempBelowNotify;
-				cumulus.LowTempAlarm.Email = settings.tempBelowEmail;
-				cumulus.LowTempAlarm.Latch = settings.tempBelowLatches;
-				cumulus.LowTempAlarm.LatchHours = settings.tempBelowLatchHrs;
+				cumulus.LowTempAlarm.Enabled = settings.tempBelow.Enabled;
+				cumulus.LowTempAlarm.Value = settings.tempBelow.Val;
+				cumulus.LowTempAlarm.Sound = settings.tempBelow.SoundEnabled;
+				cumulus.LowTempAlarm.SoundFile = settings.tempBelow.Sound;
+				cumulus.LowTempAlarm.Notify = settings.tempBelow.Notify;
+				cumulus.LowTempAlarm.Email = settings.tempBelow.Email;
+				cumulus.LowTempAlarm.Latch = settings.tempBelow.Latches;
+				cumulus.LowTempAlarm.LatchHours = settings.tempBelow.LatchHrs;
 
 
-				cumulus.HighTempAlarm.Enabled = settings.tempAboveEnabled;
-				cumulus.HighTempAlarm.Value = settings.tempAboveVal;
-				cumulus.HighTempAlarm.Sound = settings.tempAboveSoundEnabled;
-				cumulus.HighTempAlarm.SoundFile = settings.tempAboveSound;
-				cumulus.HighTempAlarm.Notify = settings.tempAboveNotify;
-				cumulus.HighTempAlarm.Email = settings.tempAboveEmail;
-				cumulus.HighTempAlarm.Latch = settings.tempAboveLatches;
-				cumulus.HighTempAlarm.LatchHours = settings.tempAboveLatchHrs;
+				cumulus.HighTempAlarm.Enabled = settings.tempAbove.Enabled;
+				cumulus.HighTempAlarm.Value = settings.tempAbove.Val;
+				cumulus.HighTempAlarm.Sound = settings.tempAbove.SoundEnabled;
+				cumulus.HighTempAlarm.SoundFile = settings.tempAbove.Sound;
+				cumulus.HighTempAlarm.Notify = settings.tempAbove.Notify;
+				cumulus.HighTempAlarm.Email = settings.tempAbove.Email;
+				cumulus.HighTempAlarm.Latch = settings.tempAbove.Latches;
+				cumulus.HighTempAlarm.LatchHours = settings.tempAbove.LatchHrs;
 
-				cumulus.TempChangeAlarm.Enabled = settings.tempChangeEnabled;
-				cumulus.TempChangeAlarm.Value = settings.tempChangeVal;
-				cumulus.TempChangeAlarm.Sound = settings.tempChangeSoundEnabled;
-				cumulus.TempChangeAlarm.SoundFile = settings.tempChangeSound;
-				cumulus.TempChangeAlarm.Notify = settings.tempChangeNotify;
-				cumulus.TempChangeAlarm.Email = settings.tempChangeEmail;
-				cumulus.TempChangeAlarm.Latch = settings.tempChangeLatches;
-				cumulus.TempChangeAlarm.LatchHours = settings.tempChangeLatchHrs;
+				cumulus.TempChangeAlarm.Enabled = settings.tempChange.Enabled;
+				cumulus.TempChangeAlarm.Value = settings.tempChange.Val;
+				cumulus.TempChangeAlarm.Sound = settings.tempChange.SoundEnabled;
+				cumulus.TempChangeAlarm.SoundFile = settings.tempChange.Sound;
+				cumulus.TempChangeAlarm.Notify = settings.tempChange.Notify;
+				cumulus.TempChangeAlarm.Email = settings.tempChange.Email;
+				cumulus.TempChangeAlarm.Latch = settings.tempChange.Latches;
+				cumulus.TempChangeAlarm.LatchHours = settings.tempChange.LatchHrs;
 
-				cumulus.LowPressAlarm.Enabled = settings.pressBelowEnabled;
-				cumulus.LowPressAlarm.Value = settings.pressBelowVal;
-				cumulus.LowPressAlarm.Sound = settings.pressBelowSoundEnabled;
-				cumulus.LowPressAlarm.SoundFile = settings.pressBelowSound;
-				cumulus.LowPressAlarm.Notify = settings.pressBelowNotify;
-				cumulus.LowPressAlarm.Email = settings.pressBelowEmail;
-				cumulus.LowPressAlarm.Latch = settings.pressBelowLatches;
-				cumulus.LowPressAlarm.LatchHours = settings.pressBelowLatchHrs;
+				cumulus.LowPressAlarm.Enabled = settings.pressBelow.Enabled;
+				cumulus.LowPressAlarm.Value = settings.pressBelow.Val;
+				cumulus.LowPressAlarm.Sound = settings.pressBelow.SoundEnabled;
+				cumulus.LowPressAlarm.SoundFile = settings.pressBelow.Sound;
+				cumulus.LowPressAlarm.Notify = settings.pressBelow.Notify;
+				cumulus.LowPressAlarm.Email = settings.pressBelow.Email;
+				cumulus.LowPressAlarm.Latch = settings.pressBelow.Latches;
+				cumulus.LowPressAlarm.LatchHours = settings.pressBelow.LatchHrs;
 
-				cumulus.HighPressAlarm.Enabled = settings.pressAboveEnabled;
-				cumulus.HighPressAlarm.Value = settings.pressAboveVal;
-				cumulus.HighPressAlarm.Sound = settings.pressAboveSoundEnabled;
-				cumulus.HighPressAlarm.SoundFile = settings.pressAboveSound;
-				cumulus.HighPressAlarm.Notify = settings.pressAboveNotify;
-				cumulus.HighPressAlarm.Email = settings.pressAboveEmail;
-				cumulus.HighPressAlarm.Latch = settings.pressAboveLatches;
-				cumulus.HighPressAlarm.LatchHours = settings.pressAboveLatchHrs;
+				cumulus.HighPressAlarm.Enabled = settings.pressAbove.Enabled;
+				cumulus.HighPressAlarm.Value = settings.pressAbove.Val;
+				cumulus.HighPressAlarm.Sound = settings.pressAbove.SoundEnabled;
+				cumulus.HighPressAlarm.SoundFile = settings.pressAbove.Sound;
+				cumulus.HighPressAlarm.Notify = settings.pressAbove.Notify;
+				cumulus.HighPressAlarm.Email = settings.pressAbove.Email;
+				cumulus.HighPressAlarm.Latch = settings.pressAbove.Latches;
+				cumulus.HighPressAlarm.LatchHours = settings.pressAbove.LatchHrs;
 
-				cumulus.PressChangeAlarm.Enabled = settings.pressChangeEnabled;
-				cumulus.PressChangeAlarm.Value = settings.pressChangeVal;
-				cumulus.PressChangeAlarm.Sound = settings.pressChangeSoundEnabled;
-				cumulus.PressChangeAlarm.SoundFile = settings.pressChangeSound;
-				cumulus.PressChangeAlarm.Notify = settings.pressChangeNotify;
-				cumulus.PressChangeAlarm.Email = settings.pressChangeEmail;
-				cumulus.PressChangeAlarm.Latch = settings.pressChangeLatches;
-				cumulus.PressChangeAlarm.LatchHours = settings.pressChangeLatchHrs;
+				cumulus.PressChangeAlarm.Enabled = settings.pressChange.Enabled;
+				cumulus.PressChangeAlarm.Value = settings.pressChange.Val;
+				cumulus.PressChangeAlarm.Sound = settings.pressChange.SoundEnabled;
+				cumulus.PressChangeAlarm.SoundFile = settings.pressChange.Sound;
+				cumulus.PressChangeAlarm.Notify = settings.pressChange.Notify;
+				cumulus.PressChangeAlarm.Email = settings.pressChange.Email;
+				cumulus.PressChangeAlarm.Latch = settings.pressChange.Latches;
+				cumulus.PressChangeAlarm.LatchHours = settings.pressChange.LatchHrs;
 
-				cumulus.HighRainTodayAlarm.Enabled = settings.rainAboveEnabled;
-				cumulus.HighRainTodayAlarm.Value = settings.rainAboveVal;
-				cumulus.HighRainTodayAlarm.Sound = settings.rainAboveSoundEnabled;
-				cumulus.HighRainTodayAlarm.SoundFile = settings.rainAboveSound;
-				cumulus.HighRainTodayAlarm.Notify = settings.rainAboveNotify;
-				cumulus.HighRainTodayAlarm.Email = settings.rainAboveEmail;
-				cumulus.HighRainTodayAlarm.Latch = settings.rainAboveLatches;
-				cumulus.HighRainTodayAlarm.LatchHours = settings.rainAboveLatchHrs;
+				cumulus.HighRainTodayAlarm.Enabled = settings.rainAbove.Enabled;
+				cumulus.HighRainTodayAlarm.Value = settings.rainAbove.Val;
+				cumulus.HighRainTodayAlarm.Sound = settings.rainAbove.SoundEnabled;
+				cumulus.HighRainTodayAlarm.SoundFile = settings.rainAbove.Sound;
+				cumulus.HighRainTodayAlarm.Notify = settings.rainAbove.Notify;
+				cumulus.HighRainTodayAlarm.Email = settings.rainAbove.Email;
+				cumulus.HighRainTodayAlarm.Latch = settings.rainAbove.Latches;
+				cumulus.HighRainTodayAlarm.LatchHours = settings.rainAbove.LatchHrs;
 
-				cumulus.HighRainRateAlarm.Enabled = settings.rainRateAboveEnabled;
-				cumulus.HighRainRateAlarm.Value = settings.rainRateAboveVal;
-				cumulus.HighRainRateAlarm.Sound = settings.rainRateAboveSoundEnabled;
-				cumulus.HighRainRateAlarm.SoundFile = settings.rainRateAboveSound;
-				cumulus.HighRainRateAlarm.Notify = settings.rainRateAboveNotify;
-				cumulus.HighRainRateAlarm.Email = settings.rainRateAboveEmail;
-				cumulus.HighRainRateAlarm.Latch = settings.rainRateAboveLatches;
-				cumulus.HighRainRateAlarm.LatchHours = settings.rainRateAboveLatchHrs;
+				cumulus.HighRainRateAlarm.Enabled = settings.rainRateAbove.Enabled;
+				cumulus.HighRainRateAlarm.Value = settings.rainRateAbove.Val;
+				cumulus.HighRainRateAlarm.Sound = settings.rainRateAbove.SoundEnabled;
+				cumulus.HighRainRateAlarm.SoundFile = settings.rainRateAbove.Sound;
+				cumulus.HighRainRateAlarm.Notify = settings.rainRateAbove.Notify;
+				cumulus.HighRainRateAlarm.Email = settings.rainRateAbove.Email;
+				cumulus.HighRainRateAlarm.Latch = settings.rainRateAbove.Latches;
+				cumulus.HighRainRateAlarm.LatchHours = settings.rainRateAbove.LatchHrs;
 
-				cumulus.HighGustAlarm.Enabled = settings.gustAboveEnabled;
-				cumulus.HighGustAlarm.Value = settings.gustAboveVal;
-				cumulus.HighGustAlarm.Sound = settings.gustAboveSoundEnabled;
-				cumulus.HighGustAlarm.SoundFile = settings.gustAboveSound;
-				cumulus.HighGustAlarm.Notify = settings.gustAboveNotify;
-				cumulus.HighGustAlarm.Email = settings.gustAboveEmail;
-				cumulus.HighGustAlarm.Latch = settings.gustAboveLatches;
-				cumulus.HighGustAlarm.LatchHours = settings.gustAboveLatchHrs;
+				cumulus.HighGustAlarm.Enabled = settings.gustAbove.Enabled;
+				cumulus.HighGustAlarm.Value = settings.gustAbove.Val;
+				cumulus.HighGustAlarm.Sound = settings.gustAbove.SoundEnabled;
+				cumulus.HighGustAlarm.SoundFile = settings.gustAbove.Sound;
+				cumulus.HighGustAlarm.Notify = settings.gustAbove.Notify;
+				cumulus.HighGustAlarm.Email = settings.gustAbove.Email;
+				cumulus.HighGustAlarm.Latch = settings.gustAbove.Latches;
+				cumulus.HighGustAlarm.LatchHours = settings.gustAbove.LatchHrs;
 
-				cumulus.HighWindAlarm.Enabled = settings.windAboveEnabled;
-				cumulus.HighWindAlarm.Value = settings.windAboveVal;
-				cumulus.HighWindAlarm.Sound = settings.windAboveSoundEnabled;
-				cumulus.HighWindAlarm.SoundFile = settings.windAboveSound;
-				cumulus.HighWindAlarm.Notify = settings.windAboveNotify;
-				cumulus.HighWindAlarm.Email = settings.windAboveEmail;
-				cumulus.HighWindAlarm.Latch = settings.windAboveLatches;
-				cumulus.HighWindAlarm.LatchHours = settings.windAboveLatchHrs;
+				cumulus.HighWindAlarm.Enabled = settings.windAbove.Enabled;
+				cumulus.HighWindAlarm.Value = settings.windAbove.Val;
+				cumulus.HighWindAlarm.Sound = settings.windAbove.SoundEnabled;
+				cumulus.HighWindAlarm.SoundFile = settings.windAbove.Sound;
+				cumulus.HighWindAlarm.Notify = settings.windAbove.Notify;
+				cumulus.HighWindAlarm.Email = settings.windAbove.Email;
+				cumulus.HighWindAlarm.Latch = settings.windAbove.Latches;
+				cumulus.HighWindAlarm.LatchHours = settings.windAbove.LatchHrs;
 
-				cumulus.SensorAlarm.Enabled = settings.contactLostEnabled;
-				cumulus.SensorAlarm.Sound = settings.contactLostSoundEnabled;
-				cumulus.SensorAlarm.SoundFile = settings.contactLostSound;
-				cumulus.SensorAlarm.Notify = settings.contactLostNotify;
-				cumulus.SensorAlarm.Email = settings.contactLostEmail;
-				cumulus.SensorAlarm.Latch = settings.contactLostLatches;
-				cumulus.SensorAlarm.LatchHours = settings.contactLostLatchHrs;
+				cumulus.SensorAlarm.Enabled = settings.contactLost.Enabled;
+				cumulus.SensorAlarm.Sound = settings.contactLost.SoundEnabled;
+				cumulus.SensorAlarm.SoundFile = settings.contactLost.Sound;
+				cumulus.SensorAlarm.Notify = settings.contactLost.Notify;
+				cumulus.SensorAlarm.Email = settings.contactLost.Email;
+				cumulus.SensorAlarm.Latch = settings.contactLost.Latches;
+				cumulus.SensorAlarm.LatchHours = settings.contactLost.LatchHrs;
 
-				cumulus.DataStoppedAlarm.Enabled = settings.dataStoppedEnabled;
-				cumulus.DataStoppedAlarm.Sound = settings.dataStoppedSoundEnabled;
-				cumulus.DataStoppedAlarm.SoundFile = settings.dataStoppedSound;
-				cumulus.DataStoppedAlarm.Notify = settings.dataStoppedNotify;
-				cumulus.DataStoppedAlarm.Email = settings.dataStoppedEmail;
-				cumulus.DataStoppedAlarm.Latch = settings.dataStoppedLatches;
-				cumulus.DataStoppedAlarm.LatchHours = settings.dataStoppedLatchHrs;
+				cumulus.DataStoppedAlarm.Enabled = settings.dataStopped.Enabled;
+				cumulus.DataStoppedAlarm.Sound = settings.dataStopped.SoundEnabled;
+				cumulus.DataStoppedAlarm.SoundFile = settings.dataStopped.Sound;
+				cumulus.DataStoppedAlarm.Notify = settings.dataStopped.Notify;
+				cumulus.DataStoppedAlarm.Email = settings.dataStopped.Email;
+				cumulus.DataStoppedAlarm.Latch = settings.dataStopped.Latches;
+				cumulus.DataStoppedAlarm.LatchHours = settings.dataStopped.LatchHrs;
 
-				cumulus.BatteryLowAlarm.Enabled = settings.batteryLowEnabled;
-				cumulus.BatteryLowAlarm.Sound = settings.batteryLowSoundEnabled;
-				cumulus.BatteryLowAlarm.SoundFile = settings.batteryLowSound;
-				cumulus.BatteryLowAlarm.Notify = settings.batteryLowNotify;
-				cumulus.BatteryLowAlarm.Email = settings.batteryLowEmail;
-				cumulus.BatteryLowAlarm.Latch = settings.batteryLowLatches;
-				cumulus.BatteryLowAlarm.LatchHours = settings.batteryLowLatchHrs;
+				cumulus.BatteryLowAlarm.Enabled = settings.batteryLow.Enabled;
+				cumulus.BatteryLowAlarm.Sound = settings.batteryLow.SoundEnabled;
+				cumulus.BatteryLowAlarm.SoundFile = settings.batteryLow.Sound;
+				cumulus.BatteryLowAlarm.Notify = settings.batteryLow.Notify;
+				cumulus.BatteryLowAlarm.Email = settings.batteryLow.Email;
+				cumulus.BatteryLowAlarm.Latch = settings.batteryLow.Latches;
+				cumulus.BatteryLowAlarm.LatchHours = settings.batteryLow.LatchHrs;
 
-				cumulus.SpikeAlarm.Enabled = settings.spikeEnabled;
-				cumulus.SpikeAlarm.Sound = settings.spikeSoundEnabled;
-				cumulus.SpikeAlarm.SoundFile = settings.spikeSound;
-				cumulus.SpikeAlarm.Notify = settings.spikeNotify;
-				cumulus.SpikeAlarm.Email = settings.spikeEmail;
-				cumulus.SpikeAlarm.Latch = settings.spikeLatches;
-				cumulus.SpikeAlarm.LatchHours = settings.spikeLatchHrs;
+				cumulus.SpikeAlarm.Enabled = settings.spike.Enabled;
+				cumulus.SpikeAlarm.Sound = settings.spike.SoundEnabled;
+				cumulus.SpikeAlarm.SoundFile = settings.spike.Sound;
+				cumulus.SpikeAlarm.Notify = settings.spike.Notify;
+				cumulus.SpikeAlarm.Email = settings.spike.Email;
+				cumulus.SpikeAlarm.Latch = settings.spike.Latches;
+				cumulus.SpikeAlarm.LatchHours = settings.spike.LatchHrs;
+				cumulus.SpikeAlarm.TriggerThreshold = settings.spike.Threshold;
 
-				cumulus.UpgradeAlarm.Enabled = settings.upgradeEnabled;
-				cumulus.UpgradeAlarm.Sound = settings.upgradeSoundEnabled;
-				cumulus.UpgradeAlarm.SoundFile = settings.upgradeSound;
-				cumulus.UpgradeAlarm.Notify = settings.upgradeNotify;
-				cumulus.UpgradeAlarm.Email = settings.upgradeEmail;
-				cumulus.UpgradeAlarm.Latch = settings.upgradeLatches;
-				cumulus.UpgradeAlarm.LatchHours = settings.upgradeLatchHrs;
+				cumulus.UpgradeAlarm.Enabled = settings.upgrade.Enabled;
+				cumulus.UpgradeAlarm.Sound = settings.upgrade.SoundEnabled;
+				cumulus.UpgradeAlarm.SoundFile = settings.upgrade.Sound;
+				cumulus.UpgradeAlarm.Notify = settings.upgrade.Notify;
+				cumulus.UpgradeAlarm.Email = settings.upgrade.Email;
+				cumulus.UpgradeAlarm.Latch = settings.upgrade.Latches;
+				cumulus.UpgradeAlarm.LatchHours = settings.upgrade.LatchHrs;
 
-				cumulus.HttpUploadAlarm.Enabled = settings.httpStoppedEnabled;
-				cumulus.HttpUploadAlarm.Sound = settings.httpStoppedSoundEnabled;
-				cumulus.HttpUploadAlarm.SoundFile = settings.httpStoppedSound;
-				cumulus.HttpUploadAlarm.Notify = settings.httpStoppedNotify;
-				cumulus.HttpUploadAlarm.Email = settings.httpStoppedEmail;
-				cumulus.HttpUploadAlarm.Latch = settings.httpStoppedLatches;
-				cumulus.HttpUploadAlarm.LatchHours = settings.httpStoppedLatchHrs;
+				cumulus.HttpUploadAlarm.Enabled = settings.httpUpload.Enabled;
+				cumulus.HttpUploadAlarm.Sound = settings.httpUpload.SoundEnabled;
+				cumulus.HttpUploadAlarm.SoundFile = settings.httpUpload.Sound;
+				cumulus.HttpUploadAlarm.Notify = settings.httpUpload.Notify;
+				cumulus.HttpUploadAlarm.Email = settings.httpUpload.Email;
+				cumulus.HttpUploadAlarm.Latch = settings.httpUpload.Latches;
+				cumulus.HttpUploadAlarm.LatchHours = settings.httpUpload.LatchHrs;
+				cumulus.HttpUploadAlarm.TriggerThreshold = settings.httpUpload.Threshold;
 
-				cumulus.MySqlUploadAlarm.Enabled = settings.mySqlStoppedEnabled;
-				cumulus.MySqlUploadAlarm.Sound = settings.mySqlStoppedSoundEnabled;
-				cumulus.MySqlUploadAlarm.SoundFile = settings.mySqlStoppedSound;
-				cumulus.MySqlUploadAlarm.Notify = settings.mySqlStoppedNotify;
-				cumulus.MySqlUploadAlarm.Email = settings.mySqlStoppedEmail;
-				cumulus.MySqlUploadAlarm.Latch = settings.mySqlStoppedLatches;
-				cumulus.MySqlUploadAlarm.LatchHours = settings.mySqlStoppedLatchHrs;
+				cumulus.MySqlUploadAlarm.Enabled = settings.mySqlUpload.Enabled;
+				cumulus.MySqlUploadAlarm.Sound = settings.mySqlUpload.SoundEnabled;
+				cumulus.MySqlUploadAlarm.SoundFile = settings.mySqlUpload.Sound;
+				cumulus.MySqlUploadAlarm.Notify = settings.mySqlUpload.Notify;
+				cumulus.MySqlUploadAlarm.Email = settings.mySqlUpload.Email;
+				cumulus.MySqlUploadAlarm.Latch = settings.mySqlUpload.Latches;
+				cumulus.MySqlUploadAlarm.LatchHours = settings.mySqlUpload.LatchHrs;
+				cumulus.MySqlUploadAlarm.TriggerThreshold = settings.mySqlUpload.Threshold;
 
 				// validate the from email
 				if (!EmailSender.CheckEmailAddress(result.email.fromEmail.Trim()))
@@ -478,151 +519,36 @@ namespace CumulusMX
 
 	public class JsonAlarmSettingsData
 	{
-		public bool tempBelowEnabled { get; set; }
-		public double tempBelowVal { get; set; }
-		public bool tempBelowSoundEnabled { get; set; }
-		public string tempBelowSound { get; set; }
-		public bool tempBelowNotify { get; set; }
-		public bool tempBelowEmail { get; set; }
-		public bool tempBelowLatches { get; set; }
-		public int tempBelowLatchHrs { get; set; }
+		public JsonAlarmValues tempBelow { get; set; }
+		public JsonAlarmValues tempAbove { get; set; }
+		public JsonAlarmValues tempChange { get; set; }
+		public JsonAlarmValues pressBelow { get; set; }
+		public JsonAlarmValues pressAbove { get; set; }
+		public JsonAlarmValues pressChange { get; set; }
+		public JsonAlarmValues rainAbove { get; set; }
+		public JsonAlarmValues rainRateAbove { get; set; }
+		public JsonAlarmValues gustAbove { get; set; }
+		public JsonAlarmValues windAbove { get; set; }
+		public JsonAlarmValues contactLost { get; set; }
+		public JsonAlarmValues dataStopped { get; set; }
+		public JsonAlarmValues batteryLow { get; set; }
+		public JsonAlarmValues spike { get; set; }
+		public JsonAlarmValues upgrade { get; set; }
+		public JsonAlarmValues httpUpload { get; set; }
+		public JsonAlarmValues mySqlUpload { get; set; }
+	}
 
-		public bool tempAboveEnabled { get; set; }
-		public double tempAboveVal { get; set; }
-		public bool tempAboveSoundEnabled { get; set; }
-		public string tempAboveSound { get; set; }
-		public bool tempAboveNotify { get; set; }
-		public bool tempAboveEmail { get; set; }
-		public bool tempAboveLatches { get; set; }
-		public int tempAboveLatchHrs { get; set; }
-
-		public bool tempChangeEnabled { get; set; }
-		public double tempChangeVal { get; set; }
-		public bool tempChangeSoundEnabled { get; set; }
-		public string tempChangeSound { get; set; }
-		public bool tempChangeNotify { get; set; }
-		public bool tempChangeEmail { get; set; }
-		public bool tempChangeLatches { get; set; }
-		public int tempChangeLatchHrs { get; set; }
-
-		public bool pressBelowEnabled { get; set; }
-		public double pressBelowVal { get; set; }
-		public bool pressBelowSoundEnabled { get; set; }
-		public string pressBelowSound { get; set; }
-		public bool pressBelowNotify { get; set; }
-		public bool pressBelowEmail { get; set; }
-		public bool pressBelowLatches { get; set; }
-		public int pressBelowLatchHrs { get; set; }
-
-		public bool pressAboveEnabled { get; set; }
-		public double pressAboveVal { get; set; }
-		public bool pressAboveSoundEnabled { get; set; }
-		public string pressAboveSound { get; set; }
-		public bool pressAboveNotify { get; set; }
-		public bool pressAboveEmail { get; set; }
-		public bool pressAboveLatches { get; set; }
-		public int pressAboveLatchHrs { get; set; }
-
-		public bool pressChangeEnabled { get; set; }
-		public double pressChangeVal { get; set; }
-		public bool pressChangeSoundEnabled { get; set; }
-		public string pressChangeSound { get; set; }
-		public bool pressChangeNotify { get; set; }
-		public bool pressChangeEmail { get; set; }
-		public bool pressChangeLatches { get; set; }
-		public int pressChangeLatchHrs { get; set; }
-
-		public bool rainAboveEnabled { get; set; }
-		public double rainAboveVal { get; set; }
-		public bool rainAboveSoundEnabled { get; set; }
-		public string rainAboveSound { get; set; }
-		public bool rainAboveNotify { get; set; }
-		public bool rainAboveEmail { get; set; }
-		public bool rainAboveLatches { get; set; }
-		public int rainAboveLatchHrs { get; set; }
-
-		public bool rainRateAboveEnabled { get; set; }
-		public double rainRateAboveVal { get; set; }
-		public bool rainRateAboveSoundEnabled { get; set; }
-		public string rainRateAboveSound { get; set; }
-		public bool rainRateAboveNotify { get; set; }
-		public bool rainRateAboveEmail { get; set; }
-		public bool rainRateAboveLatches { get; set; }
-		public int rainRateAboveLatchHrs { get; set; }
-
-		public bool gustAboveEnabled { get; set; }
-		public double gustAboveVal { get; set; }
-		public bool gustAboveSoundEnabled { get; set; }
-		public string gustAboveSound { get; set; }
-		public bool gustAboveNotify { get; set; }
-		public bool gustAboveEmail { get; set; }
-		public bool gustAboveLatches { get; set; }
-		public int gustAboveLatchHrs { get; set; }
-
-		public bool windAboveEnabled { get; set; }
-		public double windAboveVal { get; set; }
-		public bool windAboveSoundEnabled { get; set; }
-		public string windAboveSound { get; set; }
-		public bool windAboveNotify { get; set; }
-		public bool windAboveEmail { get; set; }
-		public bool windAboveLatches { get; set; }
-		public int windAboveLatchHrs { get; set; }
-
-		public bool contactLostEnabled { get; set; }
-		public bool contactLostSoundEnabled { get; set; }
-		public string contactLostSound { get; set; }
-		public bool contactLostNotify { get; set; }
-		public bool contactLostEmail { get; set; }
-		public bool contactLostLatches { get; set; }
-		public int contactLostLatchHrs { get; set; }
-
-		public bool dataStoppedEnabled { get; set; }
-		public bool dataStoppedSoundEnabled { get; set; }
-		public string dataStoppedSound { get; set; }
-		public bool dataStoppedNotify { get; set; }
-		public bool dataStoppedEmail { get; set; }
-		public bool dataStoppedLatches { get; set; }
-		public int dataStoppedLatchHrs { get; set; }
-
-		public bool batteryLowEnabled { get; set; }
-		public bool batteryLowSoundEnabled { get; set; }
-		public string batteryLowSound { get; set; }
-		public bool batteryLowNotify { get; set; }
-		public bool batteryLowEmail { get; set; }
-		public bool batteryLowLatches { get; set; }
-		public int batteryLowLatchHrs { get; set; }
-
-		public bool spikeEnabled { get; set; }
-		public bool spikeSoundEnabled { get; set; }
-		public string spikeSound { get; set; }
-		public bool spikeNotify { get; set; }
-		public bool spikeEmail { get; set; }
-		public bool spikeLatches { get; set; }
-		public int spikeLatchHrs { get; set; }
-
-		public bool upgradeEnabled { get; set; }
-		public bool upgradeSoundEnabled { get; set; }
-		public string upgradeSound { get; set; }
-		public bool upgradeNotify { get; set; }
-		public bool upgradeEmail { get; set; }
-		public bool upgradeLatches { get; set; }
-		public int upgradeLatchHrs { get; set; }
-
-		public bool httpStoppedEnabled { get; set; }
-		public bool httpStoppedSoundEnabled { get; set; }
-		public string httpStoppedSound { get; set; }
-		public bool httpStoppedNotify { get; set; }
-		public bool httpStoppedEmail { get; set; }
-		public bool httpStoppedLatches { get; set; }
-		public int httpStoppedLatchHrs { get; set; }
-
-		public bool mySqlStoppedEnabled { get; set; }
-		public bool mySqlStoppedSoundEnabled { get; set; }
-		public string mySqlStoppedSound { get; set; }
-		public bool mySqlStoppedNotify { get; set; }
-		public bool mySqlStoppedEmail { get; set; }
-		public bool mySqlStoppedLatches { get; set; }
-		public int mySqlStoppedLatchHrs { get; set; }
+	public class JsonAlarmValues
+	{
+		public bool Enabled { get; set; }
+		public double Val { get; set; }
+		public bool SoundEnabled { get; set; }
+		public string Sound { get; set; }
+		public bool Notify { get; set; }
+		public bool Email { get; set; }
+		public bool Latches { get; set; }
+		public int LatchHrs { get; set; }
+		public int Threshold { get; set; }
 	}
 
 	public class JsonAlarmEmail

--- a/CumulusMX/AlarmSettings.cs
+++ b/CumulusMX/AlarmSettings.cs
@@ -157,7 +157,23 @@ namespace CumulusMX
 				upgradeNotify = cumulus.UpgradeAlarm.Notify,
 				upgradeEmail = cumulus.UpgradeAlarm.Email,
 				upgradeLatches = cumulus.UpgradeAlarm.Latch,
-				upgradeLatchHrs = cumulus.UpgradeAlarm.LatchHours
+				upgradeLatchHrs = cumulus.UpgradeAlarm.LatchHours,
+
+				httpStoppedEnabled = cumulus.HttpUploadAlarm.Enabled,
+				httpStoppedSoundEnabled = cumulus.HttpUploadAlarm.Sound,
+				httpStoppedSound = cumulus.HttpUploadAlarm.SoundFile,
+				httpStoppedNotify = cumulus.HttpUploadAlarm.Notify,
+				httpStoppedEmail = cumulus.HttpUploadAlarm.Email,
+				httpStoppedLatches = cumulus.HttpUploadAlarm.Latch,
+				httpStoppedLatchHrs = cumulus.HttpUploadAlarm.LatchHours,
+
+				mySqlStoppedEnabled = cumulus.MySqlUploadAlarm.Enabled,
+				mySqlStoppedSoundEnabled = cumulus.MySqlUploadAlarm.Sound,
+				mySqlStoppedSound = cumulus.MySqlUploadAlarm.SoundFile,
+				mySqlStoppedNotify = cumulus.MySqlUploadAlarm.Notify,
+				mySqlStoppedEmail = cumulus.MySqlUploadAlarm.Email,
+				mySqlStoppedLatches = cumulus.MySqlUploadAlarm.Latch,
+				mySqlStoppedLatchHrs = cumulus.MySqlUploadAlarm.LatchHours
 			};
 
 			var email = new JsonAlarmEmail()
@@ -341,6 +357,22 @@ namespace CumulusMX
 				cumulus.UpgradeAlarm.Email = settings.upgradeEmail;
 				cumulus.UpgradeAlarm.Latch = settings.upgradeLatches;
 				cumulus.UpgradeAlarm.LatchHours = settings.upgradeLatchHrs;
+
+				cumulus.HttpUploadAlarm.Enabled = settings.httpStoppedEnabled;
+				cumulus.HttpUploadAlarm.Sound = settings.httpStoppedSoundEnabled;
+				cumulus.HttpUploadAlarm.SoundFile = settings.httpStoppedSound;
+				cumulus.HttpUploadAlarm.Notify = settings.httpStoppedNotify;
+				cumulus.HttpUploadAlarm.Email = settings.httpStoppedEmail;
+				cumulus.HttpUploadAlarm.Latch = settings.httpStoppedLatches;
+				cumulus.HttpUploadAlarm.LatchHours = settings.httpStoppedLatchHrs;
+
+				cumulus.MySqlUploadAlarm.Enabled = settings.mySqlStoppedEnabled;
+				cumulus.MySqlUploadAlarm.Sound = settings.mySqlStoppedSoundEnabled;
+				cumulus.MySqlUploadAlarm.SoundFile = settings.mySqlStoppedSound;
+				cumulus.MySqlUploadAlarm.Notify = settings.mySqlStoppedNotify;
+				cumulus.MySqlUploadAlarm.Email = settings.mySqlStoppedEmail;
+				cumulus.MySqlUploadAlarm.Latch = settings.mySqlStoppedLatches;
+				cumulus.MySqlUploadAlarm.LatchHours = settings.mySqlStoppedLatchHrs;
 
 				// validate the from email
 				if (!EmailSender.CheckEmailAddress(result.email.fromEmail.Trim()))
@@ -575,6 +607,22 @@ namespace CumulusMX
 		public bool upgradeEmail { get; set; }
 		public bool upgradeLatches { get; set; }
 		public int upgradeLatchHrs { get; set; }
+
+		public bool httpStoppedEnabled { get; set; }
+		public bool httpStoppedSoundEnabled { get; set; }
+		public string httpStoppedSound { get; set; }
+		public bool httpStoppedNotify { get; set; }
+		public bool httpStoppedEmail { get; set; }
+		public bool httpStoppedLatches { get; set; }
+		public int httpStoppedLatchHrs { get; set; }
+
+		public bool mySqlStoppedEnabled { get; set; }
+		public bool mySqlStoppedSoundEnabled { get; set; }
+		public string mySqlStoppedSound { get; set; }
+		public bool mySqlStoppedNotify { get; set; }
+		public bool mySqlStoppedEmail { get; set; }
+		public bool mySqlStoppedLatches { get; set; }
+		public int mySqlStoppedLatchHrs { get; set; }
 	}
 
 	public class JsonAlarmEmail

--- a/CumulusMX/AlarmSettings.cs
+++ b/CumulusMX/AlarmSettings.cs
@@ -429,6 +429,7 @@ namespace CumulusMX
 				}
 				else
 				{
+					context.Response.StatusCode = 500;
 					return ret;
 				}
 			}

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -941,7 +941,7 @@ namespace CumulusMX
 						case "ftpnow.json":
 							return await this.JsonResponseAsync(stationSettings.FtpNow(this));
 						case "testemail.json":
-							return await this.JsonResponseAsync(alarmSettings.TestEmail(this));
+							return await this.StringResponseAsync(alarmSettings.TestEmail(this));
 					}
 
 					throw new KeyNotFoundException("Key Not Found: " + lastSegment);

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1716,6 +1716,59 @@ namespace CumulusMX
 			}
 		}
 
+		// If the temperature units are changed, reset NOAA thresholds to defaults
+		internal void ChangeTempUnits()
+		{
+			SetupUnitText();
+
+			NOAAheatingthreshold = Units.Temp == 0 ? 18.3 : 65;
+			NOAAcoolingthreshold = Units.Temp == 0 ? 18.3 : 65;
+			NOAAmaxtempcomp1 = Units.Temp == 0 ? 27 : 80;
+			NOAAmaxtempcomp2 = Units.Temp == 0 ? 0 : 32;
+			NOAAmintempcomp1 = Units.Temp == 0 ? 0 : 32;
+			NOAAmintempcomp2 = Units.Temp == 0 ? -18 : 0;
+
+			ChillHourThreshold = Units.Temp == 0 ? 7 : 45;
+
+			GrowingBase1 = Units.Temp == 0 ? 5.0 : 40.0;
+			GrowingBase2 = Units.Temp == 0 ? 10.0 : 50.0;
+
+			TempChangeAlarm.Units = Units.TempTrendText;
+			HighTempAlarm.Units = Units.TempText;
+			LowTempAlarm.Units = Units.TempText;
+		}
+
+		internal void ChangeRainUnits()
+		{
+			SetupUnitText();
+
+			NOAAraincomp1 = Units.Rain == 0 ? 0.2 : 0.01;
+			NOAAraincomp2 = Units.Rain == 0 ? 2 : 0.1;
+			NOAAraincomp3 = Units.Rain == 0 ? 20 : 1;
+
+			HighRainRateAlarm.Units = Units.RainTrendText;
+			HighRainTodayAlarm.Units = Units.RainText;
+		}
+
+		internal void ChangePressureUnits()
+		{
+			SetupUnitText();
+
+			FCPressureThreshold = Units.Press == 2 ? 0.00295333727 : 0.1;
+
+			PressChangeAlarm.Units = Units.PressTrendText;
+			HighPressAlarm.Units = Units.PressText;
+			LowPressAlarm.Units = Units.PressText;
+		}
+
+		internal void ChangeWindUnits()
+		{
+			SetupUnitText();
+
+			HighWindAlarm.Units = Units.WindText;
+			HighGustAlarm.Units = Units.WindText;
+		}
+
 		public void SetFtpLogging(bool isSet)
 		{
 			try

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3505,17 +3505,16 @@ namespace CumulusMX
 			ProgramOptions.StartupDelaySecs = ini.GetValue("Program", "StartupDelaySecs", 0);
 			ProgramOptions.StartupDelayMaxUptime = ini.GetValue("Program", "StartupDelayMaxUptime", 300);
 			ProgramOptions.WarnMultiple = ini.GetValue("Station", "WarnMultiple", true);
+			SmtpOptions.Logging = ini.GetValue("SMTP", "Logging", false);
 			if (DebuggingEnabled)
 			{
 				ProgramOptions.DebugLogging = true;
 				ProgramOptions.DataLogging = true;
-				SmtpOptions.Logging = true;
 			}
 			else
 			{
 				ProgramOptions.DebugLogging = ini.GetValue("Station", "Logging", false);
 				ProgramOptions.DataLogging = ini.GetValue("Station", "DataLogging", false);
-				SmtpOptions.Logging = ini.GetValue("SMTP", "Logging", false);
 			}
 
 			ComportName = ini.GetValue("Station", "ComportName", DefaultComportName);
@@ -4559,8 +4558,8 @@ namespace CumulusMX
 
 			ini.SetValue("Program", "StartupDelaySecs", ProgramOptions.StartupDelaySecs);
 			ini.SetValue("Program", "StartupDelayMaxUptime", ProgramOptions.StartupDelayMaxUptime);
-			ini.SetValue("Station", "WarnMultiple", ProgramOptions.WarnMultiple);
 
+			ini.SetValue("Station", "WarnMultiple", ProgramOptions.WarnMultiple);
 
 			ini.SetValue("Station", "Type", StationType);
 			ini.SetValue("Station", "Model", StationModel);
@@ -4577,6 +4576,9 @@ namespace CumulusMX
 			ini.SetValue("Station", "AvgBearingMinutes", StationOptions.AvgBearingMinutes);
 			ini.SetValue("Station", "AvgSpeedMinutes", StationOptions.AvgSpeedMinutes);
 			ini.SetValue("Station", "PeakGustMinutes", StationOptions.PeakGustMinutes);
+
+			ini.SetValue("Station", "Logging", ProgramOptions.DebugLogging);
+			ini.SetValue("Station", "DataLogging", ProgramOptions.DataLogging);
 
 			ini.SetValue("Station", "DavisReadReceptionStats", DavisOptions.ReadReceptionStats);
 			ini.SetValue("Station", "DavisSetLoggerInterval", DavisOptions.SetLoggerInterval);
@@ -5246,6 +5248,7 @@ namespace CumulusMX
 			ini.SetValue("SMTP", "RequiresAuthentication", SmtpOptions.RequiresAuthentication);
 			ini.SetValue("SMTP", "User", SmtpOptions.User);
 			ini.SetValue("SMTP", "Password", SmtpOptions.Password);
+			ini.SetValue("SMTP", "Logging", SmtpOptions.Logging);
 
 			// Growing Degree Days
 			ini.SetValue("GrowingDD", "BaseTemperature1", GrowingBase1);

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -714,6 +714,9 @@ namespace CumulusMX
 		public bool MonthlyMySqlEnabled;
 		public bool DayfileMySqlEnabled;
 
+		public bool RealtimeMySql1MinLimit;
+		private int RealtimeMySqlLastMinute = -1;
+
 		public string MySqlMonthlyTable;
 		public string MySqlDayfileTable;
 		public string MySqlRealtimeTable;
@@ -1175,6 +1178,7 @@ namespace CumulusMX
 			LogMessage("Debug logging is " + (ProgramOptions.DebugLogging ? "enabled" : "disabled"));
 			LogMessage("Data logging is " + (ProgramOptions.DataLogging ? "enabled" : "disabled"));
 			LogMessage("FTP logging is " + (FTPlogging ? "enabled" : "disabled"));
+			LogMessage("Email logging is " + (SmtpOptions.Logging ? "enabled" : "disabled"));
 			LogMessage("Spike logging is " + (ErrorLogSpikeRemoval ? "enabled" : "disabled"));
 			LogMessage("Logging interval = " + logints[DataLogInterval] + " mins");
 			LogMessage("Real time interval = " + RealtimeInterval / 1000 + " secs");
@@ -2038,6 +2042,7 @@ namespace CumulusMX
 				catch (Exception ex)
 				{
 					LogMessage($"UpdateTwitter: {ex.Message}");
+					HttpUploadAlarm.LastError = "Twitter: " + ex.Message;
 					HttpUploadAlarm.Triggered = true;
 				}
 				//if (tweet != null)
@@ -2106,7 +2111,8 @@ namespace CumulusMX
 				var responseBodyAsText = await response.Content.ReadAsStringAsync();
 				if (!Wund.RapidFireEnabled || response.StatusCode != HttpStatusCode.OK)
 				{
-					LogDebugMessage("Wunderground: Response = " + response.StatusCode + ": " + responseBodyAsText);
+					LogMessage("Wunderground: Response = " + response.StatusCode + ": " + responseBodyAsText);
+					HttpUploadAlarm.LastError = "Wunderground: HTTP response - " + response.StatusCode;
 					HttpUploadAlarm.Triggered = true;
 				}
 				else
@@ -2117,6 +2123,7 @@ namespace CumulusMX
 			catch (Exception ex)
 			{
 				LogMessage("Wunderground: ERROR - " + ex.Message);
+				HttpUploadAlarm.LastError = "Wunderground: " + ex.Message;
 				HttpUploadAlarm.Triggered = true;
 			}
 			finally
@@ -2148,6 +2155,8 @@ namespace CumulusMX
 				LogDebugMessage("Windy: Response = " + response.StatusCode + ": " + responseBodyAsText);
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
+					LogMessage("Windy: ERROR - Response = " + response.StatusCode + ": " + responseBodyAsText);
+					HttpUploadAlarm.LastError = "Windy: HTTP response - " + response.StatusCode;
 					HttpUploadAlarm.Triggered = true;
 				}
 				else
@@ -2158,6 +2167,7 @@ namespace CumulusMX
 			catch (Exception ex)
 			{
 				LogMessage("Windy: ERROR - " + ex.Message);
+				HttpUploadAlarm.LastError = "Windy: " + ex.Message;
 				HttpUploadAlarm.Triggered = true;
 			}
 			finally
@@ -2189,6 +2199,8 @@ namespace CumulusMX
 				LogDebugMessage("WindGuru: " + response.StatusCode + ": " + responseBodyAsText);
 				if (response.StatusCode != HttpStatusCode.OK)
 				{
+					LogMessage("WindGuru: ERROR - " + response.StatusCode + ": " + responseBodyAsText);
+					HttpUploadAlarm.LastError = "WindGuru: HTTP response - " + response.StatusCode;
 					HttpUploadAlarm.Triggered = true;
 				}
 				else
@@ -2198,7 +2210,8 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				LogDebugMessage("WindGuru: ERROR - " + ex.Message);
+				LogMessage("WindGuru: ERROR - " + ex.Message);
+				HttpUploadAlarm.LastError = "WindGuru: " + ex.Message;
 				HttpUploadAlarm.Triggered = true;
 			}
 			finally
@@ -2237,6 +2250,8 @@ namespace CumulusMX
 
 					if (response.StatusCode != HttpStatusCode.OK)
 					{
+						LogMessage($"AWEKAS: ERROR - Response code = {response.StatusCode}, body = {responseBodyAsText}");
+						HttpUploadAlarm.LastError = $"AWEKAS: HTTP Response code = {response.StatusCode}, body = {responseBodyAsText}";
 						HttpUploadAlarm.Triggered = true;
 					}
 					else
@@ -2298,6 +2313,7 @@ namespace CumulusMX
 						else
 						{
 							LogMessage("AWEKAS: Unknown error");
+							HttpUploadAlarm.LastError = "AWEKAS: Unknown error";
 							HttpUploadAlarm.Triggered = true;
 						}
 					}
@@ -2332,6 +2348,7 @@ namespace CumulusMX
 			catch (Exception ex)
 			{
 				LogMessage("AWEKAS: Exception = " + ex.Message);
+				HttpUploadAlarm.LastError = "AWEKAS: " + ex.Message;
 				HttpUploadAlarm.Triggered = true;
 			}
 			finally
@@ -2371,31 +2388,40 @@ namespace CumulusMX
 						HttpUploadAlarm.Triggered = false;
 						break;
 					case 400:
-						msg = "Bad reuest";
+						msg = "Bad request";
+						HttpUploadAlarm.LastError = "WeatherCloud: " + msg;
 						HttpUploadAlarm.Triggered = true;
 						break;
 					case 401:
 						msg = "Incorrect WID or Key";
+						HttpUploadAlarm.LastError = "WeatherCloud: " + msg;
 						HttpUploadAlarm.Triggered = true;
 						break;
 					case 429:
 						msg = "Too many requests";
+						HttpUploadAlarm.LastError = "WeatherCloud: " + msg;
 						HttpUploadAlarm.Triggered = true;
 						break;
 					case 500:
 						msg = "Server error";
+						HttpUploadAlarm.LastError = "WeatherCloud: " + msg;
 						HttpUploadAlarm.Triggered = true;
 						break;
 					default:
 						msg = "Unknown error";
+						HttpUploadAlarm.LastError = "WeatherCloud: " + msg;
 						HttpUploadAlarm.Triggered = true;
 						break;
 				}
-				LogDebugMessage($"WeatherCloud: Response = {msg} ({response.StatusCode}): {responseBodyAsText}");
+				if ((int)response.StatusCode == 200)
+					LogDebugMessage($"WeatherCloud: Response = {msg} ({response.StatusCode}): {responseBodyAsText}");
+				else
+					LogMessage($"WeatherCloud: ERROR - Response = {msg} ({response.StatusCode}): {responseBodyAsText}");
 			}
 			catch (Exception ex)
 			{
-				LogDebugMessage("WeatherCloud: ERROR - " + ex.Message);
+				LogMessage("WeatherCloud: ERROR - " + ex.Message);
+				HttpUploadAlarm.LastError = "WeatherCloud: " + ex.Message;
 				HttpUploadAlarm.Triggered = true;
 			}
 			finally
@@ -2433,7 +2459,8 @@ namespace CumulusMX
 					LogDebugMessage($"OpenWeatherMap: Response code = {status} - {response.StatusCode}");
 					if (response.StatusCode != HttpStatusCode.NoContent)
 					{
-						LogDataMessage($"OpenWeatherMap: Response data = {responseBodyAsText}");
+						LogMessage($"OpenWeatherMap: ERROR - Response code = {response.StatusCode}, Response data = {responseBodyAsText}");
+						HttpUploadAlarm.LastError = $"OpenWeatherMap: HTTP response - {response.StatusCode}, Response data = {responseBodyAsText}";
 						HttpUploadAlarm.Triggered = true;
 					}
 					else
@@ -2445,6 +2472,7 @@ namespace CumulusMX
 			catch (Exception ex)
 			{
 				LogMessage("OpenWeatherMap: ERROR - " + ex.Message);
+				HttpUploadAlarm.LastError = "OpenWeatherMap: " + ex.Message;
 				HttpUploadAlarm.Triggered = true;
 			}
 			finally
@@ -2594,6 +2622,8 @@ namespace CumulusMX
 					CreateRealtimeFile(cycle);
 					CreateRealtimeHTMLfiles(cycle);
 					RealtimeCopyInProgress = false;
+
+					MySqlRealtimeFile(cycle);
 
 					if (RealtimeFTPEnabled && !string.IsNullOrWhiteSpace(FtpHostname))
 					{
@@ -2808,33 +2838,11 @@ namespace CumulusMX
 
 				if ((uploadfile.Length > 0) && (remotefile.Length > 0) && ExtraFiles[i].realtime && ExtraFiles[i].FTP)
 				{
-					if (uploadfile == "<currentlogfile>")
-					{
-						uploadfile = GetLogFileName(DateTime.Now);
-					}
-					else if (uploadfile == "<currentextralogfile>")
-					{
-						uploadfile = GetExtraLogFileName(DateTime.Now);
-					}
-					else if (uploadfile == "<airlinklogfile")
-					{
-						uploadfile = GetAirLinkLogFileName(DateTime.Now);
-					}
+					uploadfile = GetUploadFilename(uploadfile, DateTime.Now);
 
 					if (File.Exists(uploadfile))
 					{
-						if (remotefile.Contains("<currentlogfile>"))
-						{
-							remotefile = remotefile.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(DateTime.Now)));
-						}
-						else if (remotefile.Contains("<currentextralogfile>"))
-						{
-							remotefile = remotefile.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(DateTime.Now)));
-						}
-						else if (remotefile.Contains("<airlinklogfile"))
-						{
-							remotefile = remotefile.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(DateTime.Now)));
-						}
+						remotefile = GetRemoteFileName(remotefile, DateTime.Now);
 
 						// all checks OK, file needs to be uploaded
 						if (ExtraFiles[i].process)
@@ -2882,33 +2890,11 @@ namespace CumulusMX
 
 					if ((uploadfile.Length > 0) && (remotefile.Length > 0))
 					{
-						if (uploadfile == "<currentlogfile>")
-						{
-							uploadfile = GetLogFileName(DateTime.Now);
-						}
-						else if (uploadfile == "<currentextralogfile>")
-						{
-							uploadfile = GetExtraLogFileName(DateTime.Now);
-						}
-						else if (uploadfile == "<airlinklogfile")
-						{
-							uploadfile = GetAirLinkLogFileName(DateTime.Now);
-						}
+						uploadfile = GetUploadFilename(uploadfile, DateTime.Now);
 
 						if (File.Exists(uploadfile))
 						{
-							if (remotefile.Contains("<currentlogfile>"))
-							{
-								remotefile = remotefile.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(DateTime.Now)));
-							}
-							else if (remotefile.Contains("<currentextralogfile>"))
-							{
-								remotefile = remotefile.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(DateTime.Now)));
-							}
-							else if (remotefile.Contains("<airlinklogfile"))
-							{
-								remotefile = remotefile.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(DateTime.Now)));
-							}
+							remotefile = GetRemoteFileName(remotefile, DateTime.Now);
 
 							if (ExtraFiles[i].process)
 							{
@@ -4407,10 +4393,12 @@ namespace CumulusMX
 			SpikeAlarm.Enabled = ini.GetValue("Alarms", "DataSpikeAlarmSet", false);
 			SpikeAlarm.Sound = ini.GetValue("Alarms", "DataSpikeAlarmSound", false);
 			SpikeAlarm.SoundFile = ini.GetValue("Alarms", "DataSpikeAlarmSoundFile", DefaultSoundFile);
-			SpikeAlarm.Notify = ini.GetValue("Alarms", "SpikeAlarmNotify", true);
-			SpikeAlarm.Email = ini.GetValue("Alarms", "SpikeAlarmEmail", true);
-			SpikeAlarm.Latch = ini.GetValue("Alarms", "SpikeAlarmLatch", true);
-			SpikeAlarm.LatchHours = ini.GetValue("Alarms", "SpikeAlarmLatchHours", 24);
+			SpikeAlarm.Notify = ini.GetValue("Alarms", "DataSpikeAlarmNotify", true);
+			SpikeAlarm.Email = ini.GetValue("Alarms", "DataSpikeAlarmEmail", true);
+			SpikeAlarm.Latch = ini.GetValue("Alarms", "DataSpikeAlarmLatch", true);
+			SpikeAlarm.LatchHours = ini.GetValue("Alarms", "DataSpikeAlarmLatchHours", 24);
+			SpikeAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataSpikeAlarmTriggerCount", 1);
+
 
 			UpgradeAlarm.Enabled = ini.GetValue("Alarms", "UpgradeAlarmSet", true);
 			UpgradeAlarm.Sound = ini.GetValue("Alarms", "UpgradeAlarmSound", true);
@@ -4420,21 +4408,23 @@ namespace CumulusMX
 			UpgradeAlarm.Latch = ini.GetValue("Alarms", "UpgradeAlarmLatch", false);
 			UpgradeAlarm.LatchHours = ini.GetValue("Alarms", "UpgradeAlarmLatchHours", 24);
 
-			HttpUploadAlarm.Enabled = ini.GetValue("Alarms", "HttpUploadStoppedAlarmSet", false);
-			HttpUploadAlarm.Sound = ini.GetValue("Alarms", "HttpUploadStoppedAlarmSound", false);
-			HttpUploadAlarm.SoundFile = ini.GetValue("Alarms", "HttpUploadStoppedAlarmSoundFile", DefaultSoundFile);
-			HttpUploadAlarm.Notify = ini.GetValue("Alarms", "HttpUploadStoppedAlarmNotify", false);
-			HttpUploadAlarm.Email = ini.GetValue("Alarms", "HttpUploadStoppedAlarmEmail", false);
-			HttpUploadAlarm.Latch = ini.GetValue("Alarms", "HttpUploadStoppedAlarmLatch", false);
-			HttpUploadAlarm.LatchHours = ini.GetValue("Alarms", "HttpUploadStoppedAlarmLatchHours", 24);
+			HttpUploadAlarm.Enabled = ini.GetValue("Alarms", "HttpUploadAlarmSet", false);
+			HttpUploadAlarm.Sound = ini.GetValue("Alarms", "HttpUploadAlarmSound", false);
+			HttpUploadAlarm.SoundFile = ini.GetValue("Alarms", "HttpUploadAlarmSoundFile", DefaultSoundFile);
+			HttpUploadAlarm.Notify = ini.GetValue("Alarms", "HttpUploadAlarmNotify", false);
+			HttpUploadAlarm.Email = ini.GetValue("Alarms", "HttpUploadAlarmEmail", false);
+			HttpUploadAlarm.Latch = ini.GetValue("Alarms", "HttpUploadAlarmLatch", false);
+			HttpUploadAlarm.LatchHours = ini.GetValue("Alarms", "HttpUploadAlarmLatchHours", 24);
+			HttpUploadAlarm.TriggerThreshold = ini.GetValue("Alarms", "HttpUploadAlarmTriggerCount", 1);
 
-			MySqlUploadAlarm.Enabled = ini.GetValue("Alarms", "HttpUploadStoppedAlarmSet", false);
-			MySqlUploadAlarm.Sound = ini.GetValue("Alarms", "HttpUploadStoppedAlarmSound", false);
-			MySqlUploadAlarm.SoundFile = ini.GetValue("Alarms", "HttpUploadStoppedAlarmSoundFile", DefaultSoundFile);
-			MySqlUploadAlarm.Notify = ini.GetValue("Alarms", "HttpUploadStoppedAlarmNotify", false);
-			MySqlUploadAlarm.Email = ini.GetValue("Alarms", "HttpUploadStoppedAlarmEmail", false);
-			MySqlUploadAlarm.Latch = ini.GetValue("Alarms", "HttpUploadStoppedAlarmLatch", false);
-			MySqlUploadAlarm.LatchHours = ini.GetValue("Alarms", "HttpUploadStoppedAlarmLatchHours", 24);
+			MySqlUploadAlarm.Enabled = ini.GetValue("Alarms", "MySqlUploadAlarmSet", false);
+			MySqlUploadAlarm.Sound = ini.GetValue("Alarms", "MySqlUploadAlarmSound", false);
+			MySqlUploadAlarm.SoundFile = ini.GetValue("Alarms", "MySqlUploadAlarmSoundFile", DefaultSoundFile);
+			MySqlUploadAlarm.Notify = ini.GetValue("Alarms", "MySqlUploadAlarmNotify", false);
+			MySqlUploadAlarm.Email = ini.GetValue("Alarms", "MySqlUploadAlarmEmail", false);
+			MySqlUploadAlarm.Latch = ini.GetValue("Alarms", "MySqlUploadAlarmLatch", false);
+			MySqlUploadAlarm.LatchHours = ini.GetValue("Alarms", "MySqlUploadAlarmLatchHours", 24);
+			MySqlUploadAlarm.TriggerThreshold = ini.GetValue("Alarms", "MySqlUploadAlarmTriggerCount", 1);
 
 
 			AlarmFromEmail = ini.GetValue("Alarms", "FromEmail", "");
@@ -4597,6 +4587,7 @@ namespace CumulusMX
 			RealtimeMySqlEnabled = ini.GetValue("MySQL", "RealtimeMySqlEnabled", false);
 			MySqlRealtimeTable = ini.GetValue("MySQL", "RealtimeTable", "Realtime");
 			MySqlRealtimeRetention = ini.GetValue("MySQL", "RealtimeRetention", "");
+			RealtimeMySql1MinLimit = ini.GetValue("MySQL", "RealtimeMySql1MinLimit", false);
 			// MySQL - dayfile
 			DayfileMySqlEnabled = ini.GetValue("MySQL", "DayfileMySqlEnabled", false);
 			MySqlDayfileTable = ini.GetValue("MySQL", "DayfileTable", "Dayfile");
@@ -5201,21 +5192,21 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "UpgradeAlarmLatch", UpgradeAlarm.Latch);
 			ini.SetValue("Alarms", "UpgradeAlarmLatchHours", UpgradeAlarm.LatchHours);
 
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmSet", HttpUploadAlarm.Enabled);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmSound", HttpUploadAlarm.Sound);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmSoundFile", HttpUploadAlarm.SoundFile);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmNotify", HttpUploadAlarm.Notify);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmEmail", HttpUploadAlarm.Email);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmLatch", HttpUploadAlarm.Latch);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmLatchHours", HttpUploadAlarm.LatchHours);
+			ini.SetValue("Alarms", "HttpUploadAlarmSet", HttpUploadAlarm.Enabled);
+			ini.SetValue("Alarms", "HttpUploadAlarmSound", HttpUploadAlarm.Sound);
+			ini.SetValue("Alarms", "HttpUploadAlarmSoundFile", HttpUploadAlarm.SoundFile);
+			ini.SetValue("Alarms", "HttpUploadAlarmNotify", HttpUploadAlarm.Notify);
+			ini.SetValue("Alarms", "HttpUploadAlarmEmail", HttpUploadAlarm.Email);
+			ini.SetValue("Alarms", "HttpUploadAlarmLatch", HttpUploadAlarm.Latch);
+			ini.SetValue("Alarms", "HttpUploadAlarmLatchHours", HttpUploadAlarm.LatchHours);
 
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmSet", MySqlUploadAlarm.Enabled);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmSound", MySqlUploadAlarm.Sound);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmSoundFile", MySqlUploadAlarm.SoundFile);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmNotify", MySqlUploadAlarm.Notify);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmEmail", MySqlUploadAlarm.Email);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmLatch", MySqlUploadAlarm.Latch);
-			ini.SetValue("Alarms", "HttpUploadStoppedAlarmLatchHours", MySqlUploadAlarm.LatchHours);
+			ini.SetValue("Alarms", "MySqlUploadAlarmSet", MySqlUploadAlarm.Enabled);
+			ini.SetValue("Alarms", "MySqlUploadAlarmSound", MySqlUploadAlarm.Sound);
+			ini.SetValue("Alarms", "MySqlUploadAlarmSoundFile", MySqlUploadAlarm.SoundFile);
+			ini.SetValue("Alarms", "MySqlUploadAlarmNotify", MySqlUploadAlarm.Notify);
+			ini.SetValue("Alarms", "MySqlUploadAlarmEmail", MySqlUploadAlarm.Email);
+			ini.SetValue("Alarms", "MySqlUploadAlarmLatch", MySqlUploadAlarm.Latch);
+			ini.SetValue("Alarms", "MySqlUploadAlarmLatchHours", MySqlUploadAlarm.LatchHours);
 
 			ini.SetValue("Alarms", "FromEmail", AlarmFromEmail);
 			ini.SetValue("Alarms", "DestEmail", AlarmDestEmail.Join(";"));
@@ -5352,6 +5343,7 @@ namespace CumulusMX
 			ini.SetValue("MySQL", "Database", MySqlConnSettings.Database);
 			ini.SetValue("MySQL", "MonthlyMySqlEnabled", MonthlyMySqlEnabled);
 			ini.SetValue("MySQL", "RealtimeMySqlEnabled", RealtimeMySqlEnabled);
+			ini.SetValue("MySQL", "RealtimeMySql1MinLimit", RealtimeMySql1MinLimit);
 			ini.SetValue("MySQL", "DayfileMySqlEnabled", DayfileMySqlEnabled);
 			ini.SetValue("MySQL", "MonthlyTable", MySqlMonthlyTable);
 			ini.SetValue("MySQL", "DayfileTable", MySqlDayfileTable);
@@ -7257,6 +7249,7 @@ namespace CumulusMX
 				if (!RealtimeEnabled)
 				{
 					CreateRealtimeFile(999);
+					MySqlRealtimeFile(999);
 				}
 
 				LogDebugMessage("Creating standard web files");
@@ -7285,33 +7278,11 @@ namespace CumulusMX
 
 						if ((uploadfile.Length > 0) && (remotefile.Length > 0))
 						{
-							if (uploadfile == "<currentlogfile>")
-							{
-								uploadfile = GetLogFileName(DateTime.Now);
-							}
-							else if (uploadfile == "<currentextralogfile>")
-							{
-								uploadfile = GetExtraLogFileName(DateTime.Now);
-							}
-							else if (uploadfile == "<airlinklogfile")
-							{
-								uploadfile = GetAirLinkLogFileName(DateTime.Now);
-							}
+							uploadfile = GetUploadFilename(uploadfile, DateTime.Now);
 
 							if (File.Exists(uploadfile))
 							{
-								if (remotefile.Contains("<currentlogfile>"))
-								{
-									remotefile = remotefile.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(DateTime.Now)));
-								}
-								else if (remotefile.Contains("<currentextralogfile>"))
-								{
-									remotefile = remotefile.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(DateTime.Now)));
-								}
-								else if (remotefile.Contains("<airlinklogfile"))
-								{
-									remotefile = remotefile.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(DateTime.Now)));
-								}
+								remotefile = GetRemoteFileName(remotefile, DateTime.Now);
 
 								if (ExtraFiles[i].process)
 								{
@@ -7483,33 +7454,11 @@ namespace CumulusMX
 								// For EOD files, we want the previous days log files since it is now just past the day rollover time. Makes a difference on month rollover
 								var logDay = ExtraFiles[i].endofday ? DateTime.Now.AddDays(-1) : DateTime.Now;
 
-								if (uploadfile == "<currentlogfile>")
-								{
-									uploadfile = GetLogFileName(logDay);
-								}
-								else if (uploadfile == "<currentextralogfile>")
-								{
-									uploadfile = GetExtraLogFileName(logDay);
-								}
-								else if (uploadfile == "<airlinklogfile")
-								{
-									uploadfile = GetAirLinkLogFileName(logDay);
-								}
+								uploadfile = GetUploadFilename(uploadfile, logDay);
 
 								if (File.Exists(uploadfile))
 								{
-									if (remotefile.Contains("<currentlogfile>"))
-									{
-										remotefile = remotefile.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(logDay)));
-									}
-									else if (remotefile.Contains("<currentextralogfile>"))
-									{
-										remotefile = remotefile.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(logDay)));
-									}
-									else if (remotefile.Contains("<airlinklogfile"))
-									{
-										remotefile = remotefile.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(logDay)));
-									}
+									remotefile = GetRemoteFileName(remotefile, logDay);
 
 									// all checks OK, file needs to be uploaded
 									if (ExtraFiles[i].process)
@@ -7721,33 +7670,11 @@ namespace CumulusMX
 								// For EOD files, we want the previous days log files since it is now just past the day rollover time. Makes a difference on month rollover
 								var logDay = ExtraFiles[i].endofday ? DateTime.Now.AddDays(-1) : DateTime.Now;
 
-								if (uploadfile == "<currentlogfile>")
-								{
-									uploadfile = GetLogFileName(logDay);
-								}
-								else if (uploadfile == "<currentextralogfile>")
-								{
-									uploadfile = GetExtraLogFileName(logDay);
-								}
-								else if (uploadfile == "<airlinklogfile")
-								{
-									uploadfile = GetAirLinkLogFileName(logDay);
-								}
+								uploadfile = GetUploadFilename(uploadfile, logDay);
 
 								if (File.Exists(uploadfile))
 								{
-									if (remotefile.Contains("<currentlogfile>"))
-									{
-										remotefile = remotefile.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(logDay)));
-									}
-									else if (remotefile.Contains("<currentextralogfile>"))
-									{
-										remotefile = remotefile.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(logDay)));
-									}
-									else if (remotefile.Contains("<airlinklogfile"))
-									{
-										remotefile = remotefile.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(logDay)));
-									}
+									remotefile = GetRemoteFileName(remotefile, logDay);
 
 									// all checks OK, file needs to be uploaded
 									if (ExtraFiles[i].process)
@@ -8183,7 +8110,7 @@ namespace CumulusMX
 					file.Write(station.WindChill.ToString(TempFormat, InvC) + ' ');                // 25
 					file.Write(station.temptrendval.ToString(TempTrendFormat, InvC) + ' ');        // 26
 					file.Write(station.HiLoToday.HighTemp.ToString(TempFormat, InvC) + ' ');       // 27
-					file.Write(station.HiLoToday.HighTempTime.ToString("HH:mm ") );                // 28
+					file.Write(station.HiLoToday.HighTempTime.ToString("HH:mm "));                // 28
 					file.Write(station.HiLoToday.LowTemp.ToString(TempFormat, InvC) + ' ');        // 29
 					file.Write(station.HiLoToday.LowTempTime.ToString("HH:mm "));                  // 30
 					file.Write(station.HiLoToday.HighWind.ToString(WindAvgFormat, InvC) + ' ');    // 31
@@ -8216,7 +8143,7 @@ namespace CumulusMX
 					file.Write(station.IsSunny ? "1 " : "0 ");                                     // 58
 					file.WriteLine(station.FeelsLike.ToString(TempFormat, InvC));                  // 59
 
-				file.Close();
+					file.Close();
 				}
 			}
 			catch (Exception ex)
@@ -8224,85 +8151,94 @@ namespace CumulusMX
 				LogMessage("Error encountered during Realtime file update.");
 				LogMessage(ex.Message);
 			}
+		}
 
+		private void MySqlRealtimeFile(int cycle)
+		{
+			DateTime timestamp = DateTime.Now;
 
-			if (RealtimeMySqlEnabled)
+			if (!RealtimeMySqlEnabled)
+				return;
+
+			if (RealtimeMySql1MinLimit && RealtimeMySqlLastMinute == timestamp.Minute)
+				return;
+
+			RealtimeMySqlLastMinute = timestamp.Minute;
+
+			var InvC = new CultureInfo("");
+
+			StringBuilder values = new StringBuilder(StartOfRealtimeInsertSQL, 1024);
+			values.Append(" Values('");
+			values.Append(timestamp.ToString("yy-MM-dd HH:mm:ss") + "',");
+			values.Append(station.OutdoorTemperature.ToString(TempFormat, InvC) + ',');
+			values.Append(station.OutdoorHumidity.ToString() + ',');
+			values.Append(station.OutdoorDewpoint.ToString(TempFormat, InvC) + ',');
+			values.Append(station.WindAverage.ToString(WindAvgFormat, InvC) + ',');
+			values.Append(station.WindLatest.ToString(WindFormat, InvC) + ',');
+			values.Append(station.Bearing.ToString() + ',');
+			values.Append(station.RainRate.ToString(RainFormat, InvC) + ',');
+			values.Append(station.RainToday.ToString(RainFormat, InvC) + ',');
+			values.Append(station.Pressure.ToString(PressFormat, InvC) + ",'");
+			values.Append(station.CompassPoint(station.Bearing) + "','");
+			values.Append(Beaufort(station.WindAverage) + "','");
+			values.Append(Units.WindText + "','");
+			values.Append(Units.TempText[1].ToString() + "','");
+			values.Append(Units.PressText + "','");
+			values.Append(Units.RainText + "',");
+			values.Append(station.WindRunToday.ToString(WindRunFormat, InvC) + ",'");
+			values.Append((station.presstrendval > 0 ? '+' + station.presstrendval.ToString(PressFormat, InvC) : station.presstrendval.ToString(PressFormat, InvC)) + "',");
+			values.Append(station.RainMonth.ToString(RainFormat, InvC) + ',');
+			values.Append(station.RainYear.ToString(RainFormat, InvC) + ',');
+			values.Append(station.RainYesterday.ToString(RainFormat, InvC) + ',');
+			values.Append(station.IndoorTemperature.ToString(TempFormat, InvC) + ',');
+			values.Append(station.IndoorHumidity.ToString() + ',');
+			values.Append(station.WindChill.ToString(TempFormat, InvC) + ',');
+			values.Append(station.temptrendval.ToString(TempTrendFormat, InvC) + ',');
+			values.Append(station.HiLoToday.HighTemp.ToString(TempFormat, InvC) + ",'");
+			values.Append(station.HiLoToday.HighTempTime.ToString("HH:mm") + "',");
+			values.Append(station.HiLoToday.LowTemp.ToString(TempFormat, InvC) + ",'");
+			values.Append(station.HiLoToday.LowTempTime.ToString("HH:mm") + "',");
+			values.Append(station.HiLoToday.HighWind.ToString(WindAvgFormat, InvC) + ",'");
+			values.Append(station.HiLoToday.HighWindTime.ToString("HH:mm") + "',");
+			values.Append(station.HiLoToday.HighGust.ToString(WindFormat, InvC) + ",'");
+			values.Append(station.HiLoToday.HighGustTime.ToString("HH:mm") + "',");
+			values.Append(station.HiLoToday.HighPress.ToString(PressFormat, InvC) + ",'");
+			values.Append(station.HiLoToday.HighPressTime.ToString("HH:mm") + "',");
+			values.Append(station.HiLoToday.LowPress.ToString(PressFormat, InvC) + ",'");
+			values.Append(station.HiLoToday.LowPressTime.ToString("HH:mm") + "','");
+			values.Append(Version + "','");
+			values.Append(Build + "',");
+			values.Append(station.RecentMaxGust.ToString(WindFormat, InvC) + ',');
+			values.Append(station.HeatIndex.ToString(TempFormat, InvC) + ',');
+			values.Append(station.Humidex.ToString(TempFormat, InvC) + ',');
+			values.Append(station.UV.ToString(UVFormat, InvC) + ',');
+			values.Append(station.ET.ToString(ETFormat, InvC) + ',');
+			values.Append(((int)station.SolarRad).ToString() + ',');
+			values.Append(station.AvgBearing.ToString() + ',');
+			values.Append(station.RainLastHour.ToString(RainFormat, InvC) + ',');
+			values.Append(station.Forecastnumber.ToString() + ",'");
+			values.Append((IsDaylight() ? "1" : "0") + "','");
+			values.Append((station.SensorContactLost ? "1" : "0") + "','");
+			values.Append(station.CompassPoint(station.AvgBearing) + "',");
+			values.Append((station.CloudBase).ToString() + ",'");
+			values.Append((CloudBaseInFeet ? "ft" : "m") + "',");
+			values.Append(station.ApparentTemperature.ToString(TempFormat, InvC) + ',');
+			values.Append(station.SunshineHours.ToString(SunFormat, InvC) + ',');
+			values.Append(((int)Math.Round(station.CurrentSolarMax)).ToString() + ",'");
+			values.Append((station.IsSunny ? "1" : "0") + "',");
+			values.Append(station.FeelsLike.ToString(TempFormat, InvC));
+			values.Append(")");
+
+			string valuesString = values.ToString();
+			List<string> cmds = new List<string>() { valuesString };
+
+			if (!string.IsNullOrEmpty(MySqlRealtimeRetention))
 			{
-				var InvC = new CultureInfo("");
-
-				StringBuilder values = new StringBuilder(StartOfRealtimeInsertSQL, 1024);
-				values.Append(" Values('");
-				values.Append(timestamp.ToString("yy-MM-dd HH:mm:ss") + "',");
-				values.Append(station.OutdoorTemperature.ToString(TempFormat, InvC) + ',');
-				values.Append(station.OutdoorHumidity.ToString() + ',');
-				values.Append(station.OutdoorDewpoint.ToString(TempFormat, InvC) + ',');
-				values.Append(station.WindAverage.ToString(WindAvgFormat, InvC) + ',');
-				values.Append(station.WindLatest.ToString(WindFormat, InvC) + ',');
-				values.Append(station.Bearing.ToString() + ',');
-				values.Append(station.RainRate.ToString(RainFormat, InvC) + ',');
-				values.Append(station.RainToday.ToString(RainFormat, InvC) + ',');
-				values.Append(station.Pressure.ToString(PressFormat, InvC) + ",'");
-				values.Append(station.CompassPoint(station.Bearing) + "','");
-				values.Append(Beaufort(station.WindAverage) + "','");
-				values.Append(Units.WindText + "','");
-				values.Append(Units.TempText[1].ToString() + "','");
-				values.Append(Units.PressText + "','");
-				values.Append(Units.RainText + "',");
-				values.Append(station.WindRunToday.ToString(WindRunFormat, InvC) + ",'");
-				values.Append((station.presstrendval > 0 ? '+' + station.presstrendval.ToString(PressFormat, InvC) : station.presstrendval.ToString(PressFormat, InvC)) + "',");
-				values.Append(station.RainMonth.ToString(RainFormat, InvC) + ',');
-				values.Append(station.RainYear.ToString(RainFormat, InvC) + ',');
-				values.Append(station.RainYesterday.ToString(RainFormat, InvC) + ',');
-				values.Append(station.IndoorTemperature.ToString(TempFormat, InvC) + ',');
-				values.Append(station.IndoorHumidity.ToString() + ',');
-				values.Append(station.WindChill.ToString(TempFormat, InvC) + ',');
-				values.Append(station.temptrendval.ToString(TempTrendFormat, InvC) + ',');
-				values.Append(station.HiLoToday.HighTemp.ToString(TempFormat, InvC) + ",'");
-				values.Append(station.HiLoToday.HighTempTime.ToString("HH:mm") + "',");
-				values.Append(station.HiLoToday.LowTemp.ToString(TempFormat, InvC) + ",'");
-				values.Append(station.HiLoToday.LowTempTime.ToString("HH:mm") + "',");
-				values.Append(station.HiLoToday.HighWind.ToString(WindAvgFormat, InvC) + ",'");
-				values.Append(station.HiLoToday.HighWindTime.ToString("HH:mm") + "',");
-				values.Append(station.HiLoToday.HighGust.ToString(WindFormat, InvC) + ",'");
-				values.Append(station.HiLoToday.HighGustTime.ToString("HH:mm") + "',");
-				values.Append(station.HiLoToday.HighPress.ToString(PressFormat, InvC) + ",'");
-				values.Append(station.HiLoToday.HighPressTime.ToString("HH:mm") + "',");
-				values.Append(station.HiLoToday.LowPress.ToString(PressFormat, InvC) + ",'");
-				values.Append(station.HiLoToday.LowPressTime.ToString("HH:mm") + "','");
-				values.Append(Version + "','");
-				values.Append(Build + "',");
-				values.Append(station.RecentMaxGust.ToString(WindFormat, InvC) + ',');
-				values.Append(station.HeatIndex.ToString(TempFormat, InvC) + ',');
-				values.Append(station.Humidex.ToString(TempFormat, InvC) + ',');
-				values.Append(station.UV.ToString(UVFormat, InvC) + ',');
-				values.Append(station.ET.ToString(ETFormat, InvC) + ',');
-				values.Append(((int)station.SolarRad).ToString() + ',');
-				values.Append(station.AvgBearing.ToString() + ',');
-				values.Append(station.RainLastHour.ToString(RainFormat, InvC) + ',');
-				values.Append(station.Forecastnumber.ToString() + ",'");
-				values.Append((IsDaylight() ? "1" : "0") + "','");
-				values.Append((station.SensorContactLost ? "1" : "0") + "','");
-				values.Append(station.CompassPoint(station.AvgBearing) + "',");
-				values.Append((station.CloudBase).ToString() + ",'");
-				values.Append((CloudBaseInFeet ? "ft" : "m") + "',");
-				values.Append(station.ApparentTemperature.ToString(TempFormat, InvC) + ',');
-				values.Append(station.SunshineHours.ToString(SunFormat, InvC) + ',');
-				values.Append(((int)Math.Round(station.CurrentSolarMax)).ToString() + ",'");
-				values.Append((station.IsSunny ? "1" : "0") + "',");
-				values.Append(station.FeelsLike.ToString(TempFormat, InvC));
-				values.Append(")");
-
-				string valuesString = values.ToString();
-				List<string> cmds = new List<string>() { valuesString };
-
-				if (!string.IsNullOrEmpty(MySqlRealtimeRetention))
-				{
-					cmds.Add($"DELETE IGNORE FROM {MySqlRealtimeTable} WHERE LogDateTime < DATE_SUB('{DateTime.Now:yyyy-MM-dd HH:mm:ss}', INTERVAL {MySqlRealtimeRetention});");
-				}
-
-				// do the update
-				MySqlCommandSync(cmds, RealtimeSqlConn, $"Realtime[{cycle}]", true, true);
+				cmds.Add($"DELETE IGNORE FROM {MySqlRealtimeTable} WHERE LogDateTime < DATE_SUB('{DateTime.Now:yyyy-MM-dd HH:mm:ss}', INTERVAL {MySqlRealtimeRetention});");
 			}
+
+			// do the update
+			_ = MySqlCommandAsync(cmds, RealtimeSqlConn, $"Realtime[{cycle}]", true, true);
 		}
 
 		private void ProcessTemplateFile(string template, string outputfile, TokenParser parser)
@@ -8615,33 +8551,11 @@ namespace CumulusMX
 						// For EOD files, we want the previous days log files since it is now just past the day rollover time. Makes a difference on month rollover
 						var logDay = DateTime.Now.AddDays(-1);
 
-						if (uploadfile == "<currentlogfile>")
-						{
-							uploadfile = GetLogFileName(logDay);
-						}
-						else if (uploadfile == "<currentextralogfile>")
-						{
-							uploadfile = GetExtraLogFileName(logDay);
-						}
-						else if (uploadfile == "<airlinklogfile")
-						{
-							uploadfile = GetAirLinkLogFileName(logDay);
-						}
+						uploadfile = GetUploadFilename(uploadfile, logDay);
 
 						if (File.Exists(uploadfile))
 						{
-							if (remotefile.Contains("<currentlogfile>"))
-							{
-								remotefile = remotefile.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(logDay)));
-							}
-							else if (remotefile.Contains("<currentextralogfile>"))
-							{
-								remotefile = remotefile.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(logDay)));
-							}
-							else if (remotefile.Contains("<airlinklogfile"))
-							{
-								remotefile = remotefile.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(logDay)));
-							}
+							remotefile = GetRemoteFileName(remotefile, logDay);
 
 							if (ExtraFiles[i].process)
 							{
@@ -8699,19 +8613,14 @@ namespace CumulusMX
 		{
 			try
 			{
-				using (var mySqlConn = new MySqlConnection(MySqlConnSettings.ToString()))
-				{
-					MySqlCommandSync(MySqlList, mySqlConn, "MySQL Archive", true, true);
-				}
+				var mySqlConn = new MySqlConnection(MySqlConnSettings.ToString());
+				_= MySqlCommandAsync(MySqlList, mySqlConn, "MySQL Archive", true, true, true);
 			}
 			catch (Exception ex)
 			{
 				LogMessage("MySQL Archive: Error encountered during catchup MySQL operation.");
 				LogMessage(ex.Message);
 			}
-
-			LogMessage("MySQL Archive: End of MySQL archive upload");
-			MySqlList.Clear();
 		}
 
 		public void RealtimeFTPDisconnect()
@@ -8994,19 +8903,22 @@ namespace CumulusMX
 				{
 					HttpResponseMessage response = await PWShttpClient.GetAsync(URL);
 					var responseBodyAsText = await response.Content.ReadAsStringAsync();
-					LogDebugMessage("PWS Response: " + response.StatusCode + ": " + responseBodyAsText);
 					if (response.StatusCode != HttpStatusCode.OK)
 					{
+						LogMessage($"PWS Response: ERROR - Response code = {response.StatusCode},  Body = {responseBodyAsText}");
+						HttpUploadAlarm.LastError = $"PWS: HTTP Response code = {response.StatusCode},  Body = {responseBodyAsText}";
 						HttpUploadAlarm.Triggered = true;
 					}
 					else
 					{
+						LogDebugMessage("PWS Response: " + response.StatusCode + ": " + responseBodyAsText);
 						HttpUploadAlarm.Triggered = false;
 					}
 				}
 				catch (Exception ex)
 				{
-					LogDebugMessage("PWS update: " + ex.Message);
+					LogMessage("PWS update: " + ex.Message);
+					HttpUploadAlarm.LastError = "PWS: " + ex.Message;
 					HttpUploadAlarm.Triggered = true;
 				}
 				finally
@@ -9028,25 +8940,28 @@ namespace CumulusMX
 				string starredpwstring = "&siteAuthenticationKey=" + new string('*', WOW.PW.Length);
 
 				string LogURL = URL.Replace(pwstring, starredpwstring);
-				LogDebugMessage(LogURL);
+				LogDebugMessage("WOW URL = " + LogURL);
 
 				try
 				{
 					HttpResponseMessage response = await WOWhttpClient.GetAsync(URL);
 					var responseBodyAsText = await response.Content.ReadAsStringAsync();
-					LogDebugMessage("WOW Response: " + response.StatusCode + ": " + responseBodyAsText);
 					if (response.StatusCode != HttpStatusCode.OK)
 					{
+						LogMessage($"WOW Response: ERROR - Response code = {response.StatusCode}, body = {responseBodyAsText}");
+						HttpUploadAlarm.LastError = $"WOW: HTTP response - Response code = {response.StatusCode}, body = {responseBodyAsText}";
 						HttpUploadAlarm.Triggered = true;
 					}
 					else
 					{
+						LogDebugMessage("WOW Response: " + response.StatusCode + ": " + responseBodyAsText);
 						HttpUploadAlarm.Triggered = false;
 					}
 				}
 				catch (Exception ex)
 				{
-					LogDebugMessage("WOW update: " + ex.Message);
+					LogMessage("WOW update: " + ex.Message);
+					HttpUploadAlarm.LastError = "WOW: " + ex.Message;
 					HttpUploadAlarm.Triggered = true;
 				}
 				finally
@@ -9058,6 +8973,13 @@ namespace CumulusMX
 
 		public async Task MySqlCommandAsync(string Cmd, MySqlConnection Connection, string CallingFunction, bool OpenConnection, bool CloseConnection)
 		{
+			var Cmds = new List<string>() { Cmd };
+			await MySqlCommandAsync(Cmds, Connection, CallingFunction, OpenConnection, CloseConnection, true);
+		}
+
+		public async Task MySqlCommandAsync(List<string> Cmds, MySqlConnection Connection, string CallingFunction, bool OpenConnection, bool CloseConnection, bool ClearCommands = false)
+		{
+			int errorCount = 10;
 			try
 			{
 				if (OpenConnection)
@@ -9066,21 +8988,40 @@ namespace CumulusMX
 					await Connection.OpenAsync();
 				}
 
-				using (MySqlCommand cmd = new MySqlCommand(Cmd, Connection))
+				for (var i = 0; i < Cmds.Count; i++)
 				{
-					LogDebugMessage($"{CallingFunction}: MySQL executing - {Cmd}");
+					try
+					{
+						using (MySqlCommand cmd = new MySqlCommand(Cmds[i], Connection))
+						{
+							LogDebugMessage($"{CallingFunction}: MySQL executing - {Cmds[i]}");
 
-					int aff = await cmd.ExecuteNonQueryAsync();
-					LogDebugMessage($"{CallingFunction}: MySQL {aff} rows were affected.");
+							int aff = await cmd.ExecuteNonQueryAsync();
+							LogDebugMessage($"{CallingFunction}: MySQL {aff} rows were affected.");
+						}
+
+						MySqlUploadAlarm.Triggered = false;
+					}
+					catch (Exception ex)
+					{
+						LogMessage($"{CallingFunction}: Error encountered during MySQL operation.");
+						LogMessage($"{CallingFunction}: SQL was - \"{Cmds[i]}\"");
+						LogMessage(ex.Message);
+						MySqlUploadAlarm.LastError = ex.Message;
+						MySqlUploadAlarm.Triggered = true;
+						if (--errorCount <=0)
+						{
+							LogMessage($"{CallingFunction}: Too many errors, aborting!");
+							return;
+						}
+					}
 				}
-
-				MySqlUploadAlarm.Triggered = false;
 			}
 			catch (Exception ex)
 			{
 				LogMessage($"{CallingFunction}: Error encountered during MySQL operation.");
-				LogMessage($"{CallingFunction}: SQL was - \"{Cmd}\"");
 				LogMessage(ex.Message);
+				MySqlUploadAlarm.LastError = ex.Message;
 				MySqlUploadAlarm.Triggered = true;
 			}
 			finally
@@ -9094,66 +9035,64 @@ namespace CumulusMX
 					catch { }
 				}
 			}
-
 		}
 
-		public Task MySqlCommandSync(List<string> Cmds, MySqlConnection Connection, string CallingFunction, bool OpenConnection, bool CloseConnection, bool ClearCommands=false)
+		public void MySqlCommandSync(List<string> Cmds, MySqlConnection Connection, string CallingFunction, bool OpenConnection, bool CloseConnection, bool ClearCommands=false)
 		{
-			return Task.Run(() =>
+			try
 			{
-				try
+				if (OpenConnection)
 				{
-					if (OpenConnection)
-					{
-						LogDebugMessage($"{CallingFunction}: Opening MySQL Connection");
-						Connection.Open();
-					}
-
-					for (var i = 0; i < Cmds.Count; i++)
-					{
-						try
-						{
-							using (MySqlCommand cmd = new MySqlCommand(Cmds[i], Connection))
-							{
-								LogDebugMessage($"{CallingFunction}: MySQL executing[{i + 1}] - {Cmds[i]}");
-
-								int aff = cmd.ExecuteNonQuery();
-								LogDebugMessage($"{CallingFunction}: MySQL {aff} rows were affected.");
-							}
-
-							MySqlUploadAlarm.Triggered = false;
-						}
-						catch (Exception ex)
-						{
-							LogMessage($"{CallingFunction}: Error encountered during MySQL operation.");
-							LogMessage($"{CallingFunction}: SQL was - \"{Cmds[i]}\"");
-							LogMessage(ex.Message);
-							MySqlUploadAlarm.Triggered = true;
-						}
-					}
-
-					if (CloseConnection)
-					{
-						try
-						{
-							Connection.Close();
-						}
-						catch
-						{ }
-					}
-				}
-				catch (Exception e)
-				{
-					LogMessage($"{CallingFunction}: Error opening MySQL Connection");
-					LogMessage(e.Message);
-					MySqlUploadAlarm.Triggered = true;
+					LogDebugMessage($"{CallingFunction}: Opening MySQL Connection");
+					Connection.Open();
 				}
 
-				if (ClearCommands)
+				for (var i = 0; i < Cmds.Count; i++)
 				{
-					Cmds.Clear();
+					try
+					{
+						using (MySqlCommand cmd = new MySqlCommand(Cmds[i], Connection))
+						{
+							LogDebugMessage($"{CallingFunction}: MySQL executing[{i + 1}] - {Cmds[i]}");
+
+							int aff = cmd.ExecuteNonQuery();
+							LogDebugMessage($"{CallingFunction}: MySQL {aff} rows were affected.");
+						}
+
+						MySqlUploadAlarm.Triggered = false;
+					}
+					catch (Exception ex)
+					{
+						LogMessage($"{CallingFunction}: Error encountered during MySQL operation.");
+						LogMessage($"{CallingFunction}: SQL was - \"{Cmds[i]}\"");
+						LogMessage(ex.Message);
+						MySqlUploadAlarm.LastError = ex.Message;
+						MySqlUploadAlarm.Triggered = true;
+					}
 				}
-			});
+
+				if (CloseConnection)
+				{
+					try
+					{
+						Connection.Close();
+					}
+					catch
+					{ }
+				}
+			}
+			catch (Exception e)
+			{
+				LogMessage($"{CallingFunction}: Error opening MySQL Connection");
+				LogMessage(e.Message);
+				MySqlUploadAlarm.LastError = e.Message;
+				MySqlUploadAlarm.Triggered = true;
+			}
+
+			if (ClearCommands)
+			{
+				Cmds.Clear();
+			}
 		}
 
 		public async void GetLatestVersion()
@@ -9170,6 +9109,7 @@ namespace CumulusMX
 					var msg = $"You are not running the latest version of Cumulus MX, build {LatestBuild} is available.";
 					LogConsoleMessage(msg);
 					LogMessage(msg);
+					UpgradeAlarm.LastError = $"Build {LatestBuild} is available";
 					UpgradeAlarm.Triggered = true;
 				}
 				else if (int.Parse(Build) == int.Parse(LatestBuild))
@@ -9377,6 +9317,62 @@ namespace CumulusMX
 
 				LogMessage("Creating OpenWeatherMap data #" + OWMList.Count);
 			}
+		}
+
+		private string GetUploadFilename(string input, DateTime dat)
+		{
+			if (input == "<currentlogfile>")
+			{
+				return GetLogFileName(dat);
+			}
+			else if (input == "<currentextralogfile>")
+			{
+				return GetExtraLogFileName(dat);
+			}
+			else if (input == "<airlinklogfile")
+			{
+				return GetAirLinkLogFileName(dat);
+			}
+			else if (input == "<noaayearfile>")
+			{
+				NOAAReports noaa = new NOAAReports(this);
+				return noaa.GetLastNoaaYearReportFilename(dat, true);
+			}
+			else if (input == "<noaamonthfile>")
+			{
+				NOAAReports noaa = new NOAAReports(this);
+				return noaa.GetLastNoaaMonthReportFilename(dat, true);
+			}
+
+			return input;
+		}
+
+		private string GetRemoteFileName(string input, DateTime dat)
+		{
+			if (input.Contains("<currentlogfile>"))
+			{
+				return input.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(dat)));
+			}
+			else if (input.Contains("<currentextralogfile>"))
+			{
+				return input.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(dat)));
+			}
+			else if (input.Contains("<airlinklogfile>"))
+			{
+				return input.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(dat)));
+			}
+			else if (input.Contains("<noaayearfile>"))
+			{
+				NOAAReports noaa = new NOAAReports(this);
+				return input.Replace("<noaayearfile>", Path.GetFileName(noaa.GetLastNoaaYearReportFilename(dat, false)));
+			}
+			else if (input.Contains("<noaamonthfile>"))
+			{
+				NOAAReports noaa = new NOAAReports(this);
+				return input.Replace("<noaamonthfile>", Path.GetFileName(noaa.GetLastNoaaMonthReportFilename(dat, false)));
+			}
+
+			return input;
 		}
 
 		public void SetMonthlySqlCreateString()
@@ -9832,157 +9828,6 @@ namespace CumulusMX
 		public double latitude { get; set; }
 		public int altitude { get; set; }
 		public int source_type { get; set; }
-	}
-
-	public class Alarm
-	{
-		public Cumulus cumulus { get;  set; }
-
-		public bool Enabled { get; set; }
-		public double Value { get; set; }
-		public bool Sound { get; set; }
-		public string SoundFile { get; set; }
-
-		bool triggered;
-		public bool Triggered
-		{
-			get => triggered;
-			set
-			{
-				if (value)
-				{
-					// If we were not set before, so we need to send an email?
-					if (!triggered && Enabled && Email && cumulus.SmtpOptions.Enabled)
-					{
-						// Construct the message - preamble, plus values
-						var msg = cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsg, Value, Units);
-						cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
-					}
-
-					// If we get a new trigger, record the time
-					triggered = true;
-					TriggeredTime = DateTime.Now;
-				}
-				else
-				{
-					// If the trigger is cleared, check if we should be latching the value
-					if (Latch)
-					{
-						if (DateTime.Now > TriggeredTime.AddHours(LatchHours))
-						{
-							// We are latching, but the latch period has expired, clear the trigger
-							triggered = false;
-						}
-					}
-					else
-					{
-						// No latch, just clear the trigger
-						triggered = false;
-					}
-				}
-			}
-		}
-		public DateTime TriggeredTime { get; set; }
-		public bool Notify { get; set; }
-		public bool Email { get; set; }
-		public bool Latch { get; set; }
-		public int LatchHours { get; set; }
-		public string EmailMsg { get; set; }
-		public string Units { get; set; }
-	}
-
-	public class AlarmChange : Alarm
-	{
-		//public bool changeUp { get; set; }
-		//public bool changeDown { get; set; }
-
-		bool upTriggered;
-		public bool UpTriggered
-		{
-			get => upTriggered;
-			set
-			{
-				if (value)
-				{
-					// If we were not set before, so we need to send an email?
-					if (!upTriggered && Enabled && Email && cumulus.SmtpOptions.Enabled)
-					{
-						// Construct the message - preamble, plus values
-						var msg = Program.cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsgUp, Value, Units);
-						cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
-					}
-
-					// If we get a new trigger, record the time
-					upTriggered = true;
-					UpTriggeredTime = DateTime.Now;
-				}
-				else
-				{
-					// If the trigger is cleared, check if we should be latching the value
-					if (Latch)
-					{
-						if (DateTime.Now > UpTriggeredTime.AddHours(LatchHours))
-						{
-							// We are latching, but the latch period has expired, clear the trigger
-							upTriggered = false;
-						}
-					}
-					else
-					{
-						// No latch, just clear the trigger
-						upTriggered = false;
-					}
-				}
-			}
-		}
-		public DateTime UpTriggeredTime { get; set; }
-
-
-		bool downTriggered;
-		public bool DownTriggered
-		{
-			get => downTriggered;
-			set
-			{
-				if (value)
-				{
-					// If we were not set before, so we need to send an email?
-					if (!downTriggered && Enabled && Email && cumulus.SmtpOptions.Enabled)
-					{
-						// Construct the message - preamble, plus values
-						var msg = Program.cumulus.AlarmEmailPreamble + "\n" + string.Format(EmailMsgDn, Value, Units);
-						cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
-					}
-
-					// If we get a new trigger, record the time
-					downTriggered = true;
-					DownTriggeredTime = DateTime.Now;
-				}
-				else
-				{
-					// If the trigger is cleared, check if we should be latching the value
-					if (Latch)
-					{
-						if (DateTime.Now > DownTriggeredTime.AddHours(LatchHours))
-						{
-							// We are latching, but the latch period has expired, clear the trigger
-							downTriggered = false;
-						}
-					}
-					else
-					{
-						// No latch, just clear the trigger
-						downTriggered = false;
-					}
-				}
-			}
-		}
-
-		public DateTime DownTriggeredTime { get; set; }
-
-		public string EmailMsgUp { get; set; }
-		public string EmailMsgDn { get; set; }
-
 	}
 
 	public class WebUploadService

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -181,6 +181,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AirQualityIndices.cs" />
+    <Compile Include="Alarm.cs" />
     <Compile Include="Api.cs" />
     <Compile Include="ApiTagProcessor.cs" />
     <Compile Include="AstroLib.cs" />

--- a/CumulusMX/DataStruct.cs
+++ b/CumulusMX/DataStruct.cs
@@ -23,6 +23,7 @@ namespace CumulusMX
 							bool dataStopped, double stormRain, string stormRainStart, int cloudbase, string cloudbaseUnit, double last24hourRain, bool alarmLowTemp,
 							bool alarmHighTemp, bool alarmTempUp, bool alarmTempDown, bool alarmRain, bool alarmRainRate, bool alarmLowPress, bool alarmHighPress,
 							bool alarmPressUp, bool alarmPressDown, bool alarmGust, bool alarmWind, bool alarmSensor, bool alarmBattery, bool alarmSpike, bool alarmUpgrade,
+							bool alarmHttp, bool alarmMySql,
 							double feelsLike, double highFeelsLikeToday, string highFeelsLikeTodayTime, double lowFeelsLikeToday, string lowFeelsLikeTodayTime,
 							double highHumidexToday, string highHumidexTodayTime)
 		{
@@ -141,6 +142,8 @@ namespace CumulusMX
 			AlarmBattery = alarmBattery;
 			AlarmSpike = alarmSpike;
 			AlarmUpgrade = alarmUpgrade;
+			AlarmHttp = alarmHttp;
+			AlarmMySql = alarmMySql;
 		}
 
 		[IgnoreDataMember]
@@ -819,5 +822,12 @@ namespace CumulusMX
 
 		[DataMember]
 		public bool AlarmUpgrade { get; set; }
+
+		[DataMember]
+		public bool AlarmHttp { get; set; }
+
+		[DataMember]
+		public bool AlarmMySql { get; set; }
+
 	}
 }

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -2940,6 +2940,7 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage($"ERROR: No broadcast data received from the WLL for {tmrBroadcastWatchdog.Interval / 1000} seconds");
 				DataStopped = true;
+				cumulus.DataStoppedAlarm.LastError = $"No broadcast data received from the WLL for {tmrBroadcastWatchdog.Interval / 1000} seconds";
 				cumulus.DataStoppedAlarm.Triggered = true;
 				// Try and give the broadcasts a kick in case the last command did not get through
 				GetWllRealtime(null, null);

--- a/CumulusMX/EmailSender.cs
+++ b/CumulusMX/EmailSender.cs
@@ -50,7 +50,7 @@ namespace CumulusMX
 
 				m.Body = bodyBuilder.ToMessageBody();
 
-				using (SmtpClient client = new SmtpClient(cumulus.SmtpOptions.Logging ? new ProtocolLogger("MXdiags/smtp.log") : null))
+				using (SmtpClient client = cumulus.SmtpOptions.Logging ? new SmtpClient(new ProtocolLogger("MXdiags/smtp.log")) : new SmtpClient())
 				{
 					await client.ConnectAsync(cumulus.SmtpOptions.Server, cumulus.SmtpOptions.Port, (MailKit.Security.SecureSocketOptions)cumulus.SmtpOptions.SslOption);
 
@@ -112,7 +112,7 @@ namespace CumulusMX
 
 				m.Body = bodyBuilder.ToMessageBody();
 
-				using (SmtpClient client = new SmtpClient(cumulus.SmtpOptions.Logging ? new ProtocolLogger("MXdiags/smtp.log") : null))
+				using (SmtpClient client = cumulus.SmtpOptions.Logging ? new SmtpClient(new ProtocolLogger("MXdiags/smtp.log")) : new SmtpClient())
 				{
 					client.Connect(cumulus.SmtpOptions.Server, cumulus.SmtpOptions.Port, (MailKit.Security.SecureSocketOptions)cumulus.SmtpOptions.SslOption);
 					//client.Connect(cumulus.SmtpOptions.Server, cumulus.SmtpOptions.Port, MailKit.Security.SecureSocketOptions.StartTlsWhenAvailable);

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -658,6 +658,7 @@ namespace CumulusMX
 			if (hidDevice == null)
 			{
 				DataStopped = true;
+				cumulus.DataStoppedAlarm.LastError = "USB device no longer detected";
 				cumulus.DataStoppedAlarm.Triggered = true;
 				return false;
 			}
@@ -673,6 +674,7 @@ namespace CumulusMX
 				cumulus.LogMessage(ex.Message);
 				cumulus.LogMessage("Error sending command to station - it may need resetting");
 				DataStopped = true;
+				cumulus.DataStoppedAlarm.LastError = "Error reading data from station - it may need resetting. " + ex.Message;
 				cumulus.DataStoppedAlarm.Triggered = true;
 				return false;
 			}
@@ -691,6 +693,7 @@ namespace CumulusMX
 					cumulus.LogMessage(ex.Message);
 					cumulus.LogMessage("Error reading data from station - it may need resetting");
 					DataStopped = true;
+					cumulus.DataStoppedAlarm.LastError = "Error reading data from station - it may need resetting. " + ex.Message;
 					cumulus.DataStoppedAlarm.Triggered = true;
 					return false;
 				}
@@ -728,6 +731,7 @@ namespace CumulusMX
 				cumulus.LogMessage(ex.Message);
 				cumulus.LogMessage("Error sending command to station - it may need resetting");
 				DataStopped = true;
+				cumulus.DataStoppedAlarm.LastError = "Error sending command to station - it may need resetting: " + ex.Message;
 				cumulus.DataStoppedAlarm.Triggered = true;
 				return false;
 			}

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -472,7 +472,7 @@ namespace CumulusMX
 					client.EnableBroadcast = true;
 					client.Send(sendBytes, sendBytes.Length, sendEp);
 
-					string[] namesToCheck = { "GW1000A", "WH2650A", "EasyWeather", "AMBWeather", "WS1900A" };
+					string[] namesToCheck = { "GW1000", "WH2650", "EasyWeather", "AMBWeather", "WS1900", "WN1900" };
 
 					do
 					{
@@ -491,7 +491,7 @@ namespace CumulusMX
 							Array.Copy(receivedBytes, 5, macArr, 0, 6);
 							var macHex = BitConverter.ToString(macArr).Replace('-', ':');
 
-							if (namesToCheck.Contains(name.Split('-')[0]) && ipAddr.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 4)
+							if (namesToCheck.Any((name.Split('-')[0]).StartsWith) && ipAddr.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries).Length == 4)
 							{
 								IPAddress ipAddr2;
 								if (IPAddress.TryParse(ipAddr, out ipAddr2))

--- a/CumulusMX/MysqlSettings.cs
+++ b/CumulusMX/MysqlSettings.cs
@@ -44,7 +44,8 @@ namespace CumulusMX
 			{
 				retentionVal = retenVal,
 				retentionUnit = retenUnit,
-				table = cumulus.MySqlRealtimeTable
+				table = cumulus.MySqlRealtimeTable,
+				limit1min = cumulus.RealtimeMySql1MinLimit
 			};
 
 			var dayfile = new JsonMysqlSettingsDayfile()
@@ -163,6 +164,7 @@ namespace CumulusMX
 				{
 					cumulus.MySqlRealtimeRetention = settings.realtime.retentionVal + " " + settings.realtime.retentionUnit;
 					cumulus.MySqlRealtimeTable = String.IsNullOrWhiteSpace(settings.realtime.table) ? "Realtime" : settings.realtime.table;
+					cumulus.RealtimeMySql1MinLimit = settings.realtime.limit1min;
 				}
 				//dayfile
 				cumulus.DayfileMySqlEnabled = settings.dayenabled;
@@ -331,6 +333,7 @@ namespace CumulusMX
 		public string table { get; set; }
 		public int retentionVal { get; set; }
 		public string retentionUnit { get; set; }
+		public bool limit1min { get; set; }
 	}
 
 	public class JsonMysqlSettingsDayfile

--- a/CumulusMX/NOAAReports.cs
+++ b/CumulusMX/NOAAReports.cs
@@ -107,5 +107,72 @@ namespace CumulusMX
 			}
 			return report;
 		}
+
+		public string GetLastNoaaYearReportFilename(DateTime dat, bool fullPath)
+		{
+			// First determine the date for the logfile.
+			// If we're using 9am rollover, the date should be 9 hours (10 in summer)
+			// before 'Now'
+			// This assumes that the caller has already subtracted a day if required
+			DateTime logfiledate;
+
+			if (cumulus.RolloverHour == 0)
+			{
+				logfiledate = dat.AddDays(-1);
+			}
+			else
+			{
+				TimeZone tz = TimeZone.CurrentTimeZone;
+
+				if (cumulus.Use10amInSummer && tz.IsDaylightSavingTime(dat))
+				{
+					// Locale is currently on Daylight (summer) time
+					logfiledate = dat.AddHours(-10);
+				}
+				else
+				{
+					// Locale is currently on Standard time or unknown
+					logfiledate = dat.AddHours(-9);
+				}
+			}
+
+			if (fullPath)
+				return cumulus.ReportPath + logfiledate.ToString(cumulus.NOAAYearFileFormat);
+			else
+				return logfiledate.ToString(cumulus.NOAAYearFileFormat);
+		}
+
+		public string GetLastNoaaMonthReportFilename (DateTime dat, bool fullPath)
+		{
+			// First determine the date for the logfile.
+			// If we're using 9am rollover, the date should be 9 hours (10 in summer)
+			// before 'Now'
+			// This assumes that the caller has already subtracted a day if required
+			DateTime logfiledate;
+
+			if (cumulus.RolloverHour == 0)
+			{
+				logfiledate = dat.AddDays(-1);
+			}
+			else
+			{
+				TimeZone tz = TimeZone.CurrentTimeZone;
+
+				if (cumulus.Use10amInSummer && tz.IsDaylightSavingTime(dat))
+				{
+					// Locale is currently on Daylight (summer) time
+					logfiledate = dat.AddHours(-10);
+				}
+				else
+				{
+					// Locale is currently on Standard time or unknown
+					logfiledate = dat.AddHours(-9);
+				}
+			}
+			if (fullPath)
+				return cumulus.ReportPath + logfiledate.AddHours(-1).ToString(cumulus.NOAAMonthFileFormat);
+			else
+				return logfiledate.AddHours(-1).ToString(cumulus.NOAAMonthFileFormat);
+		}
 	}
 }

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.11.1 - Build 3130")]
+[assembly: AssemblyDescription("Version 3.11.2 - Build 3131")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.11.1.3130")]
-[assembly: AssemblyFileVersion("3.11.1.3130")]
+[assembly: AssemblyVersion("3.11.2.3131")]
+[assembly: AssemblyFileVersion("3.11.2.3131")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -974,11 +974,26 @@ namespace CumulusMX
 				// Units
 				try
 				{
-					cumulus.Units.Wind = settings.general.units.wind;
-					cumulus.Units.Press = settings.general.units.pressure;
-					cumulus.Units.Temp = settings.general.units.temp;
-					cumulus.Units.Rain = settings.general.units.rain;
-					cumulus.SetupUnitText();
+					if (cumulus.Units.Wind != settings.general.units.wind)
+					{
+						cumulus.Units.Wind = settings.general.units.wind;
+						cumulus.ChangeWindUnits();
+					}
+					if (cumulus.Units.Press != settings.general.units.pressure)
+					{
+						cumulus.Units.Press = settings.general.units.pressure;
+						cumulus.ChangePressureUnits();
+					}
+					if (cumulus.Units.Temp != settings.general.units.temp)
+					{
+						cumulus.Units.Temp = settings.general.units.temp;
+						cumulus.ChangeTempUnits();
+					}
+					if (cumulus.Units.Rain != settings.general.units.rain)
+					{
+						cumulus.Units.Rain = settings.general.units.rain;
+						cumulus.ChangeRainUnits();
+					}
 
 					cumulus.AirQualityDPlaces = settings.general.units.advanced.airqulaitydp;
 					cumulus.PressDPlaces = settings.general.units.advanced.pressdp;

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1488,7 +1488,9 @@ namespace CumulusMX
 						LastDataReadTimestamp.ToString("HH:mm:ss"), DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
 						cumulus.LowTempAlarm.Triggered, cumulus.HighTempAlarm.Triggered, cumulus.TempChangeAlarm.UpTriggered, cumulus.TempChangeAlarm.DownTriggered, cumulus.HighRainTodayAlarm.Triggered, cumulus.HighRainRateAlarm.Triggered,
 						cumulus.LowPressAlarm.Triggered, cumulus.HighPressAlarm.Triggered, cumulus.PressChangeAlarm.UpTriggered, cumulus.PressChangeAlarm.DownTriggered, cumulus.HighGustAlarm.Triggered, cumulus.HighWindAlarm.Triggered,
-						cumulus.SensorAlarm.Triggered, cumulus.BatteryLowAlarm.Triggered, cumulus.SpikeAlarm.Triggered, cumulus.UpgradeAlarm.Triggered, FeelsLike, HiLoToday.HighFeelsLike, HiLoToday.HighFeelsLikeTime.ToString("HH:mm"), HiLoToday.LowFeelsLike, HiLoToday.LowFeelsLikeTime.ToString("HH:mm"),
+						cumulus.SensorAlarm.Triggered, cumulus.BatteryLowAlarm.Triggered, cumulus.SpikeAlarm.Triggered, cumulus.UpgradeAlarm.Triggered,
+						cumulus.HttpUploadAlarm.Triggered, cumulus.MySqlUploadAlarm.Triggered,
+						FeelsLike, HiLoToday.HighFeelsLike, HiLoToday.HighFeelsLikeTime.ToString("HH:mm"), HiLoToday.LowFeelsLike, HiLoToday.LowFeelsLikeTime.ToString("HH:mm"),
 						HiLoToday.HighHumidex, HiLoToday.HighHumidexTime.ToString("HH:mm"));
 
 					//var json = jss.Serialize(data);
@@ -1605,6 +1607,12 @@ namespace CumulusMX
 
 			if (cumulus.UpgradeAlarm.Latch && cumulus.UpgradeAlarm.Triggered && DateTime.Now > cumulus.UpgradeAlarm.TriggeredTime.AddHours(cumulus.UpgradeAlarm.LatchHours))
 				cumulus.UpgradeAlarm.Triggered = false;
+
+			if (cumulus.HttpUploadAlarm.Latch && cumulus.HttpUploadAlarm.Triggered && DateTime.Now > cumulus.HttpUploadAlarm.TriggeredTime.AddHours(cumulus.HttpUploadAlarm.LatchHours))
+				cumulus.HttpUploadAlarm.Triggered = false;
+
+			if (cumulus.MySqlUploadAlarm.Latch && cumulus.MySqlUploadAlarm.Triggered && DateTime.Now > cumulus.MySqlUploadAlarm.TriggeredTime.AddHours(cumulus.MySqlUploadAlarm.LatchHours))
+				cumulus.MySqlUploadAlarm.Triggered = false;
 
 			if (cumulus.HighWindAlarm.Latch && cumulus.HighWindAlarm.Triggered && DateTime.Now > cumulus.HighWindAlarm.TriggeredTime.AddHours(cumulus.HighWindAlarm.LatchHours))
 				cumulus.HighWindAlarm.Triggered = false;
@@ -11737,7 +11745,7 @@ namespace CumulusMX
 				cumulus.BeaufortDesc(WindAverage), LastDataReadTimestamp.ToString("HH:mm:ss"), DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
 				cumulus.LowTempAlarm.Triggered, cumulus.HighTempAlarm.Triggered, cumulus.TempChangeAlarm.UpTriggered, cumulus.TempChangeAlarm.DownTriggered, cumulus.HighRainTodayAlarm.Triggered, cumulus.HighRainRateAlarm.Triggered,
 				cumulus.LowPressAlarm.Triggered, cumulus.HighPressAlarm.Triggered, cumulus.PressChangeAlarm.UpTriggered, cumulus.PressChangeAlarm.DownTriggered, cumulus.HighGustAlarm.Triggered, cumulus.HighWindAlarm.Triggered,
-				cumulus.SensorAlarm.Triggered, cumulus.BatteryLowAlarm.Triggered, cumulus.SpikeAlarm.Triggered, cumulus.UpgradeAlarm.Triggered,
+				cumulus.SensorAlarm.Triggered, cumulus.BatteryLowAlarm.Triggered, cumulus.SpikeAlarm.Triggered, cumulus.UpgradeAlarm.Triggered, cumulus.HttpUploadAlarm.Triggered, cumulus.MySqlUploadAlarm.Triggered,
 				FeelsLike, HiLoToday.HighFeelsLike, HiLoToday.HighFeelsLikeTime.ToString("HH:mm:ss"), HiLoToday.LowFeelsLike, HiLoToday.LowFeelsLikeTime.ToString("HH:mm:ss"),
 				HiLoToday.HighHumidex, HiLoToday.HighHumidexTime.ToString("HH:mm:ss"));
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2801,6 +2801,7 @@ namespace CumulusMX
 				cumulus.LogSpikeRemoval("Humidity difference greater than specified; reading ignored");
 				cumulus.LogSpikeRemoval($"NewVal={humpar} OldVal={previousHum} SpikeHumidityDiff={cumulus.Spike.HumidityDiff:F1}");
 				lastSpikeRemoval = DateTime.Now;
+				cumulus.SpikeAlarm.LastError = $"Humidity difference greater than spike value - NewVal={humpar} OldVal={previousHum}";
 				cumulus.SpikeAlarm.Triggered = true;
 				return;
 			}
@@ -2889,6 +2890,7 @@ namespace CumulusMX
 				tempC >= cumulus.Limit.TempHigh || tempC <= cumulus.Limit.TempLow)
 			{
 				lastSpikeRemoval = DateTime.Now;
+				cumulus.SpikeAlarm.LastError = $"Temp difference greater than spike value - NewVal={tempC.ToString(cumulus.TempFormat)} OldVal={previousTemp.ToString(cumulus.TempFormat)}";
 				cumulus.SpikeAlarm.Triggered = true;
 				cumulus.LogSpikeRemoval("Temp difference greater than specified; reading ignored");
 				cumulus.LogSpikeRemoval($"NewVal={tempC.ToString(cumulus.TempFormat)} OldVal={previousTemp.ToString(cumulus.TempFormat)} SpikeTempDiff={cumulus.Spike.TempDiff.ToString(cumulus.TempFormat)} HighLimit={cumulus.Limit.TempHigh.ToString(cumulus.TempFormat)} LowLimit={cumulus.Limit.TempLow.ToString(cumulus.TempFormat)}");
@@ -3332,6 +3334,7 @@ namespace CumulusMX
 				cumulus.LogSpikeRemoval("Pressure difference greater than specified; reading ignored");
 				cumulus.LogSpikeRemoval($"NewVal={pressMB:F1} OldVal={previousPress:F1} SpikePressDiff={cumulus.Spike.PressDiff:F1} HighLimit={cumulus.Limit.PressHigh:F1} LowLimit={cumulus.Limit.PressLow:F1}");
 				lastSpikeRemoval = DateTime.Now;
+				cumulus.SpikeAlarm.LastError = $"Pressure difference greater than spike value - NewVal={pressMB:F1} OldVal={previousPress:F1}";
 				cumulus.SpikeAlarm.Triggered = true;
 				return;
 			}
@@ -3449,6 +3452,7 @@ namespace CumulusMX
 				cumulus.LogSpikeRemoval("Rain rate greater than specified; reading ignored");
 				cumulus.LogSpikeRemoval($"Rate value = {rainRateMM:F2} SpikeMaxRainRate = {cumulus.Spike.MaxRainRate:F2}");
 				lastSpikeRemoval = DateTime.Now;
+				cumulus.SpikeAlarm.LastError = $"Rain rate greater than spike value - value = {rainRateMM:F2}mm/hr";
 				cumulus.SpikeAlarm.Triggered = true;
 				return;
 			}
@@ -3678,9 +3682,11 @@ namespace CumulusMX
 				}
 				else
 				{
+					var msg = $"Dew point greater than limit ({cumulus.Limit.DewHigh.ToString(cumulus.TempFormat)}); reading ignored: {dp.ToString(cumulus.TempFormat)}";
 					lastSpikeRemoval = DateTime.Now;
+					cumulus.SpikeAlarm.LastError = msg;
 					cumulus.SpikeAlarm.Triggered = true;
-					cumulus.LogSpikeRemoval($"Dew point greater than limit ({cumulus.Limit.DewHigh.ToString(cumulus.TempFormat)}); reading ignored: {dp.ToString(cumulus.TempFormat)}");
+					cumulus.LogSpikeRemoval(msg);
 				}
 			}
 		}
@@ -3871,6 +3877,7 @@ namespace CumulusMX
 				cumulus.LogSpikeRemoval($"Gust: NewVal={windGustMS:F1} OldVal={previousGust:F1} SpikeGustDiff={cumulus.Spike.GustDiff:F1} HighLimit={cumulus.Limit.WindHigh:F1}");
 				cumulus.LogSpikeRemoval($"Wind: NewVal={windAvgMS:F1} OldVal={previousWind:F1} SpikeWindDiff={cumulus.Spike.WindDiff:F1}");
 				lastSpikeRemoval = DateTime.Now;
+				cumulus.SpikeAlarm.LastError = $"Wind or gust difference greater than spike value - Gust: NewVal={windGustMS:F1}m/s OldVal={previousGust:F1}m/s - Wind: NewVal={windAvgMS:F1}m/s OldVal={previousWind:F1}m/s";
 				cumulus.SpikeAlarm.Triggered = true;
 				return;
 			}

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -3944,6 +3944,27 @@ namespace CumulusMX
 			return "0";
 		}
 
+		private string TagMySqlUploadAlarm(Dictionary<string, string> tagParams)
+		{
+			if (cumulus.MySqlUploadAlarm.Enabled)
+			{
+				return cumulus.MySqlUploadAlarm.Triggered ? "1" : "0";
+			}
+
+			return "0";
+		}
+
+		private string TagHttpUploadAlarm(Dictionary<string, string> tagParams)
+		{
+			if (cumulus.HttpUploadAlarm.Enabled)
+			{
+				return cumulus.HttpUploadAlarm.Triggered ? "1" : "0";
+			}
+
+			return "0";
+		}
+
+
 		// Monthly highs and lows - values
 		private string TagMonthTempH(Dictionary<string,string> tagParams)
 		{
@@ -5586,6 +5607,7 @@ namespace CumulusMX
 				{ "LeafWetness6", TagLeafWetness6 },
 				{ "LeafWetness7", TagLeafWetness7 },
 				{ "LeafWetness8", TagLeafWetness8 },
+
 				{ "LowTempAlarm", TagLowTempAlarm },
 				{ "HighTempAlarm", TagHighTempAlarm },
 				{ "TempChangeUpAlarm", TagTempChangeUpAlarm },
@@ -5600,7 +5622,10 @@ namespace CumulusMX
 				{ "HighWindSpeedAlarm", TagHighWindSpeedAlarm },
 				{ "BatteryLowAlarm", TagBatteryLowAlarm },
 				{ "DataSpikeAlarm", TagDataSpikeAlarm },
+				{ "MySqlUploadAlarm", TagMySqlUploadAlarm },
+				{ "HttpUploadAlarm", TagHttpUploadAlarm },
 				{ "UpgradeAlarm", TagUpgradeAlarm },
+
 				{ "RG11RainToday", TagRg11RainToday },
 				{ "RG11RainYest", TagRg11RainYest },
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -16,7 +16,8 @@
 	- Calibration Settings
 	- NOAA Settings
 	- MySQL Settings
-
+- Change: If any of the base units (wind, temp, rain, pressure) are changed via Station Settings (for instance during the initial configuration), then all the
+	thresholds and base values associated with that unit are reset back to the defaults for the new unit
 
 3.11.1 - b3130
 ——————————————

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,20 @@
 3.11.2 - b3131
 ——————————————
 - Fix: Send email failing if email logging is not enabled
+- Fix: Solar Rad colour now displays as selected on first load in the Selectachart on the dashboard and default website
+- Fix: Handlebars JS script updated due to severe security risk on previous version
+
+- Change: Setting of ALL logging options via the GUI is now "sticky" - i.e. preserved across runs of Cumulus MX
+- Change: Many of the main settings screens now alert to to the first invalid settings in a message, and the tree containing
+	the error is highlighted in red:
+	- Program Settings
+	- Station Settings
+	- Internet Settings
+	- Third Party Settings
+	- Extra Sensor Settings
+	- Calibration Settings
+	- NOAA Settings
+	- MySQL Settings
 
 
 3.11.1 - b3130

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,6 +3,7 @@
 - Fix: Send email failing if email logging is not enabled
 - Fix: Solar Rad colour now displays as selected on first load in the Selectachart on the dashboard and default website
 - Fix: Handlebars JS script updated due to severe security risk on previous version
+- Fix: GW1000 for 433, 868, 915 Mhz variants
 
 - Change: Setting of ALL logging options via the GUI is now "sticky" - i.e. preserved across runs of Cumulus MX
 - Change: Many of the main settings screens now alert to to the first invalid settings in a message, and the tree containing

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,8 @@
+3.11.2 - b3131
+——————————————
+- Fix: Send email failing if email logging is not enabled
+
+
 3.11.1 - b3130
 ——————————————
 - Fix: Fix Test email logging "success" on failure

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,7 +3,9 @@
 - Fix: Send email failing if email logging is not enabled
 - Fix: Solar Rad colour now displays as selected on first load in the Selectachart on the dashboard and default website
 - Fix: Handlebars JS script updated due to severe security risk on previous version
-- Fix: GW1000 for 433, 868, 915 Mhz variants
+- Fix: GW1000 for 433, 868, 915 MHz variants
+- Fix: Bug in MySQL catch-up
+
 
 - Change: Setting of ALL logging options via the GUI is now "sticky" - i.e. preserved across runs of Cumulus MX
 - Change: Many of the main settings screens now alert to to the first invalid settings in a message, and the tree containing
@@ -19,9 +21,25 @@
 - Change: If any of the base units (wind, temp, rain, pressure) are changed via Station Settings (for instance during the initial configuration), then all the
 	thresholds and base values associated with that unit are reset to the defaults for the new unit
 - Change: The main dashboard page now only shows alarm indicators for enabled alarms
+- Change: Alarm Settings page now has added screen reader attributes (not visible on the page)
+- Change: All HighCharts based pages (Dashboard and default web site) now use the latest stable release of HighCharts
 
 - New: Implements two new alarms for HTTP uploads failing, and MySQL uploads failing
+	- These plus Data Spike, have an additional setting via Cumulus.ini (for now) to set a trigger threshold.
+	  This defaults to 1, so the alarm will trigger immediately. If set to 5, then it will take 5 trigger events happen within the Latch time to set the alarm.
+	  The idea is to prevent an occasional error from triggering the alarm
+	  Cumulus.ini settings:
+		[Alarms]
+		SpikeAlarmTriggerCount=1
+		HttpUploadAlarmTriggerCount=1
+		MySqlUploadAlarmTriggerCount=1
 - New: Web tags - <#HttpUploadAlarm>, <#MySqlUploadAlarm>
+- New: Data Stopped, Data Spike,HTTP upload, MySQL upload emails now also report the error that triggered the alarm in the email text
+- New: Adds two new variables for Extra Web Files - <noaayearfile> & <noaamonthfile> to upload the last year and month reports. Like the day file variable
+	it only makes sense to use these with the EOD option
+- New: You can now limit the real time MySQL table inserts to once a minute. Useful if you run a short real time interval (say 5 seconds), and do not want to
+	flood your MySQL real time table with many rows that hardly change.
+
 
 
 3.11.1 - b3130

--- a/Updates.txt
+++ b/Updates.txt
@@ -17,7 +17,12 @@
 	- NOAA Settings
 	- MySQL Settings
 - Change: If any of the base units (wind, temp, rain, pressure) are changed via Station Settings (for instance during the initial configuration), then all the
-	thresholds and base values associated with that unit are reset back to the defaults for the new unit
+	thresholds and base values associated with that unit are reset to the defaults for the new unit
+- Change: The main dashboard page now only shows alarm indicators for enabled alarms
+
+- New: Implements two new alarms for HTTP uploads failing, and MySQL uploads failing
+- New: Web tags - <#HttpUploadAlarm>, <#MySqlUploadAlarm>
+
 
 3.11.1 - b3130
 ——————————————


### PR DESCRIPTION
- Fix: Send email failing if email logging is not enabled
- Fix: Solar Rad colour now displays as selected on first load in the Selectachart on the dashboard and default website
- Fix: Handlebars JS script updated due to severe security risk on previous version
- Fix: GW1000 for 433, 868, 915 MHz variants
- Fix: Bug in MySQL catch-up

- Change: Setting of ALL logging options via the GUI is now "sticky" - i.e. preserved across runs of Cumulus MX
- Change: Many of the main settings screens now alert to to the first invalid settings in a message, and the tree containing the error is highlighted in red
- Change: If any of the base units (wind, temp, rain, pressure) are changed via Station Settings (for instance during the initial configuration), then all the thresholds and base values associated with that unit are reset to the defaults for the new unit
- Change: The main dashboard page now only shows alarm indicators for enabled alarms
- Change: Alarm Settings page now has added screen reader attributes (not visible on the page)
- Change: All HighCharts based pages (Dashboard and default web site) now use the latest stable release of HighCharts

- New: Implements two new alarms for HTTP uploads failing, and MySQL uploads failing
- New: Web tags - <#HttpUploadAlarm>, <#MySqlUploadAlarm>
- New: Data Stopped, Data Spike,HTTP upload, MySQL upload emails now also report the error that triggered the alarm in the email text
- New: Adds two new variables for Extra Web Files - <noaayearfile> & <noaamonthfile> to upload the last year and month reports. Like the day file variable it only makes sense to use these with the EOD option
- New: You can now limit the real time MySQL table inserts to once a minute. Useful if you run a short real time interval (say 5 seconds), and do not want to flood your MySQL real time table with many rows that hardly change.

