### PR TITLE
v3.14.2 updates

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -427,6 +427,9 @@ namespace CumulusMX
 
 		public string ETFormat;
 
+		internal int LeafWetDPlaces = 0;
+		public string LeafWetFormat = "F0";
+
 		public string ComportName;
 		public string DefaultComportName;
 
@@ -3753,7 +3756,7 @@ namespace CumulusMX
 		{
 			const int maxEntries = 12;
 
-			List<string> fileEntries = new List<string>(Directory.GetFiles(directory).Where(f => System.Text.RegularExpressions.Regex.Match(f, @"\d{8}-\d{6}\.txt").Success));
+			List<string> fileEntries = new List<string>(Directory.GetFiles(directory).Where(f => System.Text.RegularExpressions.Regex.Match(f, @"[\\/]+\d{8}-\d{6}\.txt").Success));
 
 			fileEntries.Sort();
 
@@ -4565,6 +4568,7 @@ namespace CumulusMX
 			WOW.SendUV = ini.GetValue("WOW", "SendUV", false);
 			WOW.SendSolar = ini.GetValue("WOW", "SendSR", false);
 			WOW.SendSoilTemp = ini.GetValue("WOW", "SendSoilTemp", false);
+			WOW.SoilTempSensor = ini.GetValue("WOW", "SoilTempSensor", 1);
 			WOW.CatchUp = ini.GetValue("WOW", "CatchUp", false);
 
 			APRS.ID = ini.GetValue("APRS", "ID", "");
@@ -5528,6 +5532,7 @@ namespace CumulusMX
 			ini.SetValue("WOW", "SendUV", WOW.SendUV);
 			ini.SetValue("WOW", "SendSR", WOW.SendSolar);
 			ini.SetValue("WOW", "SendSoilTemp", WOW.SendSoilTemp);
+			ini.SetValue("WOW", "SoilTempSensor", WOW.SoilTempSensor);
 			ini.SetValue("WOW", "CatchUp", WOW.CatchUp);
 
 			ini.SetValue("APRS", "ID", APRS.ID);
@@ -10843,7 +10848,9 @@ namespace CumulusMX
 		public bool SendIndoor;
 		public bool SendAirQuality;
 		public bool SendSoilTemp;
+		public int SoilTempSensor;
 		public bool SendSoilMoisture;
+		public int SoilMoistureSensor;
 		public bool CatchUp;
 		public bool CatchingUp;
 		public bool Updating;

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4564,6 +4564,7 @@ namespace CumulusMX
 			}
 			WOW.SendUV = ini.GetValue("WOW", "SendUV", false);
 			WOW.SendSolar = ini.GetValue("WOW", "SendSR", false);
+			WOW.SendSoilTemp = ini.GetValue("WOW", "SendSoilTemp", false);
 			WOW.CatchUp = ini.GetValue("WOW", "CatchUp", false);
 
 			APRS.ID = ini.GetValue("APRS", "ID", "");
@@ -5526,6 +5527,7 @@ namespace CumulusMX
 			ini.SetValue("WOW", "Interval", WOW.Interval);
 			ini.SetValue("WOW", "SendUV", WOW.SendUV);
 			ini.SetValue("WOW", "SendSR", WOW.SendSolar);
+			ini.SetValue("WOW", "SendSoilTemp", WOW.SendSoilTemp);
 			ini.SetValue("WOW", "CatchUp", WOW.CatchUp);
 
 			ini.SetValue("APRS", "ID", APRS.ID);
@@ -10840,6 +10842,8 @@ namespace CumulusMX
 		public bool SendSolar;
 		public bool SendIndoor;
 		public bool SendAirQuality;
+		public bool SendSoilTemp;
+		public bool SendSoilMoisture;
 		public bool CatchUp;
 		public bool CatchingUp;
 		public bool Updating;

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -227,12 +227,6 @@ namespace CumulusMX
 
 		private static readonly TraceListener FtpTraceListener = new TextWriterTraceListener("ftplog.txt", "ftplog");
 
-
-		public string AirQualityUnitText = "µg/m³";
-		public string SoilMoistureUnitText = "cb";
-		public string LeafWetnessUnitText = "";  // Davis is unitless, Ecowitt uses %
-		public string CO2UnitText = "ppm";
-
 		public volatile int WebUpdating;
 
 		public double WindRoseAngle { get; set; }
@@ -3921,7 +3915,7 @@ namespace CumulusMX
 			AltitudeInFeet = ini.GetValue("Station", "AltitudeInFeet", false);
 
 			StationOptions.Humidity98Fix = ini.GetValue("Station", "Humidity98Fix", false);
-			StationOptions.UseWind10MinAve = ini.GetValue("Station", "Wind10MinAverage", false);
+			StationOptions.UseWind10MinAvg = ini.GetValue("Station", "Wind10MinAverage", false);
 			StationOptions.UseSpeedForAvgCalc = ini.GetValue("Station", "UseSpeedForAvgCalc", false);
 
 			StationOptions.AvgBearingMinutes = ini.GetValue("Station", "AvgBearingMinutes", 10);
@@ -5141,7 +5135,7 @@ namespace CumulusMX
 			ini.SetValue("Station", "Altitude", Altitude);
 			ini.SetValue("Station", "AltitudeInFeet", AltitudeInFeet);
 			ini.SetValue("Station", "Humidity98Fix", StationOptions.Humidity98Fix);
-			ini.SetValue("Station", "Wind10MinAverage", StationOptions.UseWind10MinAve);
+			ini.SetValue("Station", "Wind10MinAverage", StationOptions.UseWind10MinAvg);
 			ini.SetValue("Station", "UseSpeedForAvgCalc", StationOptions.UseSpeedForAvgCalc);
 			ini.SetValue("Station", "AvgBearingMinutes", StationOptions.AvgBearingMinutes);
 			ini.SetValue("Station", "AvgSpeedMinutes", StationOptions.AvgSpeedMinutes);
@@ -6959,8 +6953,8 @@ namespace CumulusMX
 			sb.Append(station.LeafTemp1.ToString(TempFormat) + ListSeparator);     //40
 			sb.Append(station.LeafTemp2.ToString(TempFormat) + ListSeparator);     //41
 
-			sb.Append(station.LeafWetness1 + ListSeparator);                       //42
-			sb.Append(station.LeafWetness2 + ListSeparator);                       //43
+			sb.Append(station.LeafWetness1.ToString(LeafWetFormat) + ListSeparator);	//42
+			sb.Append(station.LeafWetness2.ToString(LeafWetFormat) + ListSeparator);	//43
 
 			sb.Append(station.SoilTemp5.ToString(TempFormat) + ListSeparator);     //44
 			sb.Append(station.SoilTemp6.ToString(TempFormat) + ListSeparator);     //45
@@ -10542,19 +10536,21 @@ namespace CumulusMX
 		public string AirQualityUnitText { get; set; }
 		public string SoilMoistureUnitText { get; set; }
 		public string CO2UnitText { get; set; }
+		public string LeafWetnessUnitText { get; set; }
 
 		public StationUnits()
 		{
 			AirQualityUnitText = "µg/m³";
 			SoilMoistureUnitText = "cb";
 			CO2UnitText = "ppm";
+			LeafWetnessUnitText = "";  // Davis is unitless, Ecowitt uses %
 		}
 	}
 
 	public class StationOptions
 	{
 		public bool UseZeroBearing { get; set; }
-		public bool UseWind10MinAve { get; set; }
+		public bool UseWind10MinAvg { get; set; }
 		public bool UseSpeedForAvgCalc { get; set; }
 		public bool Humidity98Fix { get; set; }
 		public bool CalculatedDP { get; set; }
@@ -10896,15 +10892,11 @@ namespace CumulusMX
 		public bool RateLimited;
 		public int OriginalInterval;
 		public string Lang;
-		public bool SendSoilTemp;
-		public bool SendSoilMoisture;
 		public bool SendLeafWetness;
 	}
 
 	public class WebUploadWCloud : WebUploadService
 	{
-		public bool SendSoilMoisture;
-		public int SoilMoistureSensor;
 		public bool SendLeafWetness;
 		public int LeafWetnessSensor;
 	}

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -894,9 +894,9 @@ namespace CumulusMX
 			const int loop2count = 1;
 			bool reconnecting = false;
 
-			try
+			while (!stop)
 			{
-				while (!stop)
+				try
 				{
 					if (clockSetNeeded && !stop)
 					{
@@ -1020,27 +1020,35 @@ namespace CumulusMX
 					var recepStats = GetReceptionStats();
 					DecodeReceptionStats(recepStats);
 				}
-			}
-			catch (ThreadAbortException) // Catch the ThreadAbortException
-			{
-			}
-			finally
-			{
-				if (isSerial)
+				catch (ThreadAbortException) // Catch the ThreadAbortException
 				{
-					if (comport != null && comport.IsOpen)
-					{
-						comport.WriteLine("");
-						comport.Close();
-					}
+					cumulus.LogMessage("Davis Start: ThreadAbortException");
+					// and exit
+					stop = true;
 				}
-				else
+				catch (Exception ex)
 				{
-					if (socket != null && socket.Connected)
-					{
-						socket.GetStream().WriteByte(10);
-						socket.Close();
-					}
+					// any others, log them and carry on
+					cumulus.LogMessage("Davis Start: Exception - " + ex.Message);
+				}
+			}
+
+			cumulus.LogMessage("Ending normal reading loop");
+
+			if (isSerial)
+			{
+				if (comport != null && comport.IsOpen)
+				{
+					comport.WriteLine("");
+					comport.Close();
+				}
+			}
+			else
+			{
+				if (socket != null && socket.Connected)
+				{
+					socket.GetStream().WriteByte(10);
+					socket.Close();
 				}
 			}
 		}

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -98,6 +98,11 @@ namespace CumulusMX
 			dogsBodyClient.Timeout = TimeSpan.FromSeconds(10); // 10 seconds for local queries
 			dogsBodyClient.DefaultRequestHeaders.Add("Connection", "close");
 
+			// The Davis leafwetness sensors send a decimal value via WLL (only integer available via VP2/Vue)
+			cumulus.LeafWetDPlaces = 1;
+			cumulus.LeafWetFormat = "F1";
+
+
 			// If the user is using the default 10 minute Wind gust, always use gust data from the WLL - simple
 			if (cumulus.StationOptions.PeakGustMinutes == 10)
 			{

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -2718,9 +2718,9 @@ namespace CumulusMX
 					cumulus.LogDebugMessage("WLL FW version = " + DavisFirmwareVersion);
 				}
 			}
-			else if (sensor.data_structure_type == 11)
+			else if (sensor.data_structure_type == 11 || sensor.data_structure_type == 13)
 			{
-				/* ISS
+				/* ISS & Non-ISS have the same health fields
 				 * Available fields of interest to health
 				 * "afc": -1
 				 * "error_packets": 0
@@ -2736,43 +2736,52 @@ namespace CumulusMX
 
 				try
 				{
-					var data11 = sensor.data.Last().FromJsv<WlHistorySensorDataType11>();
+					string type;
+					if (sensor.sensor_type == 84 || sensor.sensor_type == 85)
+						type = "Vue";
+					else
+						type= sensor.data_structure_type == 11 ? "ISS" : "Soil/Leaf";
 
-					cumulus.LogDebugMessage("WLL Health - found health data for ISS device TxId = " + data11.tx_id);
+					var data = sensor.data.Last().FromJsv<WlHistoryHealthType11_13>();
+
+					cumulus.LogDebugMessage($"WLL Health - found health data for {type} device TxId = {data.tx_id}");
 
 					// Save the archive interval
 					//weatherLinkArchiveInterval = data.Value<int>("arch_int");
 
 					// Check battery state 0=Good, 1=Low
-					SetTxBatteryStatus(data11.tx_id, data11.trans_battery_flag);
-					if (data11.trans_battery_flag == 1)
+					SetTxBatteryStatus(data.tx_id, data.trans_battery_flag);
+					if (data.trans_battery_flag == 1)
 					{
-						cumulus.LogMessage($"WLL WARNING: Battery voltage is low in TxId {data11.tx_id}");
+						cumulus.LogMessage($"WLL WARNING: Battery voltage is low in TxId {data.tx_id}");
 					}
 					else
 					{
-						cumulus.LogDebugMessage($"WLL Health: ISS {data11.tx_id}: Battery state is OK");
+						cumulus.LogDebugMessage($"WLL Health: {type} {data.tx_id}: Battery state is OK");
 					}
 
 					//DavisTotalPacketsReceived[txid] = ;  // Do not have a value for this
-					DavisTotalPacketsMissed[data11.tx_id] = data11.error_packets;
-					DavisNumCRCerrors[data11.tx_id] = data11.error_packets;
-					DavisNumberOfResynchs[data11.tx_id] = data11.resynchs;
-					DavisMaxInARow[data11.tx_id] = data11.good_packets_streak;
-					DavisReceptionPct[data11.tx_id] = data11.reception;
-					DavisTxRssi[data11.tx_id] = data11.rssi;
+					DavisTotalPacketsMissed[data.tx_id] = data.error_packets;
+					DavisNumCRCerrors[data.tx_id] = data.error_packets;
+					DavisNumberOfResynchs[data.tx_id] = data.resynchs;
+					DavisMaxInARow[data.tx_id] = data.good_packets_streak;
+					DavisReceptionPct[data.tx_id] = data.reception;
+					DavisTxRssi[data.tx_id] = data.rssi;
 
-					cumulus.LogDebugMessage($"WLL Health: IIS {data11.tx_id}: Errors={DavisTotalPacketsMissed[data11.tx_id]}, CRCs={DavisNumCRCerrors[data11.tx_id]}, Resyncs={DavisNumberOfResynchs[data11.tx_id]}, Streak={DavisMaxInARow[data11.tx_id]}, %={DavisReceptionPct[data11.tx_id]}, RSSI={DavisTxRssi[data11.tx_id]}");
+					var logMsg = $"WLL Health: {type} {data.tx_id}: Errors={DavisTotalPacketsMissed[data.tx_id]}, CRCs={DavisNumCRCerrors[data.tx_id]}, Resyncs={DavisNumberOfResynchs[data.tx_id]}, Streak={DavisMaxInARow[data.tx_id]}, %={DavisReceptionPct[data.tx_id]}, RSSI={DavisTxRssi[data.tx_id]}";
+					logMsg += data.supercap_volt_last != null ? $", Supercap={data.supercap_volt_last:F2}V" : "";
+					logMsg += data.solar_volt_last != null ? $", Supercap={data.solar_volt_last:F2}V" : "";
+					cumulus.LogDebugMessage(logMsg);
 
 					// Is there any ET in this record?
-					if (data11.et != null)
+					if (sensor.data_structure_type == 11 && data.et != null)
 					{
 						// wl.com ET is only available in record the start of each hour.
 						// The number is the total for the one hour period.
 						// This is unlike the existing VP2 when the ET is an annual running total
 						// So we try and mimic the VP behaviour
-						var newET = AnnualETTotal + ConvertRainINToUser((double)data11.et);
-						cumulus.LogDebugMessage($"WLL DecodeHistoric: Adding {ConvertRainINToUser((double)data11.et):F3} to ET");
+						var newET = AnnualETTotal + ConvertRainINToUser((double)data.et);
+						cumulus.LogDebugMessage($"WLL Health: Adding {ConvertRainINToUser((double)data.et):F3} to ET");
 						DoET(newET, DateTime.Now);
 					}
 				}
@@ -2944,12 +2953,34 @@ namespace CumulusMX
 								if (cumulus.airLinkIn != null)
 									cumulus.airLinkIn.DecodeWlApiHealth(sensor, true);
 								break;
+							// WLL or ISS
+							case 504:
+							case int n when (n >= 43 && n < 90):
+								// Davis don't make this easy! Either a...
+								// 504 - WLL
+								//  43 - ISS VP2, wireless (6152)
+								//  44 - ISS VP2, 24hr fan, wireless (6153)
+								//  45 - ISS VP2 Plus, wireless (6162)
+								//  46 - ISS VP2 Plus, 24hr fan, wireless (6163)
+								//  48 - ISS VP2, wireless (6322)
+								//  49 - ISS VP2, 24hr fan, wireless (6323)
+								//  50 - ISS VP2 Plus, wireless (6327)
+								//  51 - ISS VP2 Plus, 24hr fan, wireless (6328)
+								//  55 - ISS
+								//  56 - Leaf/Soil
+								//  76 - ISS VP2, 24hr fan, wireless, metric (6323M)
+								//  77 - ISS VP2, 24hr fan, wireless, OV (6323OV)
+								//  78 - ISS VP2, wireless, metric (6322M)
+								//  79 - ISS VP2, wirelss, OV (6322OV)
+								//  80 - ISS VP2 Plus, 24hr fan, wireless, metric (6328M)
+								//  81 - ISS VP2 Plus, 24hr fan, wireless, OV (6328OV)
+								//  82 - ISS VP2 Plus, wireless metric (6327M)
+								//  83 - ISS VP2 Plus, wireless, OV (6327OV)
+								//  84 - Vue, wireless, metric (6357M)
+								//  85 - Vue, wireless, OV (6357OV)
+								DecodeWlApiHealth(sensor, true);
+								break;
 							default:
-								if (sensorType == 504 || dataStructureType == 11)
-								{
-									// Either a WLL (504) or ISS (data type = 11) record
-									DecodeWlApiHealth(sensor, true);
-								}
 								break;
 						}
 					}

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -9,6 +9,7 @@ namespace CumulusMX
 	class HttpStationAmbient : WeatherStation
 	{
 		private readonly WeatherStation station;
+		private bool starting = true;
 		private bool stopping = false;
 
 		public HttpStationAmbient(Cumulus cumulus, WeatherStation station = null) : base(cumulus)
@@ -62,6 +63,7 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage("Starting Extra Sensors - HTTP Station (Ambient)");
 			}
+			starting = false;
 		}
 
 		public override void Stop()
@@ -88,7 +90,7 @@ namespace CumulusMX
 			var procName = main ? "ProcessData" : "ProcessExtraData";
 			var thisStation = main ? this : station;
 
-			if (stopping)
+			if (starting || stopping)
 			{
 				context.Response.StatusCode = 200;
 				return "success";

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -28,7 +28,7 @@ namespace CumulusMX
 
 			//cumulus.StationOptions.CalculatedWC = true;
 			// Ambient does not provide average wind speeds
-			cumulus.StationOptions.UseWind10MinAve = true;
+			cumulus.StationOptions.UseWind10MinAvg = true;
 			//cumulus.StationOptions.UseSpeedForAvgCalc = false;
 			// Ambient does not send the rain rate, so we will calculate it
 			calculaterainrate = true;
@@ -37,11 +37,11 @@ namespace CumulusMX
 
 			if (station == null || (station != null && cumulus.AmbientExtraUseAQI))
 			{
-				cumulus.AirQualityUnitText = "µg/m³";
+				cumulus.Units.AirQualityUnitText = "µg/m³";
 			}
 			if (station == null || (station != null && cumulus.AmbientExtraUseSoilMoist))
 			{
-				cumulus.SoilMoistureUnitText = "%";
+				cumulus.Units.SoilMoistureUnitText = "%";
 			}
 
 			// Only perform the Start-up if we are a proper station, not a Extra Sensor

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -11,6 +11,7 @@ namespace CumulusMX
 	class HttpStationEcowitt : WeatherStation
 	{
 		private readonly WeatherStation station;
+		private bool starting = true;
 		private bool stopping = false;
 		private readonly NumberFormatInfo invNum = CultureInfo.InvariantCulture.NumberFormat;
 
@@ -81,6 +82,7 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage("Starting Extra Sensors - HTTP Station (Ecowitt)");
 			}
+			starting = false;
 		}
 
 		public override void Stop()
@@ -110,7 +112,7 @@ namespace CumulusMX
 			var thisStation = main ? this : station;
 
 
-			if (stopping)
+			if (starting || stopping)
 			{
 				context.Response.StatusCode = 200;
 				return "success";

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -14,6 +14,7 @@ namespace CumulusMX
 		private bool starting = true;
 		private bool stopping = false;
 		private readonly NumberFormatInfo invNum = CultureInfo.InvariantCulture.NumberFormat;
+		private bool reportStationType = true;
 
 		public HttpStationEcowitt(Cumulus cumulus, WeatherStation station = null) : base(cumulus)
 		{
@@ -28,33 +29,33 @@ namespace CumulusMX
 				cumulus.LogMessage("Creating Extra Sensors - HTTP Station (Ecowitt)");
 			}
 
-			//cumulus.StationOptions.CalculatedWC = true;
-			// GW1000 does not provide average wind speeds
 			// Do not set these if we are only using extra sensors
 			if (station == null)
 			{
-				cumulus.StationOptions.UseWind10MinAve = true;
-				//cumulus.StationOptions.UseSpeedForAvgCalc = false;
-				// GW1000 does not send DP, so force MX to calculate it
+				// does not provide 10 min average wind speeds
+				cumulus.StationOptions.UseWind10MinAvg = true;
+
+				// does not send DP, so force MX to calculate it
 				cumulus.StationOptions.CalculatedDP = true;
 				// Same for Wind Chill
 				cumulus.StationOptions.CalculatedWC = true;
 				// does not provide a forecast, force MX to provide it
 				cumulus.UseCumulusForecast = true;
-
+				// does not provide pressure trend strings
+				cumulus.StationOptions.UseCumulusPresstrendstr = true;
 			}
 
 			if (station == null || (station != null && cumulus.EcowittExtraUseAQI))
 			{
-				cumulus.AirQualityUnitText = "µg/m³";
+				cumulus.Units.AirQualityUnitText = "µg/m³";
 			}
 			if (station == null || (station != null && cumulus.EcowittExtraUseSoilMoist))
 			{
-				cumulus.SoilMoistureUnitText = "%";
+				cumulus.Units.SoilMoistureUnitText = "%";
 			}
 			if (station == null || (station != null && cumulus.EcowittExtraUseSoilMoist))
 			{
-				cumulus.LeafWetnessUnitText = "%";
+				cumulus.Units.LeafWetnessUnitText = "%";
 			}
 
 
@@ -136,7 +137,12 @@ namespace CumulusMX
 				// We will ignore the dateutc field, this is "live" data so just use "now" to avoid any clock issues
 				recDate = DateTime.Now;
 
-				cumulus.LogDebugMessage($"{procName}: StationType = {data["stationtype"]}, Model = {data["model"]}, Frequency = {data["freq"]}Hz");
+				// we only really want to do this once
+				if (reportStationType)
+				{
+					cumulus.LogDebugMessage($"{procName}: StationType = {data["stationtype"]}, Model = {data["model"]}, Frequency = {data["freq"]}Hz");
+					reportStationType = false;
+				}
 
 				// Only do the primary sensors if running as the main station
 				if (main)
@@ -155,10 +161,10 @@ namespace CumulusMX
 
 						var gust = data["windgustmph"];
 						var dir = data["winddir"];
-						var avg = data["windspeedmph"];
+						var spd = data["windspeedmph"];
 
 
-						if (gust == null || dir == null || avg == null)
+						if (gust == null || dir == null || spd == null)
 						{
 							cumulus.LogMessage($"ProcessData: Error, missing wind data");
 						}
@@ -166,8 +172,26 @@ namespace CumulusMX
 						{
 							var gustVal = ConvertWindMPHToUser(Convert.ToDouble(gust, invNum));
 							var dirVal = Convert.ToInt32(dir, invNum);
-							var avgVal = ConvertWindMPHToUser(Convert.ToDouble(avg, invNum));
-							DoWind(gustVal, dirVal, avgVal, recDate);
+							var spdVal = ConvertWindMPHToUser(Convert.ToDouble(spd, invNum));
+							//DoWind(gustVal, dirVal, spdVal, recDate);
+							// The protocol does not provide an average value
+							// so feed in current MX average
+							DoWind(spdVal, dirVal, WindAverage / cumulus.Calib.WindSpeed.Mult, recDate);
+
+							var gustLastCal = gustVal * cumulus.Calib.WindGust.Mult;
+							if (gustLastCal > RecentMaxGust)
+							{
+								cumulus.LogDebugMessage("Setting max gust from current value: " + gustLastCal.ToString(cumulus.WindFormat));
+								CheckHighGust(gustLastCal, dirVal, recDate);
+
+								// add to recent values so normal calculation includes this value
+								WindRecent[nextwind].Gust = gustVal; // use uncalibrated value
+								WindRecent[nextwind].Speed = WindAverage / cumulus.Calib.WindSpeed.Mult;
+								WindRecent[nextwind].Timestamp = recDate;
+								nextwind = (nextwind + 1) % MaxWindRecent;
+
+								RecentMaxGust = gustLastCal;
+							}
 						}
 					}
 					catch (Exception ex)

--- a/CumulusMX/HttpStationWund.cs
+++ b/CumulusMX/HttpStationWund.cs
@@ -6,6 +6,8 @@ namespace CumulusMX
 {
 	class HttpStationWund : WeatherStation
 	{
+		private bool starting = true;
+		private bool stopping = false;
 		private double previousRainCount = -1;
 		private double rainCount = 0;
 
@@ -27,10 +29,12 @@ namespace CumulusMX
 		{
 			DoDayResetIfNeeded();
 			timerStartNeeded = true;
+			starting = false;
 		}
 
 		public override void Stop()
 		{
+			stopping = true;
 			StopMinuteTimer();
 		}
 
@@ -54,6 +58,12 @@ namespace CumulusMX
 			 */
 
 			DateTime recDate;
+
+			if (starting || stopping)
+			{
+				context.Response.StatusCode = 200;
+				return "success";
+			}
 
 			try
 			{
@@ -386,7 +396,7 @@ namespace CumulusMX
 						var str = data["soiltemp" + i + "f"];
 						if (str != null && str != "-9999")
 						{
-							DoSoilTemp(ConvertTempFToUser(Convert.ToDouble(str, CultureInfo.InvariantCulture)), 2);
+							DoSoilTemp(ConvertTempFToUser(Convert.ToDouble(str, CultureInfo.InvariantCulture)), i);
 						}
 					}
 				}
@@ -410,10 +420,10 @@ namespace CumulusMX
 
 					for (var i = 2; i <= 4; i++)
 					{
-						var str = data["soilmoisture2"];
+						var str = data["soilmoisture" + i];
 						if (str != null && str != "-9999")
 						{
-							DoSoilMoisture(Convert.ToDouble(str, CultureInfo.InvariantCulture), 2);
+							DoSoilMoisture(Convert.ToDouble(str, CultureInfo.InvariantCulture), i);
 						}
 					}
 				}

--- a/CumulusMX/HttpStationWund.cs
+++ b/CumulusMX/HttpStationWund.cs
@@ -16,8 +16,9 @@ namespace CumulusMX
 			cumulus.LogMessage("Starting HTTP Station (Wunderground)");
 
 			cumulus.StationOptions.CalculatedWC = true;
-			cumulus.AirQualityUnitText = "µg/m³";
-			cumulus.SoilMoistureUnitText = "%";
+			cumulus.Units.AirQualityUnitText = "µg/m³";
+			cumulus.Units.SoilMoistureUnitText = "%";
+			cumulus.Units.LeafWetnessUnitText = "%";
 
 			// Wunderground does not send the rain rate, so we will calculate it
 			calculaterainrate = true;

--- a/CumulusMX/InternetSettings.cs
+++ b/CumulusMX/InternetSettings.cs
@@ -546,7 +546,7 @@ namespace CumulusMX
 		public string GetExtraWebFilesData()
 		{
 			var json = new StringBuilder(10240);
-			json.Append("{\"metadata\":[{\"name\":\"local\",\"label\":\"Local Filename\",\"datatype\":\"string\",\"editable\":true},{\"name\":\"remote\",\"label\":\"Destination Filename\",\"datatype\":\"string\",\"editable\":true},{\"name\":\"process\",\"label\":\"Process\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"realtime\",\"label\":\"Realtime\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"ftp\",\"label\":\"FTP\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"utf8\",\"label\":\"UTF-8\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"binary\",\"label\":\"Binary\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"endofday\",\"label\":\"End of day\",\"datatype\":\"boolean\",\"editable\":true}],\"data\":[");
+			json.Append("{\"metadata\":[{\"name\":\"local\",\"label\":\"Local Filename\",\"datatype\":\"string\",\"editable\":true},{\"name\":\"remote\",\"label\":\"Destination Filename\",\"datatype\":\"string\",\"editable\":true},{\"name\":\"process\",\"label\":\"Process\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"realtime\",\"label\":\"Realtime\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"ftp\",\"label\":\"FTP\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"utf8\",\"label\":\"UTF8\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"binary\",\"label\":\"Binary\",\"datatype\":\"boolean\",\"editable\":true},{\"name\":\"endofday\",\"label\":\"End of day\",\"datatype\":\"boolean\",\"editable\":true}],\"data\":[");
 
 			for (int i = 0; i < Cumulus.numextrafiles; i++)
 			{

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.14.1 - Build 3160")]
+[assembly: AssemblyDescription("Version 3.14.2 - Build 3161")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.14.1.3160")]
-[assembly: AssemblyFileVersion("3.14.1.3160")]
+[assembly: AssemblyVersion("3.14.2.3161")]
+[assembly: AssemblyFileVersion("3.14.2.3161")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.14.2 - Build 3161")]
+[assembly: AssemblyDescription("Version 3.14.2 - Build 3162")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
-[assembly: AssemblyCopyright("Copyright ©  2015-2021 Cumulus MX")]
+[assembly: AssemblyCopyright("Copyright ©  2015-2022 Cumulus MX")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.14.2.3161")]
-[assembly: AssemblyFileVersion("3.14.2.3161")]
+[assembly: AssemblyVersion("3.14.2.3162")]
+[assembly: AssemblyFileVersion("3.14.2.3162")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -40,7 +40,7 @@ namespace CumulusMX
 			var options = new JsonStationSettingsOptions()
 			{
 				usezerobearing = cumulus.StationOptions.UseZeroBearing,
-				calcwindaverage = cumulus.StationOptions.UseWind10MinAve,
+				calcwindaverage = cumulus.StationOptions.UseWind10MinAvg,
 				usespeedforavg = cumulus.StationOptions.UseSpeedForAvgCalc,
 				use100for98hum = cumulus.StationOptions.Humidity98Fix,
 				calculatedewpoint = cumulus.StationOptions.CalculatedDP,
@@ -705,7 +705,7 @@ namespace CumulusMX
 				try
 				{
 					cumulus.StationOptions.UseZeroBearing = settings.Options.usezerobearing;
-					cumulus.StationOptions.UseWind10MinAve = settings.Options.calcwindaverage;
+					cumulus.StationOptions.UseWind10MinAvg = settings.Options.calcwindaverage;
 					cumulus.StationOptions.UseSpeedForAvgCalc = settings.Options.usespeedforavg;
 					cumulus.StationOptions.Humidity98Fix = settings.Options.use100for98hum;
 					cumulus.StationOptions.CalculatedDP = settings.Options.calculatedewpoint;

--- a/CumulusMX/ThirdPartySettings.cs
+++ b/CumulusMX/ThirdPartySettings.cs
@@ -206,6 +206,7 @@ namespace CumulusMX
 					{
 						cumulus.WOW.SendSolar = settings.wow.includesolar;
 						cumulus.WOW.SendUV = settings.wow.includeuv;
+						cumulus.WOW.SendSoilTemp = settings.wow.includesoiltemp;
 						cumulus.WOW.Interval = settings.wow.interval;
 						cumulus.WOW.PW = settings.wow.password ?? string.Empty; ;
 						cumulus.WOW.ID = settings.wow.stationid ?? string.Empty; ;
@@ -426,6 +427,7 @@ namespace CumulusMX
 				enabled = cumulus.WOW.Enabled,
 				includesolar = cumulus.WOW.SendSolar,
 				includeuv = cumulus.WOW.SendUV,
+				includesoiltemp = cumulus.WOW.SendSoilTemp,
 				interval = cumulus.WOW.Interval,
 				password = cumulus.WOW.PW,
 				stationid = cumulus.WOW.ID
@@ -602,6 +604,7 @@ namespace CumulusMX
 		public bool enabled { get; set; }
 		public bool includeuv { get; set; }
 		public bool includesolar { get; set; }
+		public bool includesoiltemp { get; set; }
 		public bool catchup { get; set; }
 		public string stationid { get; set; }
 		public string password { get; set; }

--- a/CumulusMX/ThirdPartySettings.cs
+++ b/CumulusMX/ThirdPartySettings.cs
@@ -207,9 +207,10 @@ namespace CumulusMX
 						cumulus.WOW.SendSolar = settings.wow.includesolar;
 						cumulus.WOW.SendUV = settings.wow.includeuv;
 						cumulus.WOW.SendSoilTemp = settings.wow.includesoiltemp;
+						cumulus.WOW.SoilTempSensor = settings.wow.soiltempsensor;
 						cumulus.WOW.Interval = settings.wow.interval;
-						cumulus.WOW.PW = settings.wow.password ?? string.Empty; ;
-						cumulus.WOW.ID = settings.wow.stationid ?? string.Empty; ;
+						cumulus.WOW.PW = settings.wow.password ?? string.Empty;
+						cumulus.WOW.ID = settings.wow.stationid ?? string.Empty;
 						cumulus.WOW.CatchUp = settings.wow.catchup;
 					}
 				}
@@ -427,6 +428,7 @@ namespace CumulusMX
 				enabled = cumulus.WOW.Enabled,
 				includesolar = cumulus.WOW.SendSolar,
 				includeuv = cumulus.WOW.SendUV,
+				soiltempsensor = cumulus.WOW.SoilTempSensor,
 				includesoiltemp = cumulus.WOW.SendSoilTemp,
 				interval = cumulus.WOW.Interval,
 				password = cumulus.WOW.PW,
@@ -605,6 +607,7 @@ namespace CumulusMX
 		public bool includeuv { get; set; }
 		public bool includesolar { get; set; }
 		public bool includesoiltemp { get; set; }
+		public int soiltempsensor { get; set; }
 		public bool catchup { get; set; }
 		public string stationid { get; set; }
 		public string password { get; set; }

--- a/CumulusMX/WeatherLinkDotCom.cs
+++ b/CumulusMX/WeatherLinkDotCom.cs
@@ -194,6 +194,23 @@ namespace CumulusMX
 		}
 	}
 
+	public class WlHistoryHealthType11_13
+	{
+		public int afc { get; set; }
+		public int arch_int { get; set; }
+		public int error_packets { get; set; }
+		public double? et { get; set; }
+		public int good_packets_streak { get; set; }
+		public int reception { get; set; }
+		public int resynchs { get; set; }
+		public double? solar_volt_last { get; set; }
+		public double? supercap_volt_last { get; set; }
+		public int rssi { get; set; }
+		public uint trans_battery_flag { get; set; }
+		public long ts { get; set; }
+		public int tx_id { get; set; }
+	}
+
 	public class WlHistorySensorDataType13Baro
 	{
 		public int arch_int { get; set; }

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2296,7 +2296,7 @@ namespace CumulusMX
 				sbRate.Append($"[{DateTimeToUnix(data[i].Timestamp) * 1000},{data[i].RainRate.ToString(cumulus.RainFormat, InvC)}],");
 			}
 
-			if (sbRain[sbRain.Length-1] == ',')
+			if (sbRain[sbRain.Length - 1] == ',')
 			{
 				sbRain.Length--;
 				sbRate.Length--;
@@ -3959,6 +3959,9 @@ namespace CumulusMX
 
 		public void DoWind(double gustpar, int bearingpar, double speedpar, DateTime timestamp)
 		{
+#if DEBUG
+			cumulus.LogDebugMessage($"DoWind: gust={gustpar:F1}, speed={speedpar:F1}");
+#endif
 			// Spike removal is in m/s
 			var windGustMS = ConvertUserWindToMS(gustpar);
 			var windAvgMS = ConvertUserWindToMS(speedpar);
@@ -4058,7 +4061,7 @@ namespace CumulusMX
 			WindRecent[nextwind].Timestamp = timestamp;
 			nextwind = (nextwind + 1) % MaxWindRecent;
 
-			if (cumulus.StationOptions.UseWind10MinAve)
+			if (cumulus.StationOptions.UseWind10MinAvg)
 			{
 				int numvalues = 0;
 				double totalwind = 0;
@@ -7022,7 +7025,7 @@ namespace CumulusMX
 			catch (Exception ex)
 			{
 				cumulus.LogDebugMessage($"ParseDayFileRec: Error at record {idx} - {ex.Message}");
-				var e = new Exception($"Error at record {idx} = \"{st[idx-1]}\" - {ex.Message}");
+				var e = new Exception($"Error at record {idx} = \"{st[idx - 1]}\" - {ex.Message}");
 				throw e;
 			}
 			return rec;
@@ -8888,9 +8891,9 @@ namespace CumulusMX
 			sb.Append(sep + sep + sep + sep + sep + sep);                                   // 95/96/97/98/99/100 avg/max lux today/month/year
 			sb.Append(sep + sep);                                                           // 101/102 sun hours this month/year
 			sb.Append(sep + sep + sep + sep + sep + sep + sep + sep + sep);                 // 103-111 min/avg/max Soil temp today/month/year
-			//
-			// End of val fixed structure
-			//
+																							//
+																							// End of val fixed structure
+																							//
 
 			return sb.ToString();
 		}
@@ -9852,22 +9855,22 @@ namespace CumulusMX
 		{
 			var json = new StringBuilder("{\"data\":[", 1024);
 
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[1]}\",\"{SoilMoisture1:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[2]}\",\"{SoilMoisture2:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[3]}\",\"{SoilMoisture3:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[4]}\",\"{SoilMoisture4:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[5]}\",\"{SoilMoisture5:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[6]}\",\"{SoilMoisture6:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[7]}\",\"{SoilMoisture7:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[8]}\",\"{SoilMoisture8:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[9]}\",\"{SoilMoisture9:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[10]}\",\"{SoilMoisture10:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[11]}\",\"{SoilMoisture11:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[12]}\",\"{SoilMoisture12:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[13]}\",\"{SoilMoisture13:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[14]}\",\"{SoilMoisture14:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[15]}\",\"{SoilMoisture15:F0}\",\"{cumulus.SoilMoistureUnitText}\"],");
-			json.Append($"[\"{cumulus.SoilMoistureCaptions[16]}\",\"{SoilMoisture16:F0}\",\"{cumulus.SoilMoistureUnitText}\"]");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[1]}\",\"{SoilMoisture1:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[2]}\",\"{SoilMoisture2:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[3]}\",\"{SoilMoisture3:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[4]}\",\"{SoilMoisture4:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[5]}\",\"{SoilMoisture5:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[6]}\",\"{SoilMoisture6:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[7]}\",\"{SoilMoisture7:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[8]}\",\"{SoilMoisture8:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[9]}\",\"{SoilMoisture9:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[10]}\",\"{SoilMoisture10:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[11]}\",\"{SoilMoisture11:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[12]}\",\"{SoilMoisture12:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[13]}\",\"{SoilMoisture13:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[14]}\",\"{SoilMoisture14:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[15]}\",\"{SoilMoisture15:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"],");
+			json.Append($"[\"{cumulus.SoilMoistureCaptions[16]}\",\"{SoilMoisture16:F0}\",\"{cumulus.Units.SoilMoistureUnitText}\"]");
 			json.Append("]}");
 			return json.ToString();
 		}
@@ -9876,14 +9879,14 @@ namespace CumulusMX
 		{
 			var json = new StringBuilder("{\"data\":[", 1024);
 
-			json.Append($"[\"{cumulus.AirQualityCaptions[1]}\",\"{AirQuality1:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.AirQualityCaptions[2]}\",\"{AirQuality2:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.AirQualityCaptions[3]}\",\"{AirQuality3:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.AirQualityCaptions[4]}\",\"{AirQuality4:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.AirQualityAvgCaptions[1]}\",\"{AirQualityAvg1:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.AirQualityAvgCaptions[2]}\",\"{AirQualityAvg2:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.AirQualityAvgCaptions[3]}\",\"{AirQualityAvg3:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.AirQualityAvgCaptions[4]}\",\"{AirQualityAvg4:F1}\",\"{cumulus.AirQualityUnitText}\"]");
+			json.Append($"[\"{cumulus.AirQualityCaptions[1]}\",\"{AirQuality1:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.AirQualityCaptions[2]}\",\"{AirQuality2:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.AirQualityCaptions[3]}\",\"{AirQuality3:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.AirQualityCaptions[4]}\",\"{AirQuality4:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.AirQualityAvgCaptions[1]}\",\"{AirQualityAvg1:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.AirQualityAvgCaptions[2]}\",\"{AirQualityAvg2:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.AirQualityAvgCaptions[3]}\",\"{AirQualityAvg3:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.AirQualityAvgCaptions[4]}\",\"{AirQualityAvg4:F1}\",\"{cumulus.Units.AirQualityUnitText}\"]");
 			json.Append("]}");
 			return json.ToString();
 		}
@@ -9892,12 +9895,12 @@ namespace CumulusMX
 		{
 			var json = new StringBuilder("{\"data\":[", 1024);
 
-			json.Append($"[\"{cumulus.CO2_CurrentCaption}\",\"{CO2}\",\"{cumulus.CO2UnitText}\"],");
-			json.Append($"[\"{cumulus.CO2_24HourCaption}\",\"{CO2_24h}\",\"{cumulus.CO2UnitText}\"],");
-			json.Append($"[\"{cumulus.CO2_pm2p5Caption}\",\"{CO2_pm2p5:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.CO2_pm2p5_24hrCaption}\",\"{CO2_pm2p5_24h:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.CO2_pm10Caption}\",\"{CO2_pm10:F1}\",\"{cumulus.AirQualityUnitText}\"],");
-			json.Append($"[\"{cumulus.CO2_pm10_24hrCaption}\",\"{CO2_pm10_24h:F1}\",\"{cumulus.AirQualityUnitText}\"]");
+			json.Append($"[\"{cumulus.CO2_CurrentCaption}\",\"{CO2}\",\"{cumulus.Units.CO2UnitText}\"],");
+			json.Append($"[\"{cumulus.CO2_24HourCaption}\",\"{CO2_24h}\",\"{cumulus.Units.CO2UnitText}\"],");
+			json.Append($"[\"{cumulus.CO2_pm2p5Caption}\",\"{CO2_pm2p5:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.CO2_pm2p5_24hrCaption}\",\"{CO2_pm2p5_24h:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.CO2_pm10Caption}\",\"{CO2_pm10:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+			json.Append($"[\"{cumulus.CO2_pm10_24hrCaption}\",\"{CO2_pm10_24h:F1}\",\"{cumulus.Units.AirQualityUnitText}\"]");
 			json.Append("]}");
 			return json.ToString();
 		}
@@ -9919,8 +9922,8 @@ namespace CumulusMX
 
 			json.Append($"[\"{cumulus.LeafTempCaptions[1]}\",\"{LeafTemp1.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
 			json.Append($"[\"{cumulus.LeafTempCaptions[2]}\",\"{LeafTemp2.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[1]}\",\"{LeafWetness1.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[2]}\",\"{LeafWetness2.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"]");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[1]}\",\"{LeafWetness1.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[2]}\",\"{LeafWetness2.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"]");
 			json.Append("]}");
 			return json.ToString();
 		}
@@ -9931,10 +9934,10 @@ namespace CumulusMX
 
 			json.Append($"[\"{cumulus.LeafTempCaptions[1]}\",\"{LeafTemp1.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
 			json.Append($"[\"{cumulus.LeafTempCaptions[2]}\",\"{LeafTemp2.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[1]}\",\"{LeafWetness1.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[2]}\",\"{LeafWetness2.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[3]}\",\"{LeafWetness3.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[4]}\",\"{LeafWetness4.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"]");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[1]}\",\"{LeafWetness1.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[2]}\",\"{LeafWetness2.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[3]}\",\"{LeafWetness3.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[4]}\",\"{LeafWetness4.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"]");
 			json.Append("]}");
 			return json.ToString();
 		}
@@ -9945,14 +9948,14 @@ namespace CumulusMX
 
 			json.Append($"[\"{cumulus.LeafTempCaptions[1]}\",\"{LeafTemp1.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
 			json.Append($"[\"{cumulus.LeafTempCaptions[2]}\",\"{LeafTemp2.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[1]}\",\"{LeafWetness1.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[2]}\",\"{LeafWetness2.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[3]}\",\"{LeafWetness3.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[4]}\",\"{LeafWetness4.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[5]}\",\"{LeafWetness5.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[6]}\",\"{LeafWetness6.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[7]}\",\"{LeafWetness7.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
-			json.Append($"[\"{cumulus.LeafWetnessCaptions[8]}\",\"{LeafWetness8.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"]");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[1]}\",\"{LeafWetness1.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[2]}\",\"{LeafWetness2.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[3]}\",\"{LeafWetness3.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[4]}\",\"{LeafWetness4.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[5]}\",\"{LeafWetness5.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[6]}\",\"{LeafWetness6.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[7]}\",\"{LeafWetness7.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"],");
+			json.Append($"[\"{cumulus.LeafWetnessCaptions[8]}\",\"{LeafWetness8.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.Units.LeafWetnessUnitText}\"]");
 			json.Append("]}");
 			return json.ToString();
 		}
@@ -10683,7 +10686,19 @@ namespace CumulusMX
 
 		public string GetUnits()
 		{
-			return $"{{\"temp\":\"{cumulus.Units.TempText[1]}\",\"wind\":\"{cumulus.Units.WindText}\",\"rain\":\"{cumulus.Units.RainText}\",\"press\":\"{cumulus.Units.PressText}\"}}";
+			var json = new StringBuilder("{", 200);
+
+			json.Append($"\"temp\":\"{cumulus.Units.TempText[1]}\",");
+			json.Append($"\"wind\":\"{cumulus.Units.WindText}\",");
+			json.Append($"\"windrun\":\"{cumulus.Units.WindRunText}\",");
+			json.Append($"\"rain\":\"{cumulus.Units.RainText}\",");
+			json.Append($"\"press\":\"{cumulus.Units.PressText}\",");
+			json.Append($"\"soilmoisture\":\"{cumulus.Units.SoilMoistureUnitText}\",");
+			json.Append($"\"co2\":\"{cumulus.Units.CO2UnitText}\",");
+			json.Append($"\"leafwet\":\"{cumulus.Units.LeafWetnessUnitText}\",");
+			json.Append($"\"aq\":\"{cumulus.Units.AirQualityUnitText}\"");
+			json.Append('}');
+			return json.ToString();
 		}
 
 		public string GetGraphConfig()
@@ -10695,8 +10710,12 @@ namespace CumulusMX
 			json.Append($"\"rain\":{{\"units\":\"{cumulus.Units.RainText}\",\"decimals\":{cumulus.RainDPlaces}}},");
 			json.Append($"\"press\":{{\"units\":\"{cumulus.Units.PressText}\",\"decimals\":{cumulus.PressDPlaces}}},");
 			json.Append($"\"hum\":{{\"decimals\":{cumulus.HumDPlaces}}},");
-			json.Append($"\"uv\":{{\"decimals\":{cumulus.UVDPlaces}}}");
-			json.Append("}");
+			json.Append($"\"uv\":{{\"decimals\":{cumulus.UVDPlaces}}},");
+			json.Append($"\"soilmoisture\":{{\"units\":\"{cumulus.Units.SoilMoistureUnitText}\"}},");
+			json.Append($"\"co2\":{{\"units\":\"{cumulus.Units.CO2UnitText}\"}},");
+			json.Append($"\"leafwet\":{{\"units\":\"{cumulus.Units.LeafWetnessUnitText}\",\"decimals\":{cumulus.LeafWetDPlaces}}},");
+			json.Append($"\"aq\":{{\"units\":\"{cumulus.Units.AirQualityUnitText}\"}}");
+			json.Append('}');
 			return json.ToString();
 		}
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -9943,6 +9943,8 @@ namespace CumulusMX
 		{
 			var json = new StringBuilder("{\"data\":[", 256);
 
+			json.Append($"[\"{cumulus.LeafTempCaptions[1]}\",\"{LeafTemp1.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
+			json.Append($"[\"{cumulus.LeafTempCaptions[2]}\",\"{LeafTemp2.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
 			json.Append($"[\"{cumulus.LeafWetnessCaptions[1]}\",\"{LeafWetness1.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
 			json.Append($"[\"{cumulus.LeafWetnessCaptions[2]}\",\"{LeafWetness2.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");
 			json.Append($"[\"{cumulus.LeafWetnessCaptions[3]}\",\"{LeafWetness3.ToString(cumulus.LeafWetFormat)}\",\"{cumulus.LeafWetnessUnitText}\"],");

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -9282,6 +9282,10 @@ namespace CumulusMX
 			{
 				Data.Append("&solarradiation=" + SolarRad.ToString("F0"));
 			}
+			if (cumulus.WOW.SendSoilTemp)
+			{
+				Data.Append($"&soiltempf=" + TempFstr(SoilTemp1));
+			}
 
 			Data.Append("&softwaretype=Cumulus%20v" + cumulus.Version);
 			Data.Append("&action=updateraw");

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -3870,42 +3870,42 @@ namespace CumulusMX
 
 		private string TagLeafWetness1(Dictionary<string,string> tagParams)
 		{
-			return station.LeafWetness1.ToString();
+			return station.LeafWetness1.ToString(cumulus.LeafWetFormat);
 		}
 
 		private string TagLeafWetness2(Dictionary<string,string> tagParams)
 		{
-			return station.LeafWetness2.ToString();
+			return station.LeafWetness2.ToString(cumulus.LeafWetFormat);
 		}
 
 		private string TagLeafWetness3(Dictionary<string, string> tagParams)
 		{
-			return station.LeafWetness3.ToString();
+			return station.LeafWetness3.ToString(cumulus.LeafWetFormat);
 		}
 
 		private string TagLeafWetness4(Dictionary<string, string> tagParams)
 		{
-			return station.LeafWetness4.ToString();
+			return station.LeafWetness4.ToString(cumulus.LeafWetFormat);
 		}
 
 		private string TagLeafWetness5(Dictionary<string, string> tagParams)
 		{
-			return station.LeafWetness5.ToString();
+			return station.LeafWetness5.ToString(cumulus.LeafWetFormat);
 		}
 
 		private string TagLeafWetness6(Dictionary<string, string> tagParams)
 		{
-			return station.LeafWetness6.ToString();
+			return station.LeafWetness6.ToString(cumulus.LeafWetFormat);
 		}
 
 		private string TagLeafWetness7(Dictionary<string, string> tagParams)
 		{
-			return station.LeafWetness7.ToString();
+			return station.LeafWetness7.ToString(cumulus.LeafWetFormat);
 		}
 
 		private string TagLeafWetness8(Dictionary<string, string> tagParams)
 		{
-			return station.LeafWetness8.ToString();
+			return station.LeafWetness8.ToString(cumulus.LeafWetFormat);
 		}
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,13 +1,16 @@
-3.14.2 - b3161
+3.14.2 - b3162
 ——————————————
 - Fix: Dayfile viewer/editor header for log date changed year format to correct value = "dd/mm/yy"
-- Fix: HTTP stations now ignore any inbound data until any required pre=processing is complete
+- Fix: HTTP stations now ignore any inbound data until any required pre-processing is complete
 - Fix: Removal of old log files from the /MXdiags folder now ignores log files created by other utilities
+- Fix: Davis WLL: Adds missing health data decode for soil/leaf transmitters, and adds SuperCap voltage for Vue transmitters
+- Fix: GW1000 & HTTP Ecowitt: Wind speed handling now consistent across both protocols
+- Fix: Davis VP2: Fix USB/Serial stations stopping polling when connection is temporarily lost
 
-- Change: Davis leaf wetness sensors now log values as decimals when reporting via WLL stations
+- Change: Davis WLL: Davis leaf wetness sensors now log values as decimals when reporting
 
-- New: Third party upload WOW can now include soil temperature from any chosen sensor
-
+- New: Third party uploads to WOW can now include soil temperature from any chosen sensor
+- New: Adds additional units to the JSON data files - "windrun", "soilmoisture", "co2", "leafwet", and "aq"
 
 
 3.14.1 - b3160
@@ -18,7 +21,7 @@
 
 - Change: Ecowitt GW1000 discovery mechanism updated
 
-- New: The Solar calculation now allows you to input different transparency values for July and Decmember. MX uses a cosine interpolation between the two values
+- New: The Solar calculation now allows you to input different transparency values for July and December. MX uses a cosine interpolation between the two values
 	There are changes to cumulus.ini to accommodate this.
 	[Solar]
 	RStransfactor=0.8		Removed
@@ -45,7 +48,7 @@
 - Change: The monthly log file and extra log file file editors now accept a date range rather than showing a whole month at a time
 	The date range can span a month end
 	These editors now also have a search field which you can use to search for specific values or times. Only matching lines will be displayed
-	- It is up to you to be sensible on restricting the date range to the performanance of your CMX computer
+	- It is up to you to be sensible on restricting the date range to the performance of your CMX computer
 	- A fast machine with SSD drives will cope with much larger ranges than a Raspberry Pi zero for instance!
 
 
@@ -217,7 +220,7 @@ WITHDRWAN due to issues with FluentFTP and Mono when connecting to FTP servers t
 - Fix: SteelSeries gauges data mouseovers not working on the dashboard interface
 - Fix: Davis WLL, bug in Chill Hours calculation during archive data catch-up. Each interval increment was 60x larger than it should be
 - Fix: Davis WLL, add missing Sunshine hours calculation to historic catch-up
-- Fix: Davis WLL, now correctly handles null values in historic data during cath-up
+- Fix: Davis WLL, now correctly handles null values in historic data during catch-up
 - Fix: GW1000 station, 0.1mm rain tippers would take 3 tips in an interval to register "last rained" when using Inches as the rain unit
 - Fix: GW1000 station, adds missing low battery alarm
 - Fix: GW1000 station, user temperatures above channel 1 were not being assigned to the correct channel

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,10 @@
+3.14.2 - b3161
+——————————————
+
+- New: Third party upload WOW can now include soil temperature from sensor 1
+
+
+
 3.14.1 - b3160
 ——————————————
 - Fix: Davis WLL stations recording zero values if the WLL sends "null" for a value
@@ -6,7 +13,7 @@
 
 - Change: Ecowitt GW1000 discovery mechanism updated
 
-- New: The Solar calculation now allows you to input different transparency values for July and August. MX uses a cosine interpolation between the two values
+- New: The Solar calculation now allows you to input different transparency values for July and Decmember. MX uses a cosine interpolation between the two values
 	There are changes to cumulus.ini to accommodate this.
 	[Solar]
 	RStransfactor=0.8		Removed

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,7 +1,12 @@
 3.14.2 - b3161
 ——————————————
+- Fix: Dayfile viewer/editor header for log date changed year format to correct value = "dd/mm/yy"
+- Fix: HTTP stations now ignore any inbound data until any required pre=processing is complete
+- Fix: Removal of old log files from the /MXdiags folder now ignores log files created by other utilities
 
-- New: Third party upload WOW can now include soil temperature from sensor 1
+- Change: Davis leaf wetness sensors now log values as decimals when reporting via WLL stations
+
+- New: Third party upload WOW can now include soil temperature from any chosen sensor
 
 
 


### PR DESCRIPTION
- Fix: Dayfile viewer/editor header for log date changed year format to correct value = "dd/mm/yy"
- Fix: HTTP stations now ignore any inbound data until any required pre-processing is complete
- Fix: Removal of old log files from the /MXdiags folder now ignores log files created by other utilities
- Fix: Davis WLL: Adds missing health data decode for soil/leaf transmitters, and adds SuperCap voltage for Vue transmitters
- Fix: GW1000 & HTTP Ecowitt: Wind speed handling now consistent across both protocols
- Fix: Davis VP2: Fix USB/Serial stations stopping polling when connection is temporarily lost

- Change: Davis WLL: Davis leaf wetness sensors now log values as decimals when reporting

- New: Third party uploads to WOW can now include soil temperature from any chosen sensor
- New: Adds additional units to the JSON data files - "windrun", "soilmoisture", "co2", "leafwet", and "aq"