### PR TITLE
v3.15.1

### DIFF
--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -298,7 +298,7 @@ namespace CumulusMX
 					switch (lastSegment)
 					{
 						case "process.txt":
-							return await this.StringResponseAsync(tagProcessor.ProcessText(this.Request));
+							return await this.StringResponseAsync(tagProcessor.ProcessText(Request));
 					}
 
 					throw new KeyNotFoundException("Key Not Found: " + lastSegment);
@@ -320,7 +320,7 @@ namespace CumulusMX
 					switch (lastSegment)
 					{
 						case "process.json":
-							return await this.JsonResponseAsync(tagProcessor.ProcessJson(this.Request));
+							return await this.JsonResponseAsync(tagProcessor.ProcessJson(Request));
 					}
 
 					throw new KeyNotFoundException("Key Not Found: " + lastSegment);

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -298,7 +298,7 @@ namespace CumulusMX
 					switch (lastSegment)
 					{
 						case "process.txt":
-							return await this.StringResponseAsync(tagProcessor.ProcessText(this));
+							return await this.StringResponseAsync(tagProcessor.ProcessText(this.Request));
 					}
 
 					throw new KeyNotFoundException("Key Not Found: " + lastSegment);
@@ -320,7 +320,7 @@ namespace CumulusMX
 					switch (lastSegment)
 					{
 						case "process.json":
-							return await this.JsonResponseAsync(tagProcessor.ProcessJson(Request.Url.Query));
+							return await this.JsonResponseAsync(tagProcessor.ProcessJson(this.Request));
 					}
 
 					throw new KeyNotFoundException("Key Not Found: " + lastSegment);

--- a/CumulusMX/ApiTagProcessor.cs
+++ b/CumulusMX/ApiTagProcessor.cs
@@ -26,12 +26,14 @@ namespace CumulusMX
 		}
 
 		// Output the processed response as a JSON string
-		public string ProcessJson(string query)
+		public string ProcessJson(IHttpRequest request)
 		{
 			var rc = false;
 
+			var query = request.Url.Query;
+
 			cumulus.LogDebugMessage("API tag: Processing API JSON tag request");
-			cumulus.LogDataMessage("API tag: Input string = " + query);
+			cumulus.LogDataMessage($"API tag: Source = {request.RemoteEndPoint} Input string = {query}");
 
 			var output = new StringBuilder("{", query.Length * 2);
 
@@ -79,15 +81,15 @@ namespace CumulusMX
 		}
 
 		// Just return the processed text as-is
-		public string ProcessText(IHttpContext context)
+		public string ProcessText(IHttpRequest request)
 		{
 			cumulus.LogDebugMessage("API tag: Processing API Text tag request");
 
 			try
 			{
-				var data = new StreamReader(context.Request.InputStream).ReadToEnd();
+				var data = new StreamReader(request.InputStream).ReadToEnd();
 
-				cumulus.LogDataMessage("API tag: Input string = " + data);
+				cumulus.LogDataMessage($"API tag: Source = {request.RemoteEndPoint} Input string = {data}");
 
 				tokenParser.InputText = data;
 				var output = tokenParser.ToStringFromString();

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -7953,7 +7953,7 @@ namespace CumulusMX
 			}
 
 			var srcfile = "";
-			var dstfile = "";
+			string dstfile;
 
 			if (NOAAconf.NeedCopy)
 			{

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1134,15 +1134,15 @@ namespace CumulusMX
 				var msg3 = $"No PING response received in {ProgramOptions.StartupPingEscapeTime} minutes, continuing anyway";
 				LogConsoleMessage(msg1);
 				LogMessage(msg1);
-				using (var ping = new Ping())
+				var endTime = DateTime.Now.AddMinutes(ProgramOptions.StartupPingEscapeTime);
+
+				do
 				{
-					var endTime = DateTime.Now.AddMinutes(ProgramOptions.StartupPingEscapeTime);
+					pingReply = null;
 
-					ping.PingCompleted += new PingCompletedEventHandler(PingCompletedCallback);
-
-					do
+					using (var ping = new Ping())
 					{
-						pingReply = null;
+						ping.PingCompleted += new PingCompletedEventHandler(PingCompletedCallback);
 
 						try
 						{
@@ -1153,7 +1153,7 @@ namespace CumulusMX
 							do
 							{
 								Thread.Sleep(50);
-							} while (pingReply != null && DateTime.Now < pingTimeout);
+							} while (pingReply != null || DateTime.Now < pingTimeout);
 
 							if (DateTime.Now >= pingTimeout)
 							{
@@ -1166,37 +1166,37 @@ namespace CumulusMX
 						{
 							LogErrorMessage($"PING to {ProgramOptions.StartupPingHost} failed with error: {e.InnerException.Message}");
 						}
+					}
 
-						if (pingReply == null || pingReply.Status != IPStatus.Success)
+					if (pingReply == null || pingReply.Status != IPStatus.Success)
+					{
+						// no response wait 10 seconds before trying again
+						Thread.Sleep(10000);
+						// Force a DNS refresh if not an IPv4 address
+						if (!Utils.ValidateIPv4(ProgramOptions.StartupPingHost))
 						{
-							// no response wait 10 seconds before trying again
-							Thread.Sleep(10000);
-							// Force a DNS refresh if not an IPv4 address
-							if (!Utils.ValidateIPv4(ProgramOptions.StartupPingHost))
+							// catch and ignore IPv6 and invalid host name for now
+							try
 							{
-								// catch and ignore IPv6 and invalid host name for now
-								try
-								{
-									Dns.GetHostEntry(ProgramOptions.StartupPingHost);
-								}
-								catch (Exception ex)
-								{
-									LogMessage($"PING: Error with DNS refresh - {ex.Message}");
-								}
+								Dns.GetHostEntry(ProgramOptions.StartupPingHost);
+							}
+							catch (Exception ex)
+							{
+								LogMessage($"PING: Error with DNS refresh - {ex.Message}");
 							}
 						}
-					} while ((pingReply == null || pingReply.Status != IPStatus.Success) && DateTime.Now < endTime);
+					}
+				} while ((pingReply == null || pingReply.Status != IPStatus.Success) && DateTime.Now < endTime);
 
-					if (DateTime.Now >= endTime)
-					{
-						LogConsoleMessage(msg3, ConsoleColor.Yellow);
-						LogMessage(msg3);
-					}
-					else
-					{
-						LogConsoleMessage(msg2);
-						LogMessage(msg2);
-					}
+				if (DateTime.Now >= endTime)
+				{
+					LogConsoleMessage(msg3, ConsoleColor.Yellow);
+					LogMessage(msg3);
+				}
+				else
+				{
+					LogConsoleMessage(msg2);
+					LogMessage(msg2);
 				}
 			}
 			else

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1152,8 +1152,8 @@ namespace CumulusMX
 
 							do
 							{
-								Thread.Sleep(50);
-							} while (pingReply != null || DateTime.Now < pingTimeout);
+								Thread.Sleep(500);
+							} while (pingReply != null && DateTime.Now < pingTimeout);
 
 							if (DateTime.Now >= pingTimeout)
 							{
@@ -10398,20 +10398,14 @@ namespace CumulusMX
 
 		private void PingCompletedCallback(object sender, PingCompletedEventArgs e)
 		{
-			// If the operation was cancelled, display a message to the user.
-			if (e.Cancelled)
-			{
-				LogMessage("Ping cancelled.");
-			}
-
 			// If an error occurred, display the exception to the user.
-			else if (e.Error != null)
+			if (e.Error != null)
 			{
 				LogMessage("Ping failed: " + e.Error.Message + " > " + e.Error.InnerException.Message);
 			}
 			else
 			{
-				LogMessage("Ping reply: " + e.Reply);
+				LogMessage("Ping reply: " + e.Reply.Status);
 			}
 
 			pingReply = e.Reply;

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -3410,6 +3410,8 @@ namespace CumulusMX
 		{
 			var request = context.Request;
 			string text;
+			var InvC = new CultureInfo("");
+
 			using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
 			{
 				text = reader.ReadToEnd();
@@ -3451,8 +3453,55 @@ namespace CumulusMX
 
 					return "{\"errors\":{\"Logfile\":[\"<br>Failed to update, error = " + ex.Message + "\"]}}";
 				}
+				
+				// Update internal database
+				// This does not really work, as the recent data is every minute, the logged data could be every 5, 15, 30 minutes
 
+				var LogRec = station.ParseLogFileRec(newLine, false);
+				/*
+				// first check if the record is on the recent data table
+				try
+				{
 
+					var updt = new StringBuilder(1024);
+					var updtRec = station.RecentDataDb.Query<RecentData>("select * from RecentData where Timestamp=?)", LogRec.Date)[0];
+					if (updtRec != null)
+					{
+						updtRec.AppTemp = LogRec.ApparentTemperature;
+						updtRec.DewPoint = LogRec.OutdoorDewpoint;
+						updtRec.FeelsLike = LogRec.FeelsLike;
+						updtRec.HeatIndex = LogRec.HeatIndex;
+						updtRec.Humidex = LogRec.Humidex;
+						updtRec.Humidity = LogRec.OutdoorHumidity;
+						updtRec.IndoorHumidity = LogRec.IndoorHumidity;
+						updtRec.IndoorTemp = LogRec.IndoorTemperature;
+						updtRec.OutsideTemp = LogRec.OutdoorTemperature;
+						updtRec.Pressure = LogRec.Pressure;
+						updtRec.raincounter = LogRec.Raincounter;
+						updtRec.RainRate = LogRec.RainRate;
+						updtRec.RainToday = LogRec.RainToday;
+						updtRec.SolarMax = (int)LogRec.CurrentSolarMax;
+						updtRec.SolarRad = (int)LogRec.SolarRad;
+						updtRec.UV = LogRec.UV;
+						updtRec.WindAvgDir = LogRec.AvgBearing;
+						updtRec.WindChill = LogRec.WindChill;
+						updtRec.WindDir = LogRec.Bearing;
+						updtRec.WindGust = LogRec.RecentMaxGust;
+						updtRec.WindLatest = LogRec.WindLatest;
+						updtRec.WindSpeed = LogRec.WindAverage;
+
+						var rowCnt = station.RecentDataDb.Update(updtRec);
+						if (rowCnt != 1)
+						{
+							cumulus.LogMessage("EditDataLog: Failed to update SQLite database");
+						}
+					}
+				}
+				catch (Exception ex)
+				{
+					cumulus.LogMessage($"EditDataLog: Failed to update SQLite. Error = {ex.Message}");
+				}
+				*/
 
 				// Update the MySQL record
 				if (!string.IsNullOrEmpty(cumulus.MySqlConnSettings.Server) &&
@@ -3469,10 +3518,8 @@ namespace CumulusMX
 
 						try
 						{
-							var InvC = new CultureInfo("");
 							var updt = new StringBuilder(1024);
 
-							var LogRec = station.ParseLogFileRec(newLine, false);
 
 							updt.Append($"UPDATE {cumulus.MySqlSettings.Monthly.TableName} SET ");
 							updt.Append($"Temp={LogRec.OutdoorTemperature.ToString(cumulus.TempFormat, InvC)},");

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -210,7 +210,10 @@ namespace CumulusMX
 				var vals = recepStats.Split(' ');
 
 				DavisTotalPacketsReceived = Convert.ToInt32(vals[0]);
-				if (DavisTotalPacketsReceived < 0) DavisTotalPacketsReceived = DavisTotalPacketsReceived + 65536; // The console uses 16 bit signed variable to hold the value so it bit wraps
+				if (DavisTotalPacketsReceived < 0)
+				{
+					DavisTotalPacketsReceived += 65536; // The console uses 16 bit signed variable to hold the value so it bit wraps
+				}
 				DavisTotalPacketsMissed[0] = Convert.ToInt32(vals[1]);
 				DavisNumberOfResynchs[0] = Convert.ToInt32(vals[2]);
 				DavisMaxInARow[0] = Convert.ToInt32(vals[3]);

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -2742,7 +2742,7 @@ namespace CumulusMX
 				try
 				{
 					string type;
-					if (sensor.sensor_type == 84 || sensor.sensor_type == 85)
+					if (sensor.sensor_type == 37 || sensor.sensor_type == 84 || sensor.sensor_type == 85)
 						type = "Vue";
 					else
 						type= sensor.data_structure_type == 11 ? "ISS" : "Soil/Leaf";
@@ -2960,9 +2960,14 @@ namespace CumulusMX
 								break;
 							// WLL or ISS
 							case 504:
-							case int n when (n >= 43 && n < 90):
+							case int n when (n >= 23 && n < 100):
 								// Davis don't make this easy! Either a...
 								// 504 - WLL
+								//  23 - ISS VP2, Cabled (6322C)
+								//  24 - ISS VP2 Plus, Cabled (6327C)
+								//  27 - ISS VP2, Cabled, Metric (6322CM)
+								//  28 - ISS VP2 Plus, Cabled, Metric (6327CM)
+								//  37 - Vue, wireless (6357)
 								//  43 - ISS VP2, wireless (6152)
 								//  44 - ISS VP2, 24hr fan, wireless (6153)
 								//  45 - ISS VP2 Plus, wireless (6162)
@@ -2976,7 +2981,7 @@ namespace CumulusMX
 								//  76 - ISS VP2, 24hr fan, wireless, metric (6323M)
 								//  77 - ISS VP2, 24hr fan, wireless, OV (6323OV)
 								//  78 - ISS VP2, wireless, metric (6322M)
-								//  79 - ISS VP2, wirelss, OV (6322OV)
+								//  79 - ISS VP2, wireless, OV (6322OV)
 								//  80 - ISS VP2 Plus, 24hr fan, wireless, metric (6328M)
 								//  81 - ISS VP2 Plus, 24hr fan, wireless, OV (6328OV)
 								//  82 - ISS VP2 Plus, wireless metric (6327M)

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -3302,26 +3302,17 @@ namespace CumulusMX
 				}
 				else if (status != null)
 				{
-					var msg = $"Weatherlink.com overall System Status: '{status.result.status_overall.status}', Updated: {status.result.status_overall.updated}";
+					string msg;
 					if (status.result.status_overall.status_code != 100)
 					{
-						msg += "Error: ";
+						msg = status.ToString(true);
 						cumulus.LogMessage(msg);
 						Console.WriteLine(msg);
 					}
 					else
 					{
+						msg = status.ToString(false);
 						cumulus.LogDebugMessage(msg);
-					}
-					// If we are not OK, then find what isn't working
-					if (status.result.status_overall.status_code != 100)
-					{
-						foreach (var subSys in status.result.status)
-						{
-							msg = $"   wl.com system: {subSys.name}, status: {subSys.status}, updated: {subSys.updated}";
-							cumulus.LogMessage(msg);
-							Console.WriteLine(msg);
-						}
 					}
 				}
 				else

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -14,14 +14,14 @@ namespace CumulusMX
 {
 	internal class EcowittApi
 	{
-		private Cumulus cumulus;
-		private WeatherStation station;
-		private readonly NumberFormatInfo invNum = CultureInfo.InvariantCulture.NumberFormat;
+		private readonly Cumulus cumulus;
+		private readonly WeatherStation station;
+		//private readonly NumberFormatInfo invNum = CultureInfo.InvariantCulture.NumberFormat;
 
 		private static readonly HttpClientHandler httpHandler = new HttpClientHandler();
 		private readonly HttpClient httpClient = new HttpClient(httpHandler);
 
-		private static string historyUrl = "https://api.ecowitt.net/api/v3/device/history?";
+		private static readonly string historyUrl = "https://api.ecowitt.net/api/v3/device/history?";
 
 		public EcowittApi(Cumulus cuml, WeatherStation stn)
 		{
@@ -264,7 +264,7 @@ namespace CumulusMX
 
 		}
 
-		private void ProcessHistoryData(EcowittApi.EcowittHistoricData data)
+		private void ProcessHistoryData(EcowittHistoricData data)
 		{
 			// allocate a dictionary of data objects, keyed on the timestamp
 			var buffer = new SortedDictionary<DateTime, EcowittApi.HistoricData>();
@@ -1280,7 +1280,7 @@ namespace CumulusMX
 		}
 
 
-
+		/*
 		private string ErrorCode(int code)
 		{
 			switch (code)
@@ -1310,6 +1310,7 @@ namespace CumulusMX
 				default: return "Unknown error code";
 			}
 		}
+		*/
 
 		private class EcowitHistErrorResp
 		{

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -153,6 +153,8 @@ namespace CumulusMX
 			var logUrl = url.Replace(cumulus.EcowittApplicationKey, "<<App-key>>").Replace(cumulus.EcowittUserApiKey, "<<User-key>>");
 			cumulus.LogDebugMessage($"Ecowitt URL = {logUrl}");
 
+			cumulus.LogConsoleMessage($"Processing history data from {startTime.ToString("yyyy-MM-dd HH:mm")} to {endTime.ToString("yyyy-MM-dd HH:mm")}...");
+
 			try
 			{
 				string responseBody;

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -401,12 +401,12 @@ namespace CumulusMX
 						{
 							GetLiveData();
 
-							// at the start of every 10 minutes to trigger battery status check
+							// at the start of every 20 minutes to trigger battery status check
 							var minute = DateTime.Now.Minute;
 							if (minute != lastMinute)
 							{
 								lastMinute = minute;
-								if ((minute % 10) == 0)
+								if ((minute % 20) == 0)
 								{
 									GetSensorIdsNew();
 								}
@@ -826,12 +826,12 @@ namespace CumulusMX
 					case string wh35 when wh35.StartsWith("WH35"):  // ch 1-8
 					case "WH90":
 						// if a WS90 is connected, it has a 4.75 second update rate, so reduce the MX update rate from the default 10 seconds
-						if (updateRate > 4000)
+						if (updateRate > 4000 && updateRate != 4000)
 						{
 							cumulus.LogMessage($"PrintSensorInfoNew: WS90 sensor detected, changing the update rate from {updateRate / 1000} seconds to 4 seconds");
 							updateRate = 4000;
 						}
-						battV = data[battPos] * 0.02;
+						battV = data[battPos] * 0.1;
 						batt = $"{battV:f1}V ({TestBattery10(data[battPos])})";  // volts/10, low = 1.2V
 						break;
 
@@ -841,7 +841,7 @@ namespace CumulusMX
 
 					case "WH68":
 					case string wh51 when wh51.StartsWith("WH51"):  // ch 1-8
-						battV = data[battPos] * 0.02;
+						battV = data[battPos] * 0.1;
 						batt = $"{battV:f1}V ({TestBattery10(data[battPos])})"; // volts/10, low = 1.2V or 1.0V??
 						break;
 
@@ -856,12 +856,13 @@ namespace CumulusMX
 					case "WH80":
 					case "WS80":
 						// if a WS80 is connected, it has a 4.75 second update rate, so reduce the MX update rate from the default 10 seconds
-						if (updateRate > 4000)
+						if (updateRate > 4000 && updateRate != 4000)
 						{
 							cumulus.LogMessage($"PrintSensorInfoNew: WS80 sensor detected, changing the update rate from {updateRate/1000} seconds to 4 seconds");
 							updateRate = 4000;
 						}
-						batt = $"{data[battPos]} ({TestBatteryPct(data[battPos])})"; // Percent low = 20
+						battV = data[battPos] * 0.02;
+						batt = $"{battV:f1}V ({(battV > 1.2 ? "OK" : "Low")})";
 						break;
 
 					default:
@@ -1125,11 +1126,13 @@ namespace CumulusMX
 								idx += 1;
 								break;
 							case 0x4C: //All sensor lowbatt 16 char
-									   // This has been deprecated since v1.6.5 - now use CMD_READ_SENSOR_ID_NEW
+								// This has been deprecated since v1.6.5 - now use CMD_READ_SENSOR_ID_NEW
+								/*
 								if (tenMinuteChanged && fwVersion.CompareTo(new Version("1.6.5")) >= 0)
 								{
 									batteryLow = batteryLow || DoBatteryStatus(data, idx);
 								}
+								*/
 								idx += 16;
 								break;
 							case 0x2A: //PM2.5 Air Quality Sensor(μg/m³)
@@ -1539,6 +1542,7 @@ namespace CumulusMX
 			return batteryLow;
 		}
 
+/*
 		private bool DoBatteryStatus(byte[] data, int index)
 		{
 			bool batteryLow = false;
@@ -1589,14 +1593,14 @@ namespace CumulusMX
 				cumulus.LogDebugMessage(str);
 
 			str = "wh51>" +
-				" ch1=" + TestBattery1(status.wh51, (byte)Wh51Ch.Ch1) +
-				" ch2=" + TestBattery1(status.wh31, (byte)Wh51Ch.Ch2) +
-				" ch3=" + TestBattery1(status.wh31, (byte)Wh51Ch.Ch3) +
-				" ch4=" + TestBattery1(status.wh31, (byte)Wh51Ch.Ch4) +
-				" ch5=" + TestBattery1(status.wh31, (byte)Wh51Ch.Ch5) +
-				" ch6=" + TestBattery1(status.wh31, (byte)Wh51Ch.Ch6) +
-				" ch7=" + TestBattery1(status.wh31, (byte)Wh51Ch.Ch7) +
-				" ch8=" + TestBattery1(status.wh31, (byte)Wh51Ch.Ch8);
+				" ch1=" + TestBattery10((byte)Wh51Ch.Ch1) + " - " + TestBattery10V((byte)Wh51Ch.Ch1) +
+				" ch2=" + TestBattery10((byte)Wh51Ch.Ch2) + " - " + TestBattery10V((byte)Wh51Ch.Ch2) +
+				" ch3=" + TestBattery10((byte)Wh51Ch.Ch3) + " - " + TestBattery10V((byte)Wh51Ch.Ch3) +
+				" ch4=" + TestBattery10((byte)Wh51Ch.Ch4) + " - " + TestBattery10V((byte)Wh51Ch.Ch4) +
+				" ch5=" + TestBattery10((byte)Wh51Ch.Ch5) + " - " + TestBattery10V((byte)Wh51Ch.Ch5) +
+				" ch6=" + TestBattery10((byte)Wh51Ch.Ch6) + " - " + TestBattery10V((byte)Wh51Ch.Ch6) +
+				" ch7=" + TestBattery10((byte)Wh51Ch.Ch7) + " - " + TestBattery10V((byte)Wh51Ch.Ch7) +
+				" ch8=" + TestBattery10((byte)Wh51Ch.Ch8) + " - " + TestBattery10V((byte)Wh51Ch.Ch8);
 			if (str.Contains("Low"))
 			{
 				batteryLow = true;
@@ -1656,6 +1660,7 @@ namespace CumulusMX
 
 			return batteryLow;
 		}
+*/
 
 		private bool DoWH34BatteryStatus(byte[] data, int index)
 		{

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -16,7 +16,7 @@ namespace CumulusMX
 	internal class GW1000Station : WeatherStation
 	{
 		private string ipaddr;
-		private string macaddr;
+		private readonly string macaddr;
 		private const int AtPort = 45000;
 		private int updateRate = 10000; // 10 seconds by default
 		private int lastMinute;
@@ -33,9 +33,9 @@ namespace CumulusMX
 		private readonly System.Timers.Timer tmrDataWatchdog;
 		private bool stop = false;
 
-		private readonly NumberFormatInfo invNum = CultureInfo.InvariantCulture.NumberFormat;
+		//private readonly NumberFormatInfo invNum = CultureInfo.InvariantCulture.NumberFormat;
 
-		private Version fwVersion;
+		private readonly Version fwVersion;
 
 		private string mainSensor;
 
@@ -1685,17 +1685,20 @@ namespace CumulusMX
 		{
 			return (value & mask) == 0 ? "OK" : "Low";
 		}
-
+		
+		/*
 		private static string TestBattery1(UInt16 value, UInt16 mask)
 		{
 			return (value & mask) == 0 ? "OK" : "Low";
 		}
-
+		*/
+		/*
 		private static string TestBattery2(UInt16 value, UInt16 mask)
 		{
 			return (value & mask) > 1 ? "OK" : "Low";
 		}
-
+		*/
+		
 		private static string TestBattery3(byte value)
 		{
 			if (value == 6)
@@ -1712,13 +1715,15 @@ namespace CumulusMX
 		{
 			return value / 10.0;
 		}
-
+		
+		/*
 		private static string TestBatteryPct(byte value)
 		{
 			return value >= 20 ? "OK" : "Low";
 		}
+		*/
 
-
+		/*
 		private static object RawDeserialize(byte[] rawData, int position, Type anyType)
 		{
 			int rawsize = Marshal.SizeOf(anyType);
@@ -1730,6 +1735,7 @@ namespace CumulusMX
 			Marshal.FreeHGlobal(buffer);
 			return retobj;
 		}
+		*/
 
 		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
 		private struct CommandPayload

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -193,6 +193,7 @@ namespace CumulusMX
 				cumulus.LogDebugMessage($"{procName}: Processing posted data");
 
 				var text = new StreamReader(context.Request.InputStream).ReadToEnd();
+				text = System.Text.RegularExpressions.Regex.Replace(text, "PASSKEY=[^&]+", "PASSKEY=<PassKey>");
 
 				cumulus.LogDataMessage($"{procName}: Payload = {text}");
 

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -423,15 +423,16 @@ namespace CumulusMX
 						// dailyrainin
 						// weeklyrainin
 						// monthlyrainin
-						// yearlyrainin
+						// yearlyrainin - also turns out that not all stations send this :(
 						// totalrainin - not reliable, depends on console and firmware version as to whether this is available or not.
 						// rainratein
 						// 24hourrainin Ambient only?
 						// eventrainin
 
-						var rain = data["yearlyrainin"];
+						// if no yearly counter, try the total counter
+						var rain = data["yearlyrainin"] ?? data["totalrainin"];
 						var rRate = data["rainratein"];
-
+							
 						if (rRate == null)
 						{
 							// No rain rate, so we will calculate it

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.15.0 - Build 3169")]
+[assembly: AssemblyDescription("Version 3.15.1 - Build 3170")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.15.0.3169")]
-[assembly: AssemblyFileVersion("3.15.0.3169")]
+[assembly: AssemblyVersion("3.15.1.3170")]
+[assembly: AssemblyFileVersion("3.15.1.3170")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -408,8 +408,7 @@ namespace CumulusMX
 
 			var generalAdvanced = new JsonStationSettingsAdvanced()
 			{
-				recsbegandate = cumulus.RecordsBeganDate,
-				recstimeout = cumulus.RecordSetTimeoutHrs
+				recsbegandate = cumulus.RecordsBeganDate
 			};
 
 			var general = new JsonStationGeneral()
@@ -1145,7 +1144,6 @@ namespace CumulusMX
 				try
 				{
 					cumulus.RecordsBeganDate = settings.general.advanced.recsbegandate;
-					cumulus.RecordSetTimeoutHrs = settings.general.advanced.recstimeout;
 				}
 				catch (Exception ex)
 				{
@@ -1384,7 +1382,6 @@ namespace CumulusMX
 	internal class JsonStationSettingsAdvanced
 	{
 		public string recsbegandate { get; set; }
-		public int recstimeout { get; set; }
 	}
 
 	internal class JsonStationSettingsUnitsAdvanced

--- a/CumulusMX/SunriseSunset.cs
+++ b/CumulusMX/SunriseSunset.cs
@@ -156,10 +156,7 @@ namespace CumulusMX
 			var min = ts.Minutes;
 			var sec = ts.Seconds;
 
-			//double hour = (int)Math.Floor(t);
-			//double min = (int)Math.Floor((t - hour) * 60 + 0.5);
-			return (hour.ToString("00") + min.ToString("00") + sec.ToString("00"));
-			//return "0000";
+			return $"{hour:00}{min:00}{sec:00}";
 		}
 
 		private static double LocalMeanSiderealTime(double mjd, double glong)

--- a/CumulusMX/TempestStation.cs
+++ b/CumulusMX/TempestStation.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO.Ports;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;

--- a/CumulusMX/WeatherLinkDotCom.cs
+++ b/CumulusMX/WeatherLinkDotCom.cs
@@ -508,7 +508,6 @@ namespace CumulusMX
 			}
 			return msg.ToString();
 		}
-
 	}
 
 	public class WlComSystemStatusResult

--- a/CumulusMX/WeatherLinkDotCom.cs
+++ b/CumulusMX/WeatherLinkDotCom.cs
@@ -453,12 +453,69 @@ namespace CumulusMX
 	public class WlComSystemStatus
 	{
 		public WlComSystemStatusResult result {get; set;}
+
+		public string ToString(bool PrintFullMessage)
+		{
+			if (!PrintFullMessage)
+			{
+				return $"Weatherlink.com overall System Status: '{result.status_overall.status}', Updated: {result.status_overall.updated}";
+			}
+
+			var msg = new StringBuilder();
+
+			msg.AppendLine($"Weatherlink.com overall System Status: '{result.status_overall.status}', Updated: {result.status_overall.updated}");
+			if (result.status_overall.status_code != 100)
+			{
+				// If we are not OK, then find what isn't working
+				msg.AppendLine("Individual subsystems: ");
+				foreach (var subSys in result.status)
+				{
+					msg.AppendLine($"   Subsystem: {subSys.name}, status: {subSys.status}, last updated: {subSys.updated}");
+				}
+
+				if (result.incidents.Length > 0)
+				{
+					msg.AppendLine($"\nCurrent incidents:");
+					foreach (var incident in result.incidents)
+					{
+						msg.AppendLine($"  {incident.name}");
+						foreach (var message in incident.messages)
+						{
+							msg.AppendLine($"    {message.datetime} - {message.details}");
+						}
+
+						/*
+						if (incident.containers_affected.Length > 0)
+						{
+							msg.AppendLine($"  Affected containers:");
+							foreach (var container in incident.containers_affected)
+							{
+								msg.AppendLine($"    {container.name}");
+							}
+						}
+						*/
+
+						if (incident.components_affected.Length > 0)
+						{
+							msg.AppendLine($"  Affected components:");
+							foreach (var component in incident.components_affected)
+							{
+								msg.AppendLine($"    {component.name}");
+							}
+						}
+					}
+				}
+			}
+			return msg.ToString();
+		}
+
 	}
 
 	public class WlComSystemStatusResult
 	{
 		public WlComStatusOverall status_overall { get; set; }
 		public WlComStatus[] status { get; set; }
+		public WlComIncidents[] incidents { get; set; }
 	}
 
 	public class WlComStatusOverall
@@ -479,4 +536,23 @@ namespace CumulusMX
 		public string name { get; set; }
 	}
 
+	public class WlComIncidents
+	{
+		public string name { get; set; }
+		public DateTime datetime_open { get; set; }
+		public WlComIncidentMessages[] messages { get; set; }
+		public WlComAffected[] containers_affected { get; set; }
+		public WlComAffected[] components_affected { get; set; }
+	}
+
+	public class WlComIncidentMessages
+	{
+		public string details { get; set; }
+		public DateTime datetime { get; set; }
+	}
+
+	public class WlComAffected
+	{
+		public string name { get; set; }
+	}
 }

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -12528,7 +12528,7 @@ namespace CumulusMX
 
 	public class AllTimeRec
 	{
-		private static string[] alltimedescs = new[]
+		private static readonly string[] alltimedescs = new[]
 		{
 			"High temperature", "Low temperature", "High gust", "High wind speed", "Low wind chill", "High rain rate", "High daily rain",
 			"High hourly rain", "Low pressure", "High pressure", "Highest monthly rainfall", "Highest minimum temp", "Lowest maximum temp",
@@ -12536,7 +12536,7 @@ namespace CumulusMX
 			"High daily windrun", "Longest dry period", "Longest wet period", "High daily temp range", "Low daily temp range",
 			"High feels like", "Low feels like", "High Humidex"
 		};
-		private int idx;
+		private readonly int idx;
 
 		public AllTimeRec(int index)
 		{

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2062,20 +2062,16 @@ namespace CumulusMX
 			var dateFrom = date.AddHours(-1);
 
 			// get the min and max temps, humidity, pressure, and mean solar rad and wind speed for the last hour
-			var result = RecentDataDb.Query<EtData>("select max(OutsideTemp) maxTemp, min(OutsideTemp) minTemp, max(Humidity) maxHum, min(Humidity) minHum, max(Pressure) maxPress, min(Pressure) minPress, avg(SolarRad) avgSol, avg(WindSpeed) avgWind from RecentData where Timestamp >= ? order by Timestamp", dateFrom);
+			var result = RecentDataDb.Query<EtData>("select avg(OutsideTemp) avgTemp, avg(Humidity) avgHum, avg(Pressure) avgPress, avg(SolarRad) avgSol, avg(SolarMax) avgSolMax, avg(WindSpeed) avgWind from RecentData where Timestamp >= ? order by Timestamp", dateFrom);
 
 			// finally calculate the ETo
 			var newET = MeteoLib.Evapotranspiration(
-				ConvertUserTempToC(result[0].minTemp),
-				ConvertUserTempToC(result[0].maxTemp),
-				result[0].minHum,
-				result[0].maxHum,
+				ConvertUserTempToC(result[0].avgTemp),
+				result[0].avgHum,
 				result[0].avgSol,
+				result[0].avgSolMax,
 				ConvertUserWindToMS(result[0].avgWind),
-				cumulus.Latitude,
-				cumulus.Longitude,
-				AltitudeM(cumulus.Altitude),
-				date
+				ConvertUserPressureToHPa(result[0].avgPress) / 10
 			);
 
 			// convert to user units
@@ -12436,14 +12432,12 @@ namespace CumulusMX
 
 	class EtData
 	{
-		public double maxTemp { get; set; }
-		public double minTemp { get; set; }
-		public int maxHum { get; set; }
-		public int minHum { get; set; }
+		public double avgTemp { get; set; }
+		public int avgHum { get; set; }
 		public double avgSol { get; set; }
+		public double avgSolMax { get; set; }
 		public double avgWind { get; set; }
-		public double maxPress { get; set; }
-		public double minPress { get; set; }
+		public double avgPress { get; set; }
 	}
 
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -12017,6 +12017,8 @@ namespace CumulusMX
 
 		public void UpdateAPRS()
 		{
+			// See: http://aprs.net/vm/DOS/PROTOCOL.HTM
+
 			if (DataStopped)
 			{
 				// No data coming in, do nothing

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -403,8 +403,10 @@ namespace CumulusMX
 			// then if that is later than now we are still in the previous day, so subtract a day
 			if (startOfDay > DateTime.Now)
 				startOfDay = startOfDay.AddDays(-1);
-			var timeToday = station.WindRunHourMult[cumulus.Units.Wind] * (DateTime.Now - startOfDay).TotalHours;
-			return CheckRcDp(station.WindRunToday / timeToday, tagParams, cumulus.WindAvgDPlaces);
+			var hours = (DateTime.Now - startOfDay).TotalHours;
+			var timeToday = station.WindRunHourMult[cumulus.Units.Wind] * hours;
+			// just after rollover the numbers will be silly, so return zero for the first 15 minutes
+			return CheckRcDp(hours > 0.25 ? station.WindRunToday / timeToday : 0, tagParams, cumulus.WindAvgDPlaces);
 		}
 
 		private string Tagwchill(Dictionary<string,string> tagParams)

--- a/Updates.txt
+++ b/Updates.txt
@@ -4,6 +4,8 @@
 - Fix: Remove duplicated Records Set Timeout setting in Station Settings/General/Advanced
 
 - Change: Tweak to the ET calculation
+- Change: Improved WeatherLink.com status message logging
+
 
 
 3.15.0 - b3169

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,11 @@
+3.15.1 - b3107
+——————————————
+- Fix: Changes to the initial ping delay
+- Fix: Remove duplicated Records Set Timeout setting in Station Settings/General/Advanced
+
+- Change: Tweak to the ET calculation
+
+
 3.15.0 - b3169
 ——————————————
 - Fix: Prevent real time processing occurring before first data has been received

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,9 +2,12 @@
 ——————————————
 - Fix: Changes to the initial ping delay
 - Fix: Remove duplicated Records Set Timeout setting in Station Settings/General/Advanced
+- Fix: Some HTTP Ecowitt stations not sending yearlyrainin - try and use totalrainin for these
 
 - Change: Tweak to the ET calculation
 - Change: Improved WeatherLink.com status message logging
+- Change: The Ecowitt GW1000 station has been renamed to "Ecowitt Local API" to better reflect the applicability to a range of devices
+	- The Ecowitt local API remains the preferred method of connection over HTTP (Ecowitt)
 
 
 


### PR DESCRIPTION
- Fix: Changes to the initial ping delay
- Fix: Remove duplicated Records Set Timeout setting in Station Settings/General/Advanced
- Fix: Some HTTP Ecowitt stations not sending yearlyrainin - try and use totalrainin for these

- Change: Tweak to the ET calculation
- Change: Improved WeatherLink.com status message logging
- Change: The Ecowitt GW1000 station has been renamed to "Ecowitt Local API" to better reflect the applicability to a range of devices
	- The Ecowitt local API remains the preferred method of connection over HTTP (Ecowitt)
