### PR TITLE
v3.13.3

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -2951,6 +2951,7 @@ namespace CumulusMX
 
 				// OK we are reconnected, let the FTP recommence
 				RealtimeFtpReconnecting = false;
+				RealtimeFtpInProgress = false;
 				realtimeFTPRetries = 0;
 				RealtimeCopyInProgress = false;
 				LogMessage("RealtimeReconnect: Realtime FTP now connected to server (tested)");

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -10263,8 +10263,8 @@ namespace CumulusMX
 
 		private void CreateRequiredFolders()
 		{
-			// The required folders are: /backup, /data, /MXdiags, /Reports
-			var folders = new string[4] { "backup", "data", "MXdiags", "Reports"};
+			// The required folders are: /backup, /data, /Reports
+			var folders = new string[3] { "backup", "data", "Reports"};
 
 			LogMessage("Checking required folders");
 

--- a/CumulusMX/Program.cs
+++ b/CumulusMX/Program.cs
@@ -35,6 +35,22 @@ namespace CumulusMX
 				Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
 			}
 
+			try
+			{
+				if (!Directory.Exists("MXdiags"))
+				{
+					Directory.CreateDirectory("MXdiags");
+				}
+			}
+			catch (UnauthorizedAccessException)
+			{
+				Console.WriteLine("Error, no permission to read/create folder /MXdiags");
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine($"Error while attempting to read/create folder /MXdiags, error message: {ex.Message}");
+			}
+
 
 			var logfile = "MXdiags" + Path.DirectorySeparatorChar + "ServiceConsoleLog.txt";
 			var logfileOld = "MXdiags" + Path.DirectorySeparatorChar + "ServiceConsoleLog-Old.txt";

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.13.2 - Build 3147")]
+[assembly: AssemblyDescription("Version 3.13.3 - Build 3148")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13.2.3147")]
-[assembly: AssemblyFileVersion("3.13.2.3147")]
+[assembly: AssemblyVersion("3.13.3.3148")]
+[assembly: AssemblyFileVersion("3.13.3.3148")]

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -3590,9 +3590,8 @@ namespace CumulusMX
 			}
 
 			// Has the rain total in the station been reset?
-			// Or has it incremented by a large value?
 			// raindaystart greater than current total, allow for rounding
-			if (raindaystart - Raincounter > 0.1 || Raincounter - previoustotal > 50)
+			if (raindaystart - Raincounter > 0.1)
 			{
 				if (FirstChanceRainReset)
 				// second consecutive reading with reset value

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,8 +1,14 @@
+3.13.3 - b3148
+——————————————
+- Fix: FineOffset station historic catch-up is now aligned to the correct logger intervals
+
+
+
 3.13.2 - b3147
 ——————————————
 - Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly, again!
 
-- Change: The CumulusMX dustribution zip no longer contains the required empty folders /backup, /data, /MXdiags.
+- Change: The CumulusMX distribution zip no longer contains the required empty folders /backup, /data
 	These folders will now be created on start-up if they are missing
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,7 @@
 3.13.3 - b3148
 ——————————————
 - Fix: FineOffset station historic catch-up is now aligned to the correct logger intervals
+- Fix: Raincounter reset incorrectly detected if CMX restarted on a day that has already had more than 50 mm of rainfall
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,7 +1,8 @@
 3.13.3 - b3148
 ——————————————
 - Fix: FineOffset station historic catch-up is now aligned to the correct logger intervals
-- Fix: Raincounter reset incorrectly detected if CMX restarted on a day that has already had more than 50 mm of rainfall
+- Fix: Raincounter reset incorrectly detected if a day has had more than 50 mm of rainfall
+- Fix: Realtime FTP would not recover after a connection failure
 
 
 


### PR DESCRIPTION
- Fix: FineOffset station historic catch-up is now aligned to the correct logger intervals
- Fix: Raincounter reset incorrectly detected if a day has had more than 50 mm of rainfall
- Fix: Realtime FTP would not recover after a connection failure