### PR TITLE
b3149 - v3.13.4

### DIFF
--- a/CumulusMX/AstroLib.cs
+++ b/CumulusMX/AstroLib.cs
@@ -65,7 +65,7 @@ namespace CumulusMX
 		{
 			DateTime utctime = timestamp.ToUniversalTime();
 
-			CalculateSunPosition(utctime, latitude, longitude, out solarelevation, out _, out _, out _);
+			CalculateSunPosition(utctime, latitude, longitude, out solarelevation, out _);
 			var dEpoch = new DateTime(1990, 1, 1, 0, 0, 0);
 			double erv = CalcSunDistance(utctime, dEpoch);
 
@@ -85,7 +85,7 @@ namespace CumulusMX
 		// http://guideving.blogspot.co.uk/2010/08/sun-position-in-c.html
 
 		public static void CalculateSunPosition(
-			DateTime dateTime, double latitude, double longitude, out double altitude, out double azimuth, out double declination, out double hourAngle)
+			DateTime dateTime, double latitude, double longitude, out double altitude, out double azimuth)
 		{
 			const double Deg2Rad = Math.PI / 180.0;
 			const double Rad2Deg = 180.0 / Math.PI;
@@ -129,11 +129,11 @@ namespace CumulusMX
 				Math.Cos(obliquity) * Math.Sin(elipticalLongitude),
 				Math.Cos(elipticalLongitude));
 
-			declination = Math.Asin(
+			double declination = Math.Asin(
 				Math.Sin(rightAscension) * Math.Sin(obliquity));
 
 			// Horizontal Coordinates
-			hourAngle = CorrectAngle(siderealTime * Deg2Rad) - rightAscension;
+			double hourAngle = CorrectAngle(siderealTime * Deg2Rad) - rightAscension;
 
 			if (hourAngle > Math.PI)
 			{

--- a/CumulusMX/AstroLib.cs
+++ b/CumulusMX/AstroLib.cs
@@ -65,7 +65,7 @@ namespace CumulusMX
 		{
 			DateTime utctime = timestamp.ToUniversalTime();
 
-			CalculateSunPosition(utctime, latitude, longitude, out solarelevation, out _);
+			CalculateSunPosition(utctime, latitude, longitude, out solarelevation, out _, out _, out _);
 			var dEpoch = new DateTime(1990, 1, 1, 0, 0, 0);
 			double erv = CalcSunDistance(utctime, dEpoch);
 
@@ -84,8 +84,8 @@ namespace CumulusMX
 
 		// http://guideving.blogspot.co.uk/2010/08/sun-position-in-c.html
 
-		private static void CalculateSunPosition(
-			DateTime dateTime, double latitude, double longitude, out double altitude, out double azimuth)
+		public static void CalculateSunPosition(
+			DateTime dateTime, double latitude, double longitude, out double altitude, out double azimuth, out double declination, out double hourAngle)
 		{
 			const double Deg2Rad = Math.PI / 180.0;
 			const double Rad2Deg = 180.0 / Math.PI;
@@ -129,11 +129,11 @@ namespace CumulusMX
 				Math.Cos(obliquity) * Math.Sin(elipticalLongitude),
 				Math.Cos(elipticalLongitude));
 
-			double declination = Math.Asin(
+			declination = Math.Asin(
 				Math.Sin(rightAscension) * Math.Sin(obliquity));
 
 			// Horizontal Coordinates
-			double hourAngle = CorrectAngle(siderealTime * Deg2Rad) - rightAscension;
+			hourAngle = CorrectAngle(siderealTime * Deg2Rad) - rightAscension;
 
 			if (hourAngle > Math.PI)
 			{

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -3298,18 +3298,18 @@ namespace CumulusMX
 						updt.Append($"TotRainFall={station.DayFile[lineNum].TotalRain.ToString(cumulus.RainFormat, InvC)},");
 						updt.Append($"AvgTemp={station.DayFile[lineNum].AvgTemp.ToString(cumulus.TempFormat, InvC)},");
 						updt.Append($"TotWindRun={station.DayFile[lineNum].WindRun.ToString("F1", InvC)},");
-						updt.Append($"HighAvgWSpeed{station.DayFile[lineNum].HighAvgWind.ToString(cumulus.WindAvgFormat, InvC)},");
+						updt.Append($"HighAvgWSpeed={station.DayFile[lineNum].HighAvgWind.ToString(cumulus.WindAvgFormat, InvC)},");
 						updt.Append($"THAvgWSpeed={station.DayFile[lineNum].HighAvgWindTime:\\'HH:mm\\'},");
 						updt.Append($"LowHum={station.DayFile[lineNum].LowHumidity},");
 						updt.Append($"TLowHum={station.DayFile[lineNum].LowHumidityTime:\\'HH:mm\\'},");
 						updt.Append($"HighHum={station.DayFile[lineNum].HighHumidity},");
-						updt.Append($"THighHum{station.DayFile[lineNum].HighHumidityTime:\\'HH:mm\\'},");
-						updt.Append($"TotalEvap{station.DayFile[lineNum].ET.ToString(cumulus.ETFormat, InvC)},");
+						updt.Append($"THighHum={station.DayFile[lineNum].HighHumidityTime:\\'HH:mm\\'},");
+						updt.Append($"TotalEvap={station.DayFile[lineNum].ET.ToString(cumulus.ETFormat, InvC)},");
 						updt.Append($"HoursSun={station.DayFile[lineNum].SunShineHours.ToString(cumulus.SunFormat, InvC)},");
 						updt.Append($"HighHeatInd={station.DayFile[lineNum].HighHeatIndex.ToString(cumulus.TempFormat, InvC)},");
 						updt.Append($"THighHeatInd={station.DayFile[lineNum].HighHeatIndexTime:\\'HH:mm\\'},");
 						updt.Append($"HighAppTemp={station.DayFile[lineNum].HighAppTemp.ToString(cumulus.TempFormat, InvC)},");
-						updt.Append($"THighAppTemp{station.DayFile[lineNum].HighAppTempTime:\\'HH:mm\\'},");
+						updt.Append($"THighAppTemp={station.DayFile[lineNum].HighAppTempTime:\\'HH:mm\\'},");
 						updt.Append($"LowAppTemp={station.DayFile[lineNum].LowAppTemp.ToString(cumulus.TempFormat, InvC)},");
 						updt.Append($"TLowAppTemp={station.DayFile[lineNum].LowAppTempTime:\\'HH:mm\\'},");
 						updt.Append($"HighHourRain={station.DayFile[lineNum].HighHourlyRain.ToString(cumulus.RainFormat, InvC)},");
@@ -3328,7 +3328,7 @@ namespace CumulusMX
 						updt.Append($"HighUV={station.DayFile[lineNum].HighUv.ToString(cumulus.UVFormat, InvC)},");
 						updt.Append($"THighUV={station.DayFile[lineNum].HighUvTime:\\'HH:mm\\'},");
 						updt.Append($"HWindGBearSym='{station.CompassPoint(station.DayFile[lineNum].HighGustBearing)}',");
-						updt.Append($"HWindGBearSym={station.CompassPoint(station.DayFile[lineNum].DominantWindBearing)}',");
+						updt.Append($"DomWindDirSym='{station.CompassPoint(station.DayFile[lineNum].DominantWindBearing)}',");
 						updt.Append($"MaxFeelsLike={station.DayFile[lineNum].HighFeelsLike.ToString(cumulus.TempFormat, InvC)},");
 						updt.Append($"TMaxFeelsLike={station.DayFile[lineNum].HighFeelsLikeTime:\\'HH:mm\\'},");
 						updt.Append($"MinFeelsLike={station.DayFile[lineNum].LowFeelsLike.ToString(cumulus.TempFormat, InvC)},");
@@ -3336,7 +3336,7 @@ namespace CumulusMX
 						updt.Append($"MaxHumidex={station.DayFile[lineNum].HighHumidex.ToString(cumulus.TempFormat, InvC)},");
 						updt.Append($"TMaxHumidex={station.DayFile[lineNum].HighFeelsLikeTime:\\'HH:mm\\'} ");
 
-						updt.Append($"WHERE LogDate={station.DayFile[lineNum].Date:yy-MM-dd};");
+						updt.Append($"WHERE LogDate='{station.DayFile[lineNum].Date:yyyy-MM-dd}';");
 						updateStr = updt.ToString();
 
 						cumulus.MySqlCommandSync(updateStr, "EditDayFile");

--- a/CumulusMX/DavisAirLink.cs
+++ b/CumulusMX/DavisAirLink.cs
@@ -101,6 +101,10 @@ namespace CumulusMX
 				var hostname = indoor ? cumulus.AirLinkInHostName : cumulus.AirLinkOutHostName;
 				string msg;
 
+				int numOfAirLinks = 0;
+				if (cumulus.AirLinkInEnabled) numOfAirLinks++;
+				if (cumulus.AirLinkOutEnabled) numOfAirLinks++;
+
 				if (discovered.IP.Count == 0)
 				{
 					// We didn't find anything on the network
@@ -108,7 +112,7 @@ namespace CumulusMX
 					cumulus.LogMessage("ZeroConf Service: " + msg);
 					cumulus.LogConsoleMessage(msg);
 				}
-				else if (discovered.IP.Count == 1 && (string.IsNullOrEmpty(hostname) || discovered.Hostname[0] == hostname))
+				else if (discovered.IP.Count == 1 && (string.IsNullOrEmpty(hostname) || discovered.Hostname[0] == hostname) && numOfAirLinks == 1)
 				{
 					var writeConfig = false;
 
@@ -195,7 +199,7 @@ namespace CumulusMX
 				{
 					// Multiple devices discovered, and we do not have a clue!
 					string list = "";
-					msg = "*** Discovered more than one potential AirLink device.";
+					msg = "*** Discovered one or more potential AirLink devices.";
 					cumulus.LogMessage("ZeroConf Service: " + msg);
 					cumulus.LogConsoleMessage(msg);
 					msg = "*** Please select the Host name/IP address from the list and enter it manually into the configuration";
@@ -212,8 +216,10 @@ namespace CumulusMX
 			}
 			else
 			{
-				cumulus.LogMessage($"ZeroConf Service: Auto discovery is disabled");
+				cumulus.LogMessage($"ZeroConf Service: AirLink auto-discovery is disabled");
 			}
+
+			cumulus.LogMessage($"Davis AirLink ({locationStr}) - using IP address {(indoor ? cumulus.AirLinkInIPAddr : cumulus.AirLinkOutIPAddr)}");
 
 			wlHttpClient.Timeout = TimeSpan.FromSeconds(20); // 20 seconds for internet queries
 			dogsBodyClient.Timeout = TimeSpan.FromSeconds(10); // 10 seconds for local queries

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -40,9 +40,10 @@ namespace CumulusMX
 
 		public DavisStation(Cumulus cumulus) : base(cumulus)
 		{
-			cumulus.Manufacturer = cumulus.DAVIS;
-
 			calculaterainrate = false;
+
+			// VP2 does not provide pressure trend strings
+			cumulus.StationOptions.UseCumulusPresstrendstr = true;
 
 			isSerial = (cumulus.DavisOptions.ConnectionType == 0);
 
@@ -1535,9 +1536,6 @@ namespace CumulusMX
 					cumulus.LogDebugMessage($"LOOP: Ignoring pressure data. Pressure={loopData.Pressure} inHg.");
 				}
 
-
-				DoPressTrend("Pressure trend");
-
 				double wind = ConvertWindMPHToUser(loopData.CurrentWindSpeed);
 				double avgwind = ConvertWindMPHToUser(loopData.AvgWindSpeed);
 
@@ -2507,9 +2505,17 @@ namespace CumulusMX
 									SunshineHours += (interval / 60.0);
 							}
 
-							if ((archiveData.ET >= 0) && (archiveData.ET < 32000))
+							if (cumulus.StationOptions.CalculatedET && timestamp.Minute == 0)
 							{
-								DoET(ConvertRainINToUser(archiveData.ET) + AnnualETTotal, timestamp);
+								// Start of a new hour, and we want to calculate ET in Cumulus
+								CalculateEvaoptranspiration(timestamp);
+							}
+							else
+							{
+								if ((archiveData.ET >= 0) && (archiveData.ET < 32000))
+								{
+									DoET(ConvertRainINToUser(archiveData.ET) + AnnualETTotal, timestamp);
+								}
 							}
 
 							if (cumulus.StationOptions.LogExtraSensors)

--- a/CumulusMX/EasyWeather.cs
+++ b/CumulusMX/EasyWeather.cs
@@ -4,262 +4,274 @@ using System.Timers;
 
 namespace CumulusMX
 {
-    /*
-     * EasyWeather.dat file format (* indicates fields used by Cumulus)
-     * 1    Record number       int
-     * 2    Transfer Date       yyyy-mmm-dd hh:mm:ss
-     * 3*   Reading Date        yyyy-mmm-dd hh:mm:ss
-     * 4    Reading interval    int     (minutes since previous reading)
-     * 5*   Indoor humidity     int
-     * 6*   Indoor temp         float   Celsius
-     * 7*   Outdoor humidity    int
-     * 8*   Outdoor temp        float   Celsius
-     * 9*   Dew point           float   Celsius
-     * 10*  Wind chill          float   Celsius
-     * 11   Absolute press      float   mB/hPa
-     * 12*  Relative press      float   mB/hPa
-     * 13*  Wind average        float   m/s
-     * 14   Wind average        int     Beaufort
-     * 15*  Wind gust           float   m/s
-     * 16   Wind gust           int     Beaufort
-     * 17   Wind direction      int     0 - 15. 0 = North, 1 = NNE etc
-     * 18*  Wind direction      str     Oddly ENE appears as NEE, and ESE appears as SEE
-     * 19   Rain ticks          int
-     * 20   Rain total          float   mm
-     * 21   Rain since last     float   mm
-     * 22*  Rain in last hour   float   mm
-     * 23   Rain in last 24h    float   mm
-     * 24   Rain in last 7d     float   mm
-     * 25   Rain in last 30d    float   mm
-     * 26*  Rain total          float   mm
-     * 27*  Light reading       int     Lux
-     * 28*  UV Index            int
-     * 29   Status bit #0       int     0|1
-     * 30   Status bit #1       int     0|1
-     * 31   Status bit #2       int     0|1
-     * 32   Status bit #3       int     0|1
-     * 33   Status bit #4       int     0|1
-     * 34   Status bit #5       int     0|1
-     * 35   Status bit #6       int     0|1 - Outdoor readings invalid = 1
-     * 36   Status bit #7       int     0|1
-     * 37   Data address        6 digit hex
-     * 38   Raw data            16x 2-digit hex
-    */
-    internal class EasyWeather : WeatherStation
-    {
-        private readonly Timer tmrDataRead;
+	/*
+	 * EasyWeather.dat file format (* indicates fields used by Cumulus)
+	 * 1    Record number       int
+	 * 2    Transfer Date       yyyy-mmm-dd hh:mm:ss
+	 * 3*   Reading Date        yyyy-mmm-dd hh:mm:ss
+	 * 4    Reading interval    int     (minutes since previous reading)
+	 * 5*   Indoor humidity     int
+	 * 6*   Indoor temp         float   Celsius
+	 * 7*   Outdoor humidity    int
+	 * 8*   Outdoor temp        float   Celsius
+	 * 9*   Dew point           float   Celsius
+	 * 10*  Wind chill          float   Celsius
+	 * 11   Absolute press      float   mB/hPa
+	 * 12*  Relative press      float   mB/hPa
+	 * 13*  Wind average        float   m/s
+	 * 14   Wind average        int     Beaufort
+	 * 15*  Wind gust           float   m/s
+	 * 16   Wind gust           int     Beaufort
+	 * 17   Wind direction      int     0 - 15. 0 = North, 1 = NNE etc
+	 * 18*  Wind direction      str     Oddly ENE appears as NEE, and ESE appears as SEE
+	 * 19   Rain ticks          int
+	 * 20   Rain total          float   mm
+	 * 21   Rain since last     float   mm
+	 * 22*  Rain in last hour   float   mm
+	 * 23   Rain in last 24h    float   mm
+	 * 24   Rain in last 7d     float   mm
+	 * 25   Rain in last 30d    float   mm
+	 * 26*  Rain total          float   mm
+	 * 27*  Light reading       int     Lux
+	 * 28*  UV Index            int
+	 * 29   Status bit #0       int     0|1
+	 * 30   Status bit #1       int     0|1
+	 * 31   Status bit #2       int     0|1
+	 * 32   Status bit #3       int     0|1
+	 * 33   Status bit #4       int     0|1
+	 * 34   Status bit #5       int     0|1
+	 * 35   Status bit #6       int     0|1 - Outdoor readings invalid = 1
+	 * 36   Status bit #7       int     0|1
+	 * 37   Data address        6 digit hex
+	 * 38   Raw data            16x 2-digit hex
+	*/
+	internal class EasyWeather : WeatherStation
+	{
+		private readonly Timer tmrDataRead;
 
-        private const int EW_READING_DATE = 3;
-        private const int EW_READING_TIME = 4;
-        private const int EW_INDOOR_HUM = 6;
-        private const int EW_INDOOR_TEMP = 7;
-        private const int EW_OUTDOOR_HUM = 8;
-        private const int EW_OUTDOOR_TEMP = 9;
-        private const int EW_DEW_POINT = 10;
-        private const int EW_WIND_CHILL = 11;
-        private const int EW_REL_PRESSURE = 13;
-        private const int EW_AVERAGE_WIND = 14;
-        private const int EW_WIND_GUST = 16;
-        private const int EW_WIND_BEARING_CP = 19;
-        private const int EW_RAIN_LAST_HOUR = 23;
-        private const int EW_RAIN_LAST_YEAR = 27;
-        private const int EW_LIGHT = 28;
-        private const int EW_UV = 29;
+		private const int EW_READING_DATE = 3;
+		private const int EW_READING_TIME = 4;
+		private const int EW_INDOOR_HUM = 6;
+		private const int EW_INDOOR_TEMP = 7;
+		private const int EW_OUTDOOR_HUM = 8;
+		private const int EW_OUTDOOR_TEMP = 9;
+		private const int EW_DEW_POINT = 10;
+		private const int EW_WIND_CHILL = 11;
+		private const int EW_REL_PRESSURE = 13;
+		private const int EW_AVERAGE_WIND = 14;
+		private const int EW_WIND_GUST = 16;
+		private const int EW_WIND_BEARING_CP = 19;
+		private const int EW_RAIN_LAST_HOUR = 23;
+		private const int EW_RAIN_LAST_YEAR = 27;
+		private const int EW_LIGHT = 28;
+		private const int EW_UV = 29;
 
-        private string lastTime = "";
-        private string lastDate = "";
+		private string lastTime = "";
+		private string lastDate = "";
 
-        public EasyWeather(Cumulus cumulus) : base(cumulus)
-        {
-            tmrDataRead = new Timer();
-        }
+		public EasyWeather(Cumulus cumulus) : base(cumulus)
+		{
+			tmrDataRead = new Timer();
 
-        public override void Start()
-        {
-            tmrDataRead.Elapsed += EWGetData;
-            tmrDataRead.Interval = cumulus.EwOptions.Interval*60*1000;
-            tmrDataRead.Enabled = true;
 
-            DoDayResetIfNeeded();
-            DoTrendValues(DateTime.Now);
+		}
 
-            if (File.Exists(cumulus.EwOptions.Filename))
-            {
-                EWGetData(null, null);
-                cumulus.StartTimersAndSensors();
-            }
-        }
+		public override void Start()
+		{
+			tmrDataRead.Elapsed += EWGetData;
+			tmrDataRead.Interval = cumulus.EwOptions.Interval*60*1000;
+			tmrDataRead.Enabled = true;
 
-        public override void Stop()
-        {
-            tmrDataRead.Stop();
-            StopMinuteTimer();
-        }
+			DoDayResetIfNeeded();
+			DoTrendValues(DateTime.Now);
 
-        private void EWGetData(object sender, ElapsedEventArgs elapsedEventArgs)
-        {
-            if (File.Exists(cumulus.EwOptions.Filename))
-            {
-                try
-                {
-                    string line;
-                    using (FileStream fs = new FileStream(cumulus.EwOptions.Filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-                    using (var sr = new StreamReader(fs))
-                    {
-                        do
-                        {
-                            line = sr.ReadLine();
-                        } while (!sr.EndOfStream);
-                        sr.Close();
-                        fs.Close();
-                    }
-                    cumulus.LogDataMessage("Data: " + line);
+			// Easyweather file does not provide pressure trend strings
+			cumulus.StationOptions.UseCumulusPresstrendstr = true;
 
-                    // split string on commas and spaces
-                    char[] charSeparators = { ',', ' ' };
 
-                    var st = line.Split(charSeparators, StringSplitOptions.RemoveEmptyEntries);
+			if (File.Exists(cumulus.EwOptions.Filename))
+			{
+				EWGetData(null, null);
+				cumulus.StartTimersAndSensors();
+			}
+		}
 
-                    string datestr = st[EW_READING_DATE];
-                    string timestr = st[EW_READING_TIME];
+		public override void Stop()
+		{
+			tmrDataRead.Stop();
+			StopMinuteTimer();
+		}
 
-                    DateTime now = DateTime.Now;
+		private void EWGetData(object sender, ElapsedEventArgs elapsedEventArgs)
+		{
+			if (File.Exists(cumulus.EwOptions.Filename))
+			{
+				try
+				{
+					string line;
+					using (FileStream fs = new FileStream(cumulus.EwOptions.Filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+					using (var sr = new StreamReader(fs))
+					{
+						do
+						{
+							line = sr.ReadLine();
+						} while (!sr.EndOfStream);
+						sr.Close();
+						fs.Close();
+					}
+					cumulus.LogDataMessage("Data: " + line);
 
-                    if ((datestr != lastDate) || (timestr != lastTime))
-                    {
-                        lastDate = datestr;
-                        lastTime = timestr;
-                    }
+					// split string on commas and spaces
+					char[] charSeparators = { ',', ' ' };
 
-                    DoWind(ConvertWindMSToUser(GetConvertedValue(st[EW_WIND_GUST])), CPtoBearing(st[EW_WIND_BEARING_CP]), ConvertWindMSToUser(GetConvertedValue(st[EW_AVERAGE_WIND])), now);
+					var st = line.Split(charSeparators, StringSplitOptions.RemoveEmptyEntries);
 
-                    DoWindChill(ConvertTempCToUser(GetConvertedValue(st[EW_WIND_CHILL])), now);
+					string datestr = st[EW_READING_DATE];
+					string timestr = st[EW_READING_TIME];
 
-                    DoIndoorHumidity(Convert.ToInt32(st[EW_INDOOR_HUM]));
+					DateTime now = DateTime.Now;
 
-                    DoOutdoorHumidity(Convert.ToInt32(st[EW_OUTDOOR_HUM]), now);
+					if ((datestr != lastDate) || (timestr != lastTime))
+					{
+						lastDate = datestr;
+						lastTime = timestr;
+					}
 
-                    DoOutdoorDewpoint(ConvertTempCToUser(GetConvertedValue(st[EW_DEW_POINT])), now);
+					DoWind(ConvertWindMSToUser(GetConvertedValue(st[EW_WIND_GUST])), CPtoBearing(st[EW_WIND_BEARING_CP]), ConvertWindMSToUser(GetConvertedValue(st[EW_AVERAGE_WIND])), now);
 
-                    DoPressure(ConvertPressMBToUser(GetConvertedValue(st[EW_REL_PRESSURE])), now);
-                    UpdatePressureTrendString();
+					DoWindChill(ConvertTempCToUser(GetConvertedValue(st[EW_WIND_CHILL])), now);
 
-                    DoIndoorTemp(ConvertTempCToUser(GetConvertedValue(st[EW_INDOOR_TEMP])));
+					DoIndoorHumidity(Convert.ToInt32(st[EW_INDOOR_HUM]));
 
-                    DoOutdoorTemp(ConvertTempCToUser(GetConvertedValue(st[EW_OUTDOOR_TEMP])), now);
+					DoOutdoorHumidity(Convert.ToInt32(st[EW_OUTDOOR_HUM]), now);
 
-                    DoRain(ConvertRainMMToUser(GetConvertedValue(st[EW_RAIN_LAST_YEAR])), // use year as total
-                            ConvertRainMMToUser(GetConvertedValue(st[EW_RAIN_LAST_HOUR])), // use last hour as current rate
-                            now);
+					DoOutdoorDewpoint(ConvertTempCToUser(GetConvertedValue(st[EW_DEW_POINT])), now);
 
-                    DoApparentTemp(now);
-                    DoFeelsLike(now);
-                    DoHumidex(now);
+					DoPressure(ConvertPressMBToUser(GetConvertedValue(st[EW_REL_PRESSURE])), now);
+					UpdatePressureTrendString();
 
-                    DoForecast(string.Empty, false);
+					DoIndoorTemp(ConvertTempCToUser(GetConvertedValue(st[EW_INDOOR_TEMP])));
 
-                    if (cumulus.StationOptions.LogExtraSensors)
-                    {
-                        var lightReading = GetConvertedValue(st[EW_LIGHT]);
+					DoOutdoorTemp(ConvertTempCToUser(GetConvertedValue(st[EW_OUTDOOR_TEMP])), now);
 
-                        if ((lightReading >= 0) && (lightReading <= 300000))
-                        {
-                            DoSolarRad((int)(lightReading * cumulus.LuxToWM2), now);
-                            LightValue = lightReading;
-                        }
+					DoRain(ConvertRainMMToUser(GetConvertedValue(st[EW_RAIN_LAST_YEAR])), // use year as total
+							ConvertRainMMToUser(GetConvertedValue(st[EW_RAIN_LAST_HOUR])), // use last hour as current rate
+							now);
 
-                        var uVreading = GetConvertedValue(st[EW_UV]);
+					DoApparentTemp(now);
+					DoFeelsLike(now);
+					DoHumidex(now);
 
-                        if (uVreading == 255)
-                        {
-                            // ignore
-                        }
-                        else if (uVreading < 0)
-                        {
-                            DoUV(0, now);
-                        }
-                        else if (uVreading > 16)
-                        {
-                            DoUV(16, now);
-                        }
-                        else
-                        {
-                            DoUV(uVreading, now);
-                        }
-                    }
+					DoForecast(string.Empty, false);
 
-                    UpdateStatusPanel(now);
-                    UpdateMQTT();
-                }
-                catch (Exception ex)
-                {
-                    cumulus.LogMessage("Error while processing easyweather file: " + ex.Message);
-                }
-            } else
-            {
-                cumulus.LogDebugMessage("Easyweather file not found");
-            }
-        }
+					if (cumulus.StationOptions.LogExtraSensors)
+					{
+						var lightReading = GetConvertedValue(st[EW_LIGHT]);
 
-        private static int CPtoBearing(string cp)
-        {
-            switch (cp)
-            {
-                case "N":
-                    return 360;
-                case "NNE":
-                    return 22;
-                case "NE":
-                    return 45;
-                case "NEE":
-                    return 67;
-                case "ENE":
-                    return 67;
-                case "E":
-                    return 90;
-                case "SEE":
-                    return 112;
-                case "EES":
-                    return 112;
-                case "ESE":
-                    return 112;
-                case "SE":
-                    return 135;
-                case "SSE":
-                    return 157;
-                case "S":
-                    return 180;
-                case "SSW":
-                    return 202;
-                case "SW":
-                    return 225;
-                case "SWW":
-                    return 247;
-                case "WSW":
-                    return 247;
-                case "W":
-                    return 270;
-                case "NWW":
-                    return 292;
-                case "WNW":
-                    return 292;
-                case "NW":
-                    return 315;
-                case "NNW":
-                    return 337;
-                default:
-                    return 0;
-            }
-        }
+						if ((lightReading >= 0) && (lightReading <= 300000))
+						{
+							DoSolarRad((int)(lightReading * cumulus.LuxToWM2), now);
+							LightValue = lightReading;
+						}
 
-        private string ConvertPeriodToSystemDecimal(string aStr)
-        {
-            return aStr.Replace(".", cumulus.DecimalSeparator);
-        }
+						var uVreading = GetConvertedValue(st[EW_UV]);
 
-        private double GetConvertedValue(string aStr)
-        {
-            return Convert.ToDouble(ConvertPeriodToSystemDecimal(aStr));
-        }
-    }
+						if (uVreading == 255)
+						{
+							// ignore
+						}
+						else if (uVreading < 0)
+						{
+							DoUV(0, now);
+						}
+						else if (uVreading > 16)
+						{
+							DoUV(16, now);
+						}
+						else
+						{
+							DoUV(uVreading, now);
+						}
+					}
+
+					if (cumulus.StationOptions.CalculatedET && now.Minute == 0)
+					{
+						// Start of a new hour, and we want to calculate ET in Cumulus
+						CalculateEvaoptranspiration(now);
+					}
+
+					UpdateStatusPanel(now);
+					UpdateMQTT();
+				}
+				catch (Exception ex)
+				{
+					cumulus.LogMessage("Error while processing easyweather file: " + ex.Message);
+				}
+			} else
+			{
+				cumulus.LogDebugMessage("Easyweather file not found");
+			}
+		}
+
+		private static int CPtoBearing(string cp)
+		{
+			switch (cp)
+			{
+				case "N":
+					return 360;
+				case "NNE":
+					return 22;
+				case "NE":
+					return 45;
+				case "NEE":
+					return 67;
+				case "ENE":
+					return 67;
+				case "E":
+					return 90;
+				case "SEE":
+					return 112;
+				case "EES":
+					return 112;
+				case "ESE":
+					return 112;
+				case "SE":
+					return 135;
+				case "SSE":
+					return 157;
+				case "S":
+					return 180;
+				case "SSW":
+					return 202;
+				case "SW":
+					return 225;
+				case "SWW":
+					return 247;
+				case "WSW":
+					return 247;
+				case "W":
+					return 270;
+				case "NWW":
+					return 292;
+				case "WNW":
+					return 292;
+				case "NW":
+					return 315;
+				case "NNW":
+					return 337;
+				default:
+					return 0;
+			}
+		}
+
+		private string ConvertPeriodToSystemDecimal(string aStr)
+		{
+			return aStr.Replace(".", cumulus.DecimalSeparator);
+		}
+
+		private double GetConvertedValue(string aStr)
+		{
+			return Convert.ToDouble(ConvertPeriodToSystemDecimal(aStr));
+		}
+	}
 }

--- a/CumulusMX/ExtraSensorSettings.cs
+++ b/CumulusMX/ExtraSensorSettings.cs
@@ -236,8 +236,11 @@ namespace CumulusMX
 						cumulus.EcowittExtraUseLightning = settings.httpSensors.ecowitt.useLightning;
 						cumulus.EcowittExtraUseLeak = settings.httpSensors.ecowitt.useLeak;
 
-						// Also enable extra logging
-						cumulus.StationOptions.LogExtraSensors = true;
+						// Also enable extra logging if applicable
+						if (cumulus.EcowittExtraUseTempHum || cumulus.EcowittExtraUseSoilTemp || cumulus.EcowittExtraUseSoilMoist || cumulus.EcowittExtraUseLeafWet || cumulus.EcowittExtraUseUserTemp || cumulus.EcowittExtraUseAQI || cumulus.EcowittExtraUseCo2)
+						{
+							cumulus.StationOptions.LogExtraSensors = true;
+						}
 					}
 					else
 						cumulus.EcowittExtraEnabled = false;
@@ -267,8 +270,11 @@ namespace CumulusMX
 						cumulus.AmbientExtraUseLightning = settings.httpSensors.ambient.useLightning;
 						cumulus.AmbientExtraUseLeak = settings.httpSensors.ambient.useLeak;
 
-						// Also enable extra logging
-						cumulus.StationOptions.LogExtraSensors = true;
+						// Also enable extra logging if applicable
+						if (cumulus.AmbientExtraUseTempHum || cumulus.AmbientExtraUseSoilTemp || cumulus.AmbientExtraUseSoilMoist || cumulus.AmbientExtraUseAQI || cumulus.AmbientExtraUseCo2)
+						{
+							cumulus.StationOptions.LogExtraSensors = true;
+						}
 					}
 					else
 						cumulus.AmbientExtraEnabled = false;

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -46,7 +46,6 @@ namespace CumulusMX
 
 		internal FOStation(Cumulus cumulus) : base(cumulus)
 		{
-			cumulus.Manufacturer = cumulus.EW;
 			var data = new byte[32];
 
 			tmrDataRead = new Timer();
@@ -579,6 +578,13 @@ namespace CumulusMX
 				AddRecentDataWithAq(timestamp, WindAverage, RecentMaxGust, WindLatest, Bearing, AvgBearing, OutdoorTemperature, WindChill, OutdoorDewpoint, HeatIndex,
 					OutdoorHumidity, Pressure, RainToday, SolarRad, UV, Raincounter, FeelsLike, Humidex, ApparentTemperature, IndoorTemperature, IndoorHumidity, CurrentSolarMax, RainRate);
 				DoTrendValues(timestamp);
+
+				if (cumulus.StationOptions.CalculatedET && timestamp.Minute == 0)
+				{
+					// Start of a new hour, and we want to calculate ET in Cumulus
+					CalculateEvaoptranspiration(timestamp);
+				}
+
 				UpdatePressureTrendString();
 				UpdateStatusPanel(timestamp);
 				cumulus.AddToWebServiceLists(timestamp);

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -232,7 +232,6 @@ namespace CumulusMX
 		public GW1000Station(Cumulus cumulus) : base(cumulus)
 		{
 
-			cumulus.Manufacturer = cumulus.ECOWITT;
 			cumulus.AirQualityUnitText = "µg/m³";
 			cumulus.SoilMoistureUnitText = "%";
 			// GW1000 does not provide average wind speeds
@@ -246,6 +245,10 @@ namespace CumulusMX
 
 			// GW1000 does not send DP, so force MX to calculate it
 			cumulus.StationOptions.CalculatedDP = true;
+
+			// GW1000 does not provide pressure trend strings
+			cumulus.StationOptions.UseCumulusPresstrendstr = true;
+
 
 			ipaddr = cumulus.Gw1000IpAddress;
 			macaddr = cumulus.Gw1000MacAddress;
@@ -968,7 +971,6 @@ namespace CumulusMX
 							case 0x09: //Relative Barometric (hPa)
 								tempUint16 = ConvertBigEndianUInt16(data, idx);
 								DoPressure(ConvertPressMBToUser(tempUint16 / 10.0), dateTime);
-								DoPressTrend("Pressure trend");
 								idx += 2;
 								break;
 							case 0x0A: //Wind Direction (360°)

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -34,7 +34,6 @@ namespace CumulusMX
 			// Ambient does not send DP, so force MX to calculate it
 			//cumulus.StationOptions.CalculatedDP = true;
 
-			cumulus.Manufacturer = cumulus.AMBIENT;
 			if (station == null || (station != null && cumulus.AmbientExtraUseAQI))
 			{
 				cumulus.AirQualityUnitText = "µg/m³";

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -39,7 +39,6 @@ namespace CumulusMX
 				cumulus.StationOptions.CalculatedWC = true;
 			}
 
-			cumulus.Manufacturer = cumulus.ECOWITT;
 			if (station == null || (station != null && cumulus.EcowittExtraUseAQI))
 			{
 				cumulus.AirQualityUnitText = "µg/m³";
@@ -771,7 +770,7 @@ namespace CumulusMX
 				try
 				{
 					// leafwetness
-					// leafwetness[2-8]
+					// leafwetness_ch[1-8]
 
 					if (cumulus.EcowittExtraUseLeafWet)
 					{
@@ -1007,11 +1006,11 @@ namespace CumulusMX
 				station.DoLeafWetness(Convert.ToDouble(data["leafwetness"], CultureInfo.InvariantCulture), 1);
 			}
 			// Though Ecowitt supports up to 8 sensors, MX only supports the first 4
-			for (var i = 2; i <= 4; i++)
+			for (var i = 1; i <= 4; i++)
 			{
-				if (data["leafwetness" + i] != null)
+				if (data["leafwetness_ch" + i] != null)
 				{
-					station.DoLeafWetness(Convert.ToDouble(data["leafwetness" + i], CultureInfo.InvariantCulture), i - 1);
+					station.DoLeafWetness(Convert.ToDouble(data["leafwetness_ch" + i], CultureInfo.InvariantCulture), i - 1);
 				}
 			}
 
@@ -1158,12 +1157,14 @@ namespace CumulusMX
 				lowBatt = lowBatt || (data["pm25batt" + i] != null && data["pm25batt" + i] == "1");
 				lowBatt = lowBatt || (data["leakbatt" + i] != null && data["leakbatt" + i] == "1");
 				lowBatt = lowBatt || (data["tf_batt" + i]  != null && Convert.ToDouble(data["tf_batt" + i], CultureInfo.InvariantCulture) <= 1.2);
+				lowBatt = lowBatt || (data["leaf_batt" + i] != null && Convert.ToDouble(data["leaf_batt" + i], CultureInfo.InvariantCulture) <= 1.2);
 			}
 			for (var i = 5; i < 9; i++)
 			{
 				lowBatt = lowBatt || (data["batt" + i]     != null && data["batt" + i] == "1");
 				lowBatt = lowBatt || (data["soilbatt" + i] != null && Convert.ToDouble(data["soilbatt" + i], CultureInfo.InvariantCulture) <= 1.2);
 				lowBatt = lowBatt || (data["tf_batt" + i]  != null && Convert.ToDouble(data["tf_batt" + i], CultureInfo.InvariantCulture) <= 1.2);
+				lowBatt = lowBatt || (data["leaf_batt" + i] != null && Convert.ToDouble(data["leaf_batt" + i], CultureInfo.InvariantCulture) <= 1.2);
 			}
 
 			cumulus.BatteryLowAlarm.Triggered = lowBatt;

--- a/CumulusMX/HttpStationWund.cs
+++ b/CumulusMX/HttpStationWund.cs
@@ -14,7 +14,6 @@ namespace CumulusMX
 			cumulus.LogMessage("Starting HTTP Station (Wunderground)");
 
 			cumulus.StationOptions.CalculatedWC = true;
-			cumulus.Manufacturer = cumulus.HTTPSTATION;
 			cumulus.AirQualityUnitText = "µg/m³";
 			cumulus.SoilMoistureUnitText = "%";
 

--- a/CumulusMX/ImetStation.cs
+++ b/CumulusMX/ImetStation.cs
@@ -21,7 +21,6 @@ namespace CumulusMX
 
 		public ImetStation(Cumulus cumulus) : base(cumulus)
 		{
-			cumulus.Manufacturer = cumulus.INSTROMET;
 			cumulus.LogMessage("ImetUpdateLogPointer=" + cumulus.ImetOptions.UpdateLogPointer);
 			cumulus.LogMessage("ImetWaitTime=" + cumulus.ImetOptions.WaitTime);
 			cumulus.LogMessage("ImetReadDelay=" + cumulus.ImetOptions.ReadDelay);
@@ -773,6 +772,13 @@ namespace CumulusMX
 							AddRecentDataEntry(timestamp, WindAverage, RecentMaxGust, WindLatest, Bearing, AvgBearing, OutdoorTemperature, WindChill, OutdoorDewpoint, HeatIndex,
 								OutdoorHumidity, Pressure, RainToday, SolarRad, UV, Raincounter, FeelsLike, Humidex, ApparentTemperature, IndoorTemperature, IndoorHumidity, CurrentSolarMax, RainRate, -1, -1);
 							DoTrendValues(timestamp);
+
+							if (cumulus.StationOptions.CalculatedET && timestamp.Minute == 0)
+							{
+								// Start of a new hour, and we want to calculate ET in Cumulus
+								CalculateEvaoptranspiration(timestamp);
+							}
+
 							UpdatePressureTrendString();
 							UpdateStatusPanel(timestamp);
 

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.13.3 - Build 3148")]
+[assembly: AssemblyDescription("Version 3.13.4 - Build 3149")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.13.3.3148")]
-[assembly: AssemblyFileVersion("3.13.3.3148")]
+[assembly: AssemblyVersion("3.13.4.3149")]
+[assembly: AssemblyFileVersion("3.13.4.3149")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -45,6 +45,7 @@ namespace CumulusMX
 				use100for98hum = cumulus.StationOptions.Humidity98Fix,
 				calculatedewpoint = cumulus.StationOptions.CalculatedDP,
 				calculatewindchill = cumulus.StationOptions.CalculatedWC,
+				calculateet = cumulus.StationOptions.CalculatedET,
 				cumuluspresstrendnames = cumulus.StationOptions.UseCumulusPresstrendstr,
 				extrasensors = cumulus.StationOptions.LogExtraSensors,
 				ignorelacrosseclock = cumulus.StationOptions.WS2300IgnoreStationClock,
@@ -701,6 +702,7 @@ namespace CumulusMX
 					cumulus.StationOptions.Humidity98Fix = settings.Options.use100for98hum;
 					cumulus.StationOptions.CalculatedDP = settings.Options.calculatedewpoint;
 					cumulus.StationOptions.CalculatedWC = settings.Options.calculatewindchill;
+					cumulus.StationOptions.CalculatedET = settings.Options.calculateet;
 					cumulus.StationOptions.UseCumulusPresstrendstr = settings.Options.cumuluspresstrendnames;
 					cumulus.StationOptions.LogExtraSensors = settings.Options.extrasensors;
 					cumulus.StationOptions.WS2300IgnoreStationClock = settings.Options.ignorelacrosseclock;
@@ -1394,6 +1396,7 @@ namespace CumulusMX
 		public bool use100for98hum { get; set; }
 		public bool calculatedewpoint { get; set; }
 		public bool calculatewindchill { get; set; }
+		public bool calculateet { get; set; }
 		public bool cumuluspresstrendnames { get; set; }
 		public bool roundwindspeeds { get; set; }
 		public bool ignorelacrosseclock { get; set; }

--- a/CumulusMX/WS2300Station.cs
+++ b/CumulusMX/WS2300Station.cs
@@ -675,7 +675,7 @@ namespace CumulusMX
 				if (res > ERROR)
 				{
 					DoForecast(forecast, false);
-					DoPressTrend(presstrend);
+					Presstrendstr = presstrend;
 				}
 			}
 

--- a/CumulusMX/WS2300Station.cs
+++ b/CumulusMX/WS2300Station.cs
@@ -675,7 +675,7 @@ namespace CumulusMX
 				if (res > ERROR)
 				{
 					DoForecast(forecast, false);
-					Presstrendstr = presstrend;
+					DoPressTrend(presstrend);
 				}
 			}
 

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -3211,7 +3211,7 @@ namespace CumulusMX
 
 		private string TagEt(Dictionary<string,string> tagParams)
 		{
-			return CheckRcDp(station.ET, tagParams, cumulus.RainDPlaces);
+			return CheckRcDp(station.ET, tagParams, cumulus.RainDPlaces + 1);
 		}
 
 		private string TagLight(Dictionary<string,string> tagParams)

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,9 +1,26 @@
+3.13.4 - b3149
+——————————————
+- Fix: Dayfile editor MySQL update statement failing and knock on effects
+- Fix: Davis AirLink sensors now honours the disabling of auto-discovery, and improve auto-discovery logic
+- Fix: Davis WLL station now honours the disabling of auto-discovery
+- Fix: HTTP Extra sensors were over-riding the station manufacturer causing various side effects
+- Fix: Extra sensor logging is now only automatically enabled for HTTP sensors if the selected sensors are actually logged
+- Fix: HTTP Ecowitt station decode of leaf wetness sensors values and battery data
+
+- New: Adds an estimated evapotranspiration value (ET) for stations that have a solar irradiation sensor and do not already supply this value
+	The only currently supported station provides an ET value are Davis VP2/WLL stations with solar sensors
+	The Cumulus calculation uses the standard grass reference crop
+
+- Change: Instead of 'Cumulus pressure names' being implicitly set internally for Davis stations and having to be explicitly set for some other stations
+	Davis VP2/WLL and some! other stations will now explicitly set this option for you
+
+
+
 3.13.3 - b3148
 ——————————————
 - Fix: FineOffset station historic catch-up is now aligned to the correct logger intervals
 - Fix: Raincounter reset incorrectly detected if a day has had more than 50 mm of rainfall
 - Fix: Realtime FTP would not recover after a connection failure
-
 
 
 3.13.2 - b3147


### PR DESCRIPTION
- Fix: Dayfile editor MySQL update statement failing and knock on effects
- Fix: Davis AirLink sensors now honours the disabling of auto-discovery, and improve auto-discovery logic
- Fix: Davis WLL station now honours the disabling of auto-discovery
- Fix: HTTP Extra sensors were over-riding the station manufacturer causing various side effects
- Fix: Extra sensor logging is now only automatically enabled for HTTP sensors if the selected sensors are actually logged
- Fix: HTTP Ecowitt station decode of leaf wetness sensors values and battery data

- New: Adds an estimated evapotranspiration value (ET) for stations that have a solar irradiation sensor and do not already supply this value
	The only currently supported station provides an ET value are Davis VP2/WLL stations with solar sensors
	The Cumulus calculation uses the standard grass reference crop

- Change: Instead of 'Cumulus pressure names' being implicitly set internally for Davis stations and having to be explicitly set for some other stations
	Davis VP2/WLL and some! other stations will now explicitly set this option for you
