### PR TITLE
v3.15.3

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1151,9 +1151,9 @@ namespace CumulusMX
 							do
 							{
 								Thread.Sleep(500);
-							} while (pingReply == null || DateTime.Now > pingTimeout);
+							} while (pingReply == null && DateTime.Now < pingTimeout);
 
-							if (DateTime.Now >= pingTimeout)
+							if (pingReply == null)
 							{
 								LogMessage("Ping Error: The PING failed to return after the timeout, cancelling it...");
 								ping.SendAsyncCancel();

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.15.3 - Build 3172")]
+[assembly: AssemblyDescription("Version 3.15.3 - Build 3173")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.15.3.3172")]
-[assembly: AssemblyFileVersion("3.15.3.3172")]
+[assembly: AssemblyVersion("3.15.3.3173")]
+[assembly: AssemblyFileVersion("3.15.3.3173")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.15.2 - Build 3171")]
+[assembly: AssemblyDescription("Version 3.15.3 - Build 3172")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.15.2.3171")]
-[assembly: AssemblyFileVersion("3.15.2.3171")]
+[assembly: AssemblyVersion("3.15.3.3172")]
+[assembly: AssemblyFileVersion("3.15.3.3172")]

--- a/CumulusMX/ThirdPartySettings.cs
+++ b/CumulusMX/ThirdPartySettings.cs
@@ -289,12 +289,12 @@ namespace CumulusMX
 				{
 					// custom seconds
 					cumulus.CustomHttpSecondsEnabled = settings.customhttp.customseconds.enabled;
+					cumulus.CustomHttpSecondsTimer.Enabled = cumulus.CustomHttpSecondsEnabled;
 					if (cumulus.CustomHttpSecondsEnabled)
 					{
 						cumulus.CustomHttpSecondsString = settings.customhttp.customseconds.url ?? string.Empty;
 						cumulus.CustomHttpSecondsInterval = settings.customhttp.customseconds.interval;
 						cumulus.CustomHttpSecondsTimer.Interval = cumulus.CustomHttpSecondsInterval * 1000;
-						cumulus.CustomHttpSecondsTimer.Enabled = cumulus.CustomHttpSecondsEnabled;
 					}
 					// custom minutes
 					cumulus.CustomHttpMinutesEnabled = settings.customhttp.customminutes.enabled;

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1718,7 +1718,7 @@ namespace CumulusMX
 						}
 						else if (cumulus.WebUpdating >= 2)
 						{
-							cumulus.LogMessage("Warning, previous web update is still in progress,second chance, aborting connection");
+							cumulus.LogMessage("Warning, previous web update is still in progress, second chance, aborting connection");
 							if (cumulus.ftpThread.ThreadState == System.Threading.ThreadState.Running)
 								cumulus.ftpThread.Abort();
 							cumulus.LogMessage("Trying new web update");

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,12 @@
-3.15.3 - b3172
+3.15.3 - b3173
 ——————————————
 - Fix: Broken start-up ping in 3.15.2 - doh!
+- Fix: Ecowitt historic catch-up when expected data is missing
+- Fix: Disabling the Third Party HTTP Seconds upload no longer requires a restart of CMX
+
+- Change: Ecowitt historic catch-up now applies a 5 minute offset to the received data
+
+
 
 3.15.2 - b3171
 ——————————————

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,7 @@
+3.15.3 - b3172
+——————————————
+- Fix: Broken start-up ping in 3.15.2 - doh!
+
 3.15.2 - b3171
 ——————————————
 - Fix: Broken start-up ping in 3.15.1


### PR DESCRIPTION
- Fix: Broken start-up ping in 3.15.2 - doh!
- Fix: Ecowitt historic catch-up when expected data is missing
- Fix: Disabling the Third Party HTTP Seconds upload no longer requires a restart of CMX

- Change: Ecowitt historic catch-up now applies a 5 minute offset to the received data