### PR TITLE
v3.13.1

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1030,32 +1030,48 @@ namespace CumulusMX
 			ReadIniFile();
 
 			// Do we prevent more than one copy of CumulusMX running?
-			if (ProgramOptions.WarnMultiple)
+			try
 			{
-				try
+				if (!Program.appMutex.WaitOne(0, false))
 				{
-					if (!Program.appMutex.WaitOne(0, false))
+					if (ProgramOptions.WarnMultiple)
 					{
 						LogConsoleMessage("Cumulus is already running - terminating");
 						LogConsoleMessage("Program exit");
-						LogMessage("Stop second instance: Cumulus is already running and 'Stop second instance is enabled' - terminating");
+						LogMessage("Stop second instance: Cumulus is already running and 'Stop second instance' is enabled - terminating");
 						LogMessage("Stop second instance: Program exit");
 						Program.exitSystem = true;
 						return;
 					}
+					else
+					{
+						LogConsoleMessage("Cumulus is already running - but 'Stop second instance' is disabled");
+						LogMessage("Stop second instance: Cumulus is already running but 'Stop second instance' is disabled - continuing");
+					}
 				}
-				catch (AbandonedMutexException)
+				else
 				{
-					LogMessage("Stop second instance: Abandoned Mutex Error!");
-					LogMessage("Stop second instance: Was a previous copy of Cumulus terminated from task manager, or otherwise forcibly stopped?");
-					LogMessage("Stop second instance: Continuing this instance of Cumulus");
+					LogMessage("Stop second instance: No other running instances of Cumulus found");
 				}
-				catch (Exception ex)
+			}
+			catch (AbandonedMutexException)
+			{
+				LogMessage("Stop second instance: Abandoned Mutex Error!");
+				LogMessage("Stop second instance: Was a previous copy of Cumulus terminated from task manager, or otherwise forcibly stopped?");
+				LogMessage("Stop second instance: Continuing this instance of Cumulus");
+			}
+			catch (Exception ex)
+			{
+				LogMessage("Stop second instance: Mutex Error! - " + ex);
+				if (ProgramOptions.WarnMultiple)
 				{
-					LogMessage("Stop second instance: Mutex Error! - " + ex);
 					LogMessage("Stop second instance: Terminating this instance of Cumulus");
 					Program.exitSystem = true;
 					return;
+				}
+				else
+				{
+					LogMessage("Stop second instance: 'Stop second instance' is disabled - continuing this instance of Cumulus");
 				}
 			}
 
@@ -6899,11 +6915,10 @@ namespace CumulusMX
 				sb.Append(station.AirQualityAvg3.ToString("F1") + ListSeparator);  //74
 				sb.Append(station.AirQualityAvg4.ToString("F1") + ListSeparator);  //75
 
-				for (int i = 1; i < 8; i++)
+				for (int i = 1; i < 9; i++)
 				{
-					sb.Append(station.UserTemp[i].ToString(TempFormat) + ListSeparator);   //76-82
+					sb.Append(station.UserTemp[i].ToString(TempFormat) + ListSeparator);   //76-83
 				}
-				sb.Append(station.UserTemp[8].ToString(TempFormat) + ListSeparator);       //83
 
 				sb.Append(station.CO2 + ListSeparator);                                    //84
 				sb.Append(station.CO2_24h + ListSeparator);                                //85

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4147,6 +4147,7 @@ namespace CumulusMX
 			EcowittExtraUseSoilTemp = ini.GetValue("GW1000", "ExtraSensorUseSoilTemp", true);
 			EcowittExtraUseSoilMoist = ini.GetValue("GW1000", "ExtraSensorUseSoilMoist", true);
 			EcowittExtraUseLeafWet = ini.GetValue("GW1000", "ExtraSensorUseLeafWet", true);
+			EcowittExtraUseUserTemp = ini.GetValue("GW1000", "ExtraSensorUseUserTemp", true);
 			EcowittExtraUseAQI = ini.GetValue("GW1000", "ExtraSensorUseAQI", true);
 			EcowittExtraUseCo2= ini.GetValue("GW1000", "ExtraSensorUseCo2", true);
 			EcowittExtraUseLightning = ini.GetValue("GW1000", "ExtraSensorUseLightning", true);
@@ -5238,6 +5239,7 @@ namespace CumulusMX
 			ini.SetValue("GW1000", "ExtraSensorUseSoilTemp", EcowittExtraUseSoilTemp);
 			ini.SetValue("GW1000", "ExtraSensorUseSoilMoist", EcowittExtraUseSoilMoist);
 			ini.SetValue("GW1000", "ExtraSensorUseLeafWet", EcowittExtraUseLeafWet);
+			ini.SetValue("GW1000", "ExtraSensorUseUserTemp", EcowittExtraUseUserTemp);
 			ini.SetValue("GW1000", "ExtraSensorUseAQI", EcowittExtraUseAQI);
 			ini.SetValue("GW1000", "ExtraSensorUseCo2", EcowittExtraUseCo2);
 			ini.SetValue("GW1000", "ExtraSensorUseLightning", EcowittExtraUseLightning);
@@ -6204,6 +6206,7 @@ namespace CumulusMX
 		public bool EcowittExtraUseSoilTemp { get; set; }
 		public bool EcowittExtraUseSoilMoist { get; set; }
 		public bool EcowittExtraUseLeafWet { get; set; }
+		public bool EcowittExtraUseUserTemp { get; set; }
 		public bool EcowittExtraUseAQI { get; set; }
 		public bool EcowittExtraUseCo2 { get; set; }
 		public bool EcowittExtraUseLightning { get; set; }

--- a/CumulusMX/ExtraSensorSettings.cs
+++ b/CumulusMX/ExtraSensorSettings.cs
@@ -51,6 +51,7 @@ namespace CumulusMX
 				useSoilTemp = cumulus.EcowittExtraUseSoilTemp,
 				useSoilMoist = cumulus.EcowittExtraUseSoilMoist,
 				useLeafWet = cumulus.EcowittExtraUseLeafWet,
+				useUserTemp = cumulus.EcowittExtraUseUserTemp,
 				useAQI = cumulus.EcowittExtraUseAQI,
 				useCo2 = cumulus.EcowittExtraUseCo2,
 				useLightning = cumulus.EcowittExtraUseLightning,
@@ -229,6 +230,7 @@ namespace CumulusMX
 						cumulus.EcowittExtraUseSoilTemp = settings.httpSensors.ecowitt.useSoilTemp;
 						cumulus.EcowittExtraUseSoilMoist = settings.httpSensors.ecowitt.useSoilMoist;
 						cumulus.EcowittExtraUseLeafWet = settings.httpSensors.ecowitt.useLeafWet;
+						cumulus.EcowittExtraUseUserTemp = settings.httpSensors.ecowitt.useUserTemp;
 						cumulus.EcowittExtraUseAQI = settings.httpSensors.ecowitt.useAQI;
 						cumulus.EcowittExtraUseCo2 = settings.httpSensors.ecowitt.useCo2;
 						cumulus.EcowittExtraUseLightning = settings.httpSensors.ecowitt.useLightning;
@@ -388,6 +390,7 @@ namespace CumulusMX
 		public bool useSoilTemp { get; set; }
 		public bool useSoilMoist { get; set; }
 		public bool useLeafWet { get; set; }
+		public bool useUserTemp { get; set; }
 		public bool useAQI { get; set; }
 		public bool useCo2 { get; set; }
 		public bool useLightning { get; set; }

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -1023,7 +1023,7 @@ namespace CumulusMX
 			{
 				if (data["tf_ch" + i] != null)
 				{
-					station.DoUserTemp(Convert.ToDouble(data["tf_ch" + i], CultureInfo.InvariantCulture), i);
+					station.DoUserTemp(ConvertTempFToUser(Convert.ToDouble(data["tf_ch" + i], CultureInfo.InvariantCulture)), i);
 				}
 			}
 		}
@@ -1062,7 +1062,7 @@ namespace CumulusMX
 
 			if (data["tf_co2"] != null)
 			{
-				station.CO2_temperature = Convert.ToDouble(data["tf_co2"], CultureInfo.InvariantCulture);
+				station.CO2_temperature = ConvertTempFToUser(Convert.ToDouble(data["tf_co2"], CultureInfo.InvariantCulture));
 			}
 			if (data["humi_co2"] != null)
 			{

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -636,7 +636,8 @@ namespace CumulusMX
 			 *
 			POST Parameters - all fields are URL escaped
 
-			PASSKEY=DFD82AD35BF6EC2843920EC477D60648&stationtype=GW1000A_V1.6.8&dateutc=2021-07-23+17:13:34&tempinf=80.6&humidityin=50&baromrelin=29.940&baromabsin=29.081&tempf=81.3&humidity=43&winddir=296&windspeedmph=2.46&windgustmph=4.25&maxdailygust=14.09&solarradiation=226.28&uv=1&rainratein=0.000&eventrainin=0.000&hourlyrainin=0.000&dailyrainin=0.000&weeklyrainin=0.000&monthlyrainin=4.118&yearlyrainin=29.055&totalrainin=29.055&temp1f=83.48&humidity1=39&temp2f=87.98&humidity2=40&temp3f=82.04&humidity3=40&temp4f=93.56&humidity4=34&temp5f=-11.38&temp6f=87.26&humidity6=38&temp7f=45.50&humidity7=40&soilmoisture1=51&soilmoisture2=65&soilmoisture3=72&soilmoisture4=36&soilmoisture5=48&pm25_ch1=11.0&pm25_avg_24h_ch1=10.8&pm25_ch2=13.0&pm25_avg_24h_ch2=15.0&tf_co2=80.8&humi_co2=48&pm25_co2=4.8&pm25_24h_co2=6.1&pm10_co2=4.9&pm10_24h_co2=6.5&co2=493&co2_24h=454&lightning_time=1627039348&lightning_num=3&lightning=24&wh65batt=0&wh80batt=3.06&batt1=0&batt2=0&batt3=0&batt4=0&batt5=0&batt6=0&batt7=0&soilbatt1=1.5&soilbatt2=1.4&soilbatt3=1.5&soilbatt4=1.5&soilbatt5=1.6&pm25batt1=4&pm25batt2=4&wh57batt=4&co2_batt=6&freq=868M&model=GW1000_Pro
+			PASSKEY=<redacted>&stationtype=GW1000A_V1.6.8&dateutc=2021-07-23+17:13:34&tempinf=80.6&humidityin=50&baromrelin=29.940&baromabsin=29.081&tempf=81.3&humidity=43&winddir=296&windspeedmph=2.46&windgustmph=4.25&maxdailygust=14.09&solarradiation=226.28&uv=1&rainratein=0.000&eventrainin=0.000&hourlyrainin=0.000&dailyrainin=0.000&weeklyrainin=0.000&monthlyrainin=4.118&yearlyrainin=29.055&totalrainin=29.055&temp1f=83.48&humidity1=39&temp2f=87.98&humidity2=40&temp3f=82.04&humidity3=40&temp4f=93.56&humidity4=34&temp5f=-11.38&temp6f=87.26&humidity6=38&temp7f=45.50&humidity7=40&soilmoisture1=51&soilmoisture2=65&soilmoisture3=72&soilmoisture4=36&soilmoisture5=48&pm25_ch1=11.0&pm25_avg_24h_ch1=10.8&pm25_ch2=13.0&pm25_avg_24h_ch2=15.0&tf_co2=80.8&humi_co2=48&pm25_co2=4.8&pm25_24h_co2=6.1&pm10_co2=4.9&pm10_24h_co2=6.5&co2=493&co2_24h=454&lightning_time=1627039348&lightning_num=3&lightning=24&wh65batt=0&wh80batt=3.06&batt1=0&batt2=0&batt3=0&batt4=0&batt5=0&batt6=0&batt7=0&soilbatt1=1.5&soilbatt2=1.4&soilbatt3=1.5&soilbatt4=1.5&soilbatt5=1.6&pm25batt1=4&pm25batt2=4&wh57batt=4&co2_batt=6&freq=868M&model=GW1000_Pro
+			PASSKEY=<redacted>&stationtype=GW1100A_V2.0.2&dateutc=2021-09-08+11:58:39&tempinf=80.8&humidityin=42&baromrelin=29.864&baromabsin=29.415&temp1f=87.8&tf_ch1=64.4&batt1=0&tf_batt1=1.48&freq=868M&model=GW1100A
 
 			 */
 
@@ -782,6 +783,20 @@ namespace CumulusMX
 					cumulus.LogMessage("ProcessExtraData: Error in Leaf wetness data - " + ex.Message);
 				}
 
+				// === User Temp (Soil or Water) ===
+				try
+				{
+					// tf_ch[1-8]
+					if (cumulus.EcowittExtraUseUserTemp)
+					{
+						ProcessUserTemp(data, station);
+					}
+				}
+				catch (Exception ex)
+				{
+					cumulus.LogMessage("ProcessExtraData: Error in User Temp (soil or water) data - " + ex.Message);
+				}
+
 
 				// === Air Quality ===
 				try
@@ -872,6 +887,7 @@ namespace CumulusMX
 					soilbatt[1-8] (wh51)
 					pm25batt[1-4] (wh41/wh43)
 					leakbatt[1-4] (wh55)
+					tf_batt[1-8]=1.48 (wn34s/wn34l)
 					*/
 
 					ProcessBatteries(data);
@@ -1001,6 +1017,18 @@ namespace CumulusMX
 
 		}
 
+		private void ProcessUserTemp(NameValueCollection data, WeatherStation station)
+		{
+			for (var i = 1; i <= 8; i++)
+			{
+				if (data["tf_ch" + i] != null)
+				{
+					station.DoUserTemp(Convert.ToDouble(data["tf_ch" + i], CultureInfo.InvariantCulture), i);
+				}
+			}
+		}
+
+
 		private void ProcessAirQuality(NameValueCollection data, WeatherStation station)
 		{
 			// pm25_ch[1-4]
@@ -1125,15 +1153,17 @@ namespace CumulusMX
 			lowBatt = lowBatt || (data["wh80batt"] != null && Convert.ToDouble(data["wh80batt"], CultureInfo.InvariantCulture) <= 1.2);
 			for (var i = 1; i < 5; i++)
 			{
-				lowBatt = lowBatt || (data["batt" + i] != null && data["batt" + i] == "1");
+				lowBatt = lowBatt || (data["batt" + i]     != null && data["batt" + i] == "1");
 				lowBatt = lowBatt || (data["soilbatt" + i] != null && Convert.ToDouble(data["soilbatt" + i], CultureInfo.InvariantCulture) <= 1.2);
 				lowBatt = lowBatt || (data["pm25batt" + i] != null && data["pm25batt" + i] == "1");
 				lowBatt = lowBatt || (data["leakbatt" + i] != null && data["leakbatt" + i] == "1");
+				lowBatt = lowBatt || (data["tf_batt" + i]  != null && Convert.ToDouble(data["tf_batt" + i], CultureInfo.InvariantCulture) <= 1.2);
 			}
 			for (var i = 5; i < 9; i++)
 			{
-				lowBatt = lowBatt || (data["batt" + i] != null && data["batt" + i] == "1");
+				lowBatt = lowBatt || (data["batt" + i]     != null && data["batt" + i] == "1");
 				lowBatt = lowBatt || (data["soilbatt" + i] != null && Convert.ToDouble(data["soilbatt" + i], CultureInfo.InvariantCulture) <= 1.2);
+				lowBatt = lowBatt || (data["tf_batt" + i]  != null && Convert.ToDouble(data["tf_batt" + i], CultureInfo.InvariantCulture) <= 1.2);
 			}
 
 			cumulus.BatteryLowAlarm.Triggered = lowBatt;

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -516,11 +516,11 @@ namespace CumulusMX
 					// tf_co2
 					// humi_co2
 					// pm25_co2
-					// pm25_24_co2
+					// pm25_24h_co2
 					// pm10_co2
 					// pm10_24h_co2
 					// co2
-					// co2_24
+					// co2_24h
 
 					ProcessCo2(data, this);
 				}
@@ -1026,11 +1026,11 @@ namespace CumulusMX
 			// tf_co2
 			// humi_co2
 			// pm25_co2
-			// pm25_24_co2
+			// pm25_24h_co2
 			// pm10_co2
 			// pm10_24h_co2
 			// co2
-			// co2_24
+			// co2_24h
 
 			if (data["tf_co2"] != null)
 			{
@@ -1044,7 +1044,7 @@ namespace CumulusMX
 			{
 				station.CO2_pm2p5 = Convert.ToDouble(data["pm25_co2"], CultureInfo.InvariantCulture);
 			}
-			if (data["pm25_24_co2"] != null)
+			if (data["pm25_24h_co2"] != null)
 			{
 				station.CO2_pm2p5_24h = Convert.ToDouble(data["pm25_24_co2"], CultureInfo.InvariantCulture);
 			}
@@ -1060,7 +1060,7 @@ namespace CumulusMX
 			{
 				station.CO2 = Convert.ToInt32(data["co2"], CultureInfo.InvariantCulture);
 			}
-			if (data["co2_24"] != null)
+			if (data["co2_24h"] != null)
 			{
 				station.CO2_24h = Convert.ToInt32(data["co2"], CultureInfo.InvariantCulture);
 			}

--- a/CumulusMX/MeteoLib.cs
+++ b/CumulusMX/MeteoLib.cs
@@ -330,5 +330,23 @@ namespace CumulusMX
 
 			return hindex - wind;
 		}
+
+
+		public static double GetSeaLevelPressure(double altitudeM, double pressureHpa, double tempC)
+		{
+			/* constants */
+			double i = 287.05;// gas constant for dry air
+			double a = 9.80665;// gravity
+			double r = .0065; //standard atmosphere lapse rate
+			double s = 1013.25;// standard sea level pressure
+			double n = 273.15 + tempC; //288.15; // standard sea level temp;
+
+			double l = a / (i * r);//
+			double c = i * r / a;
+			double u = Math.Pow(1 + Math.Pow(s / pressureHpa, c) * (r * altitudeM / n), l);
+			double d = pressureHpa * u;
+			return d;
+		}
+
 	}
 }

--- a/CumulusMX/NOAASettings.cs
+++ b/CumulusMX/NOAASettings.cs
@@ -198,7 +198,7 @@ namespace CumulusMX
 					cumulus.NOAAconf.RainNorms[4] = settings.normalrain.apr;
 					cumulus.NOAAconf.RainNorms[5] = settings.normalrain.may;
 					cumulus.NOAAconf.RainNorms[6] = settings.normalrain.jun;
-					cumulus.NOAAconf.RainNorms[6] = settings.normalrain.jul;
+					cumulus.NOAAconf.RainNorms[7] = settings.normalrain.jul;
 					cumulus.NOAAconf.RainNorms[8] = settings.normalrain.aug;
 					cumulus.NOAAconf.RainNorms[9] = settings.normalrain.sep;
 					cumulus.NOAAconf.RainNorms[10] = settings.normalrain.oct;

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.13.10 - Build 3145")]
+[assembly: AssemblyDescription("Version 3.13.1 - Build 3146")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13.0.3145")]
-[assembly: AssemblyFileVersion("3.13.0.3145")]
+[assembly: AssemblyVersion("3.13.1.3146")]
+[assembly: AssemblyFileVersion("3.13.1.3146")]

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,10 @@
 3.13.1 - b3146
 ——————————————
 - Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly
+- Fix: AirLink crash when used as a standalone station
+- Fix: NOAA settings normal precipitation value for July being saved as June's value
+
+- Change: On start-up Cumulus now always checks for other running instances and reports if one is found, but only aborts if 'Stop second instance' is enabled
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -5,9 +5,14 @@
 - Fix: NOAA settings normal precipitation value for July being saved as June's value
 
 - New: Ecowitt, adds support for WN34S/WN34L soil/water temperature sensors as User Temps as per GW1000
+- New: The default web site index page now shows the Moon illumination percentage
 
 - Change: On start-up Cumulus now always checks for other running instances and reports if one is found, but only aborts if 'Stop second instance' is enabled
 
+- Summary of Cumulus.ini changes:
+	>> NEW >>
+		[GW1000]
+		ExtraSensorUseUserTemp=1
 
 
 3.13.0 - b3145

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,10 @@
-3.13.0 - b3144
+3.13.1 - b3146
+——————————————
+- Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly
+
+
+
+3.13.0 - b3145
 ——————————————
 - Fix: Realtime FTP, now correctly clears the RT FTP in progress flag
 - Fix: Station Settings, Units, Advanced not being saved correctly

--- a/Updates.txt
+++ b/Updates.txt
@@ -4,6 +4,8 @@
 - Fix: AirLink crash when used as a standalone station
 - Fix: NOAA settings normal precipitation value for July being saved as June's value
 
+- New: Ecowitt, adds support for WN34S/WN34L soil/water temperature sensors as User Temps as per GW1000
+
 - Change: On start-up Cumulus now always checks for other running instances and reports if one is found, but only aborts if 'Stop second instance' is enabled
 
 


### PR DESCRIPTION
- Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly
- Fix: AirLink crash when used as a standalone station
- Fix: NOAA settings normal precipitation value for July being saved as June's value

- New: Ecowitt, adds support for WN34S/WN34L soil/water temperature sensors as User Temps as per GW1000
- New: The default web site index page now shows the Moon illumination percentage

- Change: On start-up Cumulus now always checks for other running instances and reports if one is found, but only aborts if 'Stop second instance' is enabled