### PR TITLE
v3.13.2 support

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -10263,8 +10263,8 @@ namespace CumulusMX
 
 		private void CreateRequiredFolders()
 		{
-			// The required folders are: /backup, /data, /MXdiags
-			var folders = new string[3] { "backup", "data", "MXdiags" };
+			// The required folders are: /backup, /data, /MXdiags, /Reports
+			var folders = new string[4] { "backup", "data", "MXdiags", "Reports"};
 
 			LogMessage("Checking required folders");
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -834,6 +834,10 @@ namespace CumulusMX
 
 			LogMessage(DateTime.Now.ToString("G"));
 
+
+			// Check if all the folders required by CMX exist, if not create them
+			CreateRequiredFolders();
+
 			// find the data folder
 			//datapath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + DirectorySeparator + "Cumulus" + DirectorySeparator;
 
@@ -10238,6 +10242,23 @@ namespace CumulusMX
 			}
 
 			pingReply = e.Reply;
+		}
+
+		private void CreateRequiredFolders()
+		{
+			// The required folders are: /backup, /data, /MXdiags
+			var folders = new string[3] { "backup", "data", "MXdiags" };
+
+			LogMessage("Checking required folders");
+
+			foreach (var folder in folders)
+			{
+				if (!Directory.Exists(folder))
+				{
+					LogMessage("Creating required folder: /" + folder);
+					Directory.CreateDirectory(folder);
+				}
+			}
 		}
 	}
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -10253,10 +10253,25 @@ namespace CumulusMX
 
 			foreach (var folder in folders)
 			{
-				if (!Directory.Exists(folder))
+				try
 				{
-					LogMessage("Creating required folder: /" + folder);
-					Directory.CreateDirectory(folder);
+					if (!Directory.Exists(folder))
+					{
+						LogMessage("Creating required folder: /" + folder);
+						Directory.CreateDirectory(folder);
+					}
+				}
+				catch (UnauthorizedAccessException)
+				{
+					var msg = "Error, no permission to read/create folder: " + folder;
+					LogConsoleMessage(msg);
+					LogErrorMessage(msg);
+				}
+				catch (Exception ex)
+				{
+					var msg = $"Error while attempting to read/create folder: {folder}, error message: {ex.Message}";
+					LogConsoleMessage(msg);
+					LogErrorMessage(msg);
 				}
 			}
 		}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -7139,6 +7139,11 @@ namespace CumulusMX
 			if (!Directory.Exists(dirpath))
 			{
 				LogMessage("BackupData: *** Error - backup folder does not exist - " + dirpath);
+				CreateRequiredFolders();
+				if (!Directory.Exists(dirpath))
+				{
+					return;
+				}
 			}
 			else
 			{
@@ -7148,16 +7153,28 @@ namespace CumulusMX
 
 				while (dirlist.Count > 10)
 				{
-					if (Path.GetFileName(dirlist[0]) == "daily")
+					try
 					{
-						LogMessage("BackupData: *** Error - the backup folder has unexpected contents");
-						break;
+						if (Path.GetFileName(dirlist[0]) == "daily")
+						{
+							LogMessage("BackupData: *** Error - the backup folder has unexpected contents");
+							break;
+						}
+						else
+						{
+							Directory.Delete(dirlist[0], true);
+							dirlist.RemoveAt(0);
+						}
 					}
-					else
+					catch (UnauthorizedAccessException)
 					{
-						Directory.Delete(dirlist[0], true);
-						dirlist.RemoveAt(0);
+						LogErrorMessage("BackupData: Error, no permission to read/delete folder: " + dirlist[0]);
 					}
+					catch (Exception ex)
+					{
+						LogErrorMessage($"BackupData: Error while attempting to read/delete folder: {dirlist[0]}, error message: {ex.Message}");
+					}
+
 				}
 
 				string foldername = timestamp.ToString("yyyyMMddHHmmss");

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -1074,7 +1074,7 @@ namespace CumulusMX
 			}
 			if (data["pm25_24h_co2"] != null)
 			{
-				station.CO2_pm2p5_24h = Convert.ToDouble(data["pm25_24_co2"], CultureInfo.InvariantCulture);
+				station.CO2_pm2p5_24h = Convert.ToDouble(data["pm25_24h_co2"], CultureInfo.InvariantCulture);
 			}
 			if (data["pm10_co2"] != null)
 			{
@@ -1090,7 +1090,7 @@ namespace CumulusMX
 			}
 			if (data["co2_24h"] != null)
 			{
-				station.CO2_24h = Convert.ToInt32(data["co2"], CultureInfo.InvariantCulture);
+				station.CO2_24h = Convert.ToInt32(data["co2_24h"], CultureInfo.InvariantCulture);
 			}
 		}
 

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.13.1 - Build 3146")]
+[assembly: AssemblyDescription("Version 3.13.2 - Build 3147")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13.1.3146")]
-[assembly: AssemblyFileVersion("3.13.1.3146")]
+[assembly: AssemblyVersion("3.13.2.3147")]
+[assembly: AssemblyFileVersion("3.13.2.3147")]

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,11 @@
+3.13.2 - b3147
+——————————————
+- Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly, again!
+
+- Change: The CumulusMX dustribution zip no longer contains the required empty folders /backup, /data, /MXdiags.
+	These folders will now be created on start-up if they are missing
+
+
 3.13.1 - b3146
 ——————————————
 - Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly


### PR DESCRIPTION
Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly, again!
Change: The CumulusMX distribution zip no longer contains the required empty folders /backup, /data, /MXdiags.
	These folders will now be created on start-up if they are missing

