### PR TITLE
v3.16.0

### DIFF
--- a/CumulusMX/AlarmSettings.cs
+++ b/CumulusMX/AlarmSettings.cs
@@ -268,6 +268,8 @@ namespace CumulusMX
 				// process the settings
 				cumulus.LogMessage("Updating Alarm settings");
 
+				var emailRequired = false;
+
 				cumulus.LowTempAlarm.Enabled = settings.tempBelow.Enabled;
 				cumulus.LowTempAlarm.Value = settings.tempBelow.Val;
 				cumulus.LowTempAlarm.Sound = settings.tempBelow.SoundEnabled;
@@ -276,7 +278,7 @@ namespace CumulusMX
 				cumulus.LowTempAlarm.Email = settings.tempBelow.Email;
 				cumulus.LowTempAlarm.Latch = settings.tempBelow.Latches;
 				cumulus.LowTempAlarm.LatchHours = settings.tempBelow.LatchHrs;
-
+				emailRequired = cumulus.LowTempAlarm.Email && cumulus.LowTempAlarm.Enabled;
 
 				cumulus.HighTempAlarm.Enabled = settings.tempAbove.Enabled;
 				cumulus.HighTempAlarm.Value = settings.tempAbove.Val;
@@ -286,6 +288,7 @@ namespace CumulusMX
 				cumulus.HighTempAlarm.Email = settings.tempAbove.Email;
 				cumulus.HighTempAlarm.Latch = settings.tempAbove.Latches;
 				cumulus.HighTempAlarm.LatchHours = settings.tempAbove.LatchHrs;
+				emailRequired = emailRequired || (cumulus.HighTempAlarm.Email && cumulus.HighTempAlarm.Enabled);
 
 				cumulus.TempChangeAlarm.Enabled = settings.tempChange.Enabled;
 				cumulus.TempChangeAlarm.Value = settings.tempChange.Val;
@@ -295,6 +298,7 @@ namespace CumulusMX
 				cumulus.TempChangeAlarm.Email = settings.tempChange.Email;
 				cumulus.TempChangeAlarm.Latch = settings.tempChange.Latches;
 				cumulus.TempChangeAlarm.LatchHours = settings.tempChange.LatchHrs;
+				emailRequired = emailRequired || (cumulus.TempChangeAlarm.Email && cumulus.TempChangeAlarm.Enabled);
 
 				cumulus.LowPressAlarm.Enabled = settings.pressBelow.Enabled;
 				cumulus.LowPressAlarm.Value = settings.pressBelow.Val;
@@ -304,6 +308,7 @@ namespace CumulusMX
 				cumulus.LowPressAlarm.Email = settings.pressBelow.Email;
 				cumulus.LowPressAlarm.Latch = settings.pressBelow.Latches;
 				cumulus.LowPressAlarm.LatchHours = settings.pressBelow.LatchHrs;
+				emailRequired = emailRequired || (cumulus.LowPressAlarm.Email && cumulus.LowPressAlarm.Enabled);
 
 				cumulus.HighPressAlarm.Enabled = settings.pressAbove.Enabled;
 				cumulus.HighPressAlarm.Value = settings.pressAbove.Val;
@@ -313,6 +318,7 @@ namespace CumulusMX
 				cumulus.HighPressAlarm.Email = settings.pressAbove.Email;
 				cumulus.HighPressAlarm.Latch = settings.pressAbove.Latches;
 				cumulus.HighPressAlarm.LatchHours = settings.pressAbove.LatchHrs;
+				emailRequired = emailRequired || (cumulus.HighPressAlarm.Email && cumulus.HighPressAlarm.Enabled);
 
 				cumulus.PressChangeAlarm.Enabled = settings.pressChange.Enabled;
 				cumulus.PressChangeAlarm.Value = settings.pressChange.Val;
@@ -322,6 +328,7 @@ namespace CumulusMX
 				cumulus.PressChangeAlarm.Email = settings.pressChange.Email;
 				cumulus.PressChangeAlarm.Latch = settings.pressChange.Latches;
 				cumulus.PressChangeAlarm.LatchHours = settings.pressChange.LatchHrs;
+				emailRequired = emailRequired || (cumulus.PressChangeAlarm.Email && cumulus.PressChangeAlarm.Enabled);
 
 				cumulus.HighRainTodayAlarm.Enabled = settings.rainAbove.Enabled;
 				cumulus.HighRainTodayAlarm.Value = settings.rainAbove.Val;
@@ -331,6 +338,7 @@ namespace CumulusMX
 				cumulus.HighRainTodayAlarm.Email = settings.rainAbove.Email;
 				cumulus.HighRainTodayAlarm.Latch = settings.rainAbove.Latches;
 				cumulus.HighRainTodayAlarm.LatchHours = settings.rainAbove.LatchHrs;
+				emailRequired = emailRequired || (cumulus.HighRainTodayAlarm.Email && cumulus.HighRainTodayAlarm.Enabled);
 
 				cumulus.HighRainRateAlarm.Enabled = settings.rainRateAbove.Enabled;
 				cumulus.HighRainRateAlarm.Value = settings.rainRateAbove.Val;
@@ -340,6 +348,7 @@ namespace CumulusMX
 				cumulus.HighRainRateAlarm.Email = settings.rainRateAbove.Email;
 				cumulus.HighRainRateAlarm.Latch = settings.rainRateAbove.Latches;
 				cumulus.HighRainRateAlarm.LatchHours = settings.rainRateAbove.LatchHrs;
+				emailRequired = emailRequired || (cumulus.HighRainRateAlarm.Email && cumulus.HighRainRateAlarm.Enabled);
 
 				cumulus.HighGustAlarm.Enabled = settings.gustAbove.Enabled;
 				cumulus.HighGustAlarm.Value = settings.gustAbove.Val;
@@ -349,6 +358,7 @@ namespace CumulusMX
 				cumulus.HighGustAlarm.Email = settings.gustAbove.Email;
 				cumulus.HighGustAlarm.Latch = settings.gustAbove.Latches;
 				cumulus.HighGustAlarm.LatchHours = settings.gustAbove.LatchHrs;
+				emailRequired = emailRequired || (cumulus.HighGustAlarm.Email && cumulus.HighGustAlarm.Enabled);
 
 				cumulus.HighWindAlarm.Enabled = settings.windAbove.Enabled;
 				cumulus.HighWindAlarm.Value = settings.windAbove.Val;
@@ -358,6 +368,7 @@ namespace CumulusMX
 				cumulus.HighWindAlarm.Email = settings.windAbove.Email;
 				cumulus.HighWindAlarm.Latch = settings.windAbove.Latches;
 				cumulus.HighWindAlarm.LatchHours = settings.windAbove.LatchHrs;
+				emailRequired = emailRequired || (cumulus.HighWindAlarm.Email && cumulus.HighWindAlarm.Enabled);
 
 				cumulus.SensorAlarm.Enabled = settings.contactLost.Enabled;
 				cumulus.SensorAlarm.Sound = settings.contactLost.SoundEnabled;
@@ -367,6 +378,7 @@ namespace CumulusMX
 				cumulus.SensorAlarm.Latch = settings.contactLost.Latches;
 				cumulus.SensorAlarm.LatchHours = settings.contactLost.LatchHrs;
 				cumulus.SensorAlarm.TriggerThreshold = settings.contactLost.Threshold;
+				emailRequired = emailRequired || (cumulus.SensorAlarm.Email && cumulus.SensorAlarm.Enabled);
 
 				cumulus.DataStoppedAlarm.Enabled = settings.dataStopped.Enabled;
 				cumulus.DataStoppedAlarm.Sound = settings.dataStopped.SoundEnabled;
@@ -376,6 +388,7 @@ namespace CumulusMX
 				cumulus.DataStoppedAlarm.Latch = settings.dataStopped.Latches;
 				cumulus.DataStoppedAlarm.LatchHours = settings.dataStopped.LatchHrs;
 				cumulus.DataStoppedAlarm.TriggerThreshold = settings.dataStopped.Threshold;
+				emailRequired = emailRequired || (cumulus.DataStoppedAlarm.Email && cumulus.DataStoppedAlarm.Enabled);
 
 				cumulus.BatteryLowAlarm.Enabled = settings.batteryLow.Enabled;
 				cumulus.BatteryLowAlarm.Sound = settings.batteryLow.SoundEnabled;
@@ -385,6 +398,7 @@ namespace CumulusMX
 				cumulus.BatteryLowAlarm.Latch = settings.batteryLow.Latches;
 				cumulus.BatteryLowAlarm.LatchHours = settings.batteryLow.LatchHrs;
 				cumulus.BatteryLowAlarm.TriggerThreshold = settings.batteryLow.Threshold;
+				emailRequired = emailRequired || (cumulus.BatteryLowAlarm.Email && cumulus.BatteryLowAlarm.Enabled);
 
 				cumulus.SpikeAlarm.Enabled = settings.spike.Enabled;
 				cumulus.SpikeAlarm.Sound = settings.spike.SoundEnabled;
@@ -394,6 +408,7 @@ namespace CumulusMX
 				cumulus.SpikeAlarm.Latch = settings.spike.Latches;
 				cumulus.SpikeAlarm.LatchHours = settings.spike.LatchHrs;
 				cumulus.SpikeAlarm.TriggerThreshold = settings.spike.Threshold;
+				emailRequired = emailRequired || (cumulus.SpikeAlarm.Email && cumulus.SpikeAlarm.Enabled);
 
 				cumulus.UpgradeAlarm.Enabled = settings.upgrade.Enabled;
 				cumulus.UpgradeAlarm.Sound = settings.upgrade.SoundEnabled;
@@ -402,6 +417,7 @@ namespace CumulusMX
 				cumulus.UpgradeAlarm.Email = settings.upgrade.Email;
 				cumulus.UpgradeAlarm.Latch = settings.upgrade.Latches;
 				cumulus.UpgradeAlarm.LatchHours = settings.upgrade.LatchHrs;
+				emailRequired = emailRequired || (cumulus.UpgradeAlarm.Email && cumulus.UpgradeAlarm.Enabled);
 
 				cumulus.HttpUploadAlarm.Enabled = settings.httpUpload.Enabled;
 				cumulus.HttpUploadAlarm.Sound = settings.httpUpload.SoundEnabled;
@@ -411,6 +427,7 @@ namespace CumulusMX
 				cumulus.HttpUploadAlarm.Latch = settings.httpUpload.Latches;
 				cumulus.HttpUploadAlarm.LatchHours = settings.httpUpload.LatchHrs;
 				cumulus.HttpUploadAlarm.TriggerThreshold = settings.httpUpload.Threshold;
+				emailRequired = emailRequired || (cumulus.HttpUploadAlarm.Email && cumulus.HttpUploadAlarm.Enabled);
 
 				cumulus.MySqlUploadAlarm.Enabled = settings.mySqlUpload.Enabled;
 				cumulus.MySqlUploadAlarm.Sound = settings.mySqlUpload.SoundEnabled;
@@ -420,16 +437,20 @@ namespace CumulusMX
 				cumulus.MySqlUploadAlarm.Latch = settings.mySqlUpload.Latches;
 				cumulus.MySqlUploadAlarm.LatchHours = settings.mySqlUpload.LatchHrs;
 				cumulus.MySqlUploadAlarm.TriggerThreshold = settings.mySqlUpload.Threshold;
+				emailRequired = emailRequired || (cumulus.MySqlUploadAlarm.Email && cumulus.MySqlUploadAlarm.Enabled);
 
 				// validate the from email
-				if (!EmailSender.CheckEmailAddress(result.email.fromEmail.Trim()))
+				if (emailRequired && !EmailSender.CheckEmailAddress(result.email.fromEmail.Trim()))
 				{
-					var msg = "ERROR: Invalid Alarm from email address entered";
+					var msg = "ERROR: Alarm email option enabled and an invalid Alarm from email address entered";
 					cumulus.LogMessage(msg);
 					context.Response.StatusCode = 500;
 					return msg;
 				}
-				cumulus.AlarmFromEmail = result.email.fromEmail.Trim();
+				else
+				{
+					cumulus.AlarmFromEmail = result.email.fromEmail.Trim();
+				}
 
 				// validate the destination email(s)
 				var emails = result.email.destEmail.Trim().Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);

--- a/CumulusMX/AstroLib.cs
+++ b/CumulusMX/AstroLib.cs
@@ -66,11 +66,11 @@ namespace CumulusMX
 			double factor = 0;
 			if (options.SolarCalc == 0)
 			{
-				factor = GetFactor(timestamp, options.RStransfactorJul, options.RStransfactorDec);
+				factor = GetFactor(timestamp, options.RStransfactorJun, options.RStransfactorDec);
 			}
 			if (options.SolarCalc == 1)
 			{
-				factor = GetFactor(timestamp, options.BrasTurbidityJul, options.BrasTurbidityDec);
+				factor = GetFactor(timestamp, options.BrasTurbidityJun, options.BrasTurbidityDec);
 			}
 			return SolarMax(timestamp, longitude, latitude, altitude, out solarelevation, factor, options.SolarCalc);
 		}
@@ -99,9 +99,9 @@ namespace CumulusMX
 		}
 
 		// Calculate the interpolated factor using a cosine function
-		private static double GetFactor(DateTime timestamp, double jul, double dec)
+		private static double GetFactor(DateTime timestamp, double jun, double dec)
 		{
-			var range = jul - dec;
+			var range = jun - dec;
 			var doy = timestamp.DayOfYear;
 			return dec + Math.Cos((doy - 172) / 183.0 * Math.PI / 2) * range;
 		}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4245,6 +4245,11 @@ namespace CumulusMX
 			EcowittExtraUseCo2= ini.GetValue("GW1000", "ExtraSensorUseCo2", true);
 			EcowittExtraUseLightning = ini.GetValue("GW1000", "ExtraSensorUseLightning", true);
 			EcowittExtraUseLeak= ini.GetValue("GW1000", "ExtraSensorUseLeak", true);
+			EcowittSetCustomServer = ini.GetValue("GW1000", "SetCustomServer", false);
+			EcowittGatewayAddr = ini.GetValue("GW1000", "EcowittGwAddr", "0.0.0.0");
+			var localIp = Utils.GetIpWithDefaultGateway();
+			EcowittLocalAddr = ini.GetValue("GW1000", "EcowittLocalAddr", localIp.ToString());
+			EcowittCustomInterval = ini.GetValue("GW1000", "EcowittCustomInterval", 16);
 			// api
 			EcowittApplicationKey = ini.GetValue("GW1000", "EcowittAppKey", "");
 			EcowittUserApiKey = ini.GetValue("GW1000", "EcowittUserKey", "");
@@ -5372,6 +5377,10 @@ namespace CumulusMX
 			ini.SetValue("GW1000", "ExtraSensorUseCo2", EcowittExtraUseCo2);
 			ini.SetValue("GW1000", "ExtraSensorUseLightning", EcowittExtraUseLightning);
 			ini.SetValue("GW1000", "ExtraSensorUseLeak", EcowittExtraUseLeak);
+			ini.SetValue("GW1000", "SetCustomServer", EcowittSetCustomServer);
+			ini.SetValue("GW1000", "EcowittGwAddr", EcowittGatewayAddr);
+			ini.SetValue("GW1000", "EcowittLocalAddr", EcowittLocalAddr);
+			ini.SetValue("GW1000", "EcowittCustomInterval", EcowittCustomInterval);
 
 			ini.SetValue("GW1000", "EcowittAppKey", EcowittApplicationKey);
 			ini.SetValue("GW1000", "EcowittUserKey", EcowittUserApiKey);
@@ -6338,6 +6347,10 @@ namespace CumulusMX
 		public string EcowittApplicationKey { get; set; }
 		public string EcowittUserApiKey { get; set; }
 		public string EcowittMacAddress { get; set; }
+		public bool EcowittSetCustomServer { get; set; }
+		public string EcowittGatewayAddr { get; set; }
+		public string EcowittLocalAddr { get; set; }
+		public int EcowittCustomInterval { get; set; }
 
 		public bool AmbientExtraEnabled { get; set; }
 		public bool AmbientExtraUseSolar { get; set; }

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4233,6 +4233,7 @@ namespace CumulusMX
 			Gw1000MacAddress = ini.GetValue("GW1000", "MACAddress", "");
 			Gw1000AutoUpdateIpAddress = ini.GetValue("GW1000", "AutoUpdateIpAddress", true);
 			Gw1000PrimaryTHSensor = ini.GetValue("GW1000", "PrimaryTHSensor", 0);  // 0=default, 1-8=extra t/h sensor number
+			Gw1000PrimaryRainSensor = ini.GetValue("GW1000", "PrimaryRainSensor", 0); //0=main station (tipping bucket) 1=piezo
 			EcowittExtraEnabled = ini.GetValue("GW1000", "ExtraSensorDataEnabled", false);
 			EcowittExtraUseSolar = ini.GetValue("GW1000", "ExtraSensorUseSolar", true);
 			EcowittExtraUseUv = ini.GetValue("GW1000", "ExtraSensorUseUv", true);
@@ -4250,6 +4251,11 @@ namespace CumulusMX
 			var localIp = Utils.GetIpWithDefaultGateway();
 			EcowittLocalAddr = ini.GetValue("GW1000", "EcowittLocalAddr", localIp.ToString());
 			EcowittCustomInterval = ini.GetValue("GW1000", "EcowittCustomInterval", 16);
+			//
+			EcowittExtraSetCustomServer = ini.GetValue("GW1000", "ExtraSetCustomServer", false);
+			EcowittExtraGatewayAddr = ini.GetValue("GW1000", "EcowittExtraGwAddr", "0.0.0.0");
+			EcowittExtraLocalAddr = ini.GetValue("GW1000", "EcowittExtraLocalAddr", localIp.ToString());
+			EcowittExtraCustomInterval = ini.GetValue("GW1000", "EcowittExtraCustomInterval", 16);
 			// api
 			EcowittApplicationKey = ini.GetValue("GW1000", "EcowittAppKey", "");
 			EcowittUserApiKey = ini.GetValue("GW1000", "EcowittUserKey", "");
@@ -5365,6 +5371,7 @@ namespace CumulusMX
 			ini.SetValue("GW1000", "MACAddress", Gw1000MacAddress);
 			ini.SetValue("GW1000", "AutoUpdateIpAddress", Gw1000AutoUpdateIpAddress);
 			ini.SetValue("GW1000", "PrimaryTHSensor", Gw1000PrimaryTHSensor);
+			ini.SetValue("GW1000", "PrimaryRainSensor", Gw1000PrimaryRainSensor);
 			ini.SetValue("GW1000", "ExtraSensorDataEnabled", EcowittExtraEnabled);
 			ini.SetValue("GW1000", "ExtraSensorUseSolar", EcowittExtraUseSolar);
 			ini.SetValue("GW1000", "ExtraSensorUseUv", EcowittExtraUseUv);
@@ -5381,7 +5388,11 @@ namespace CumulusMX
 			ini.SetValue("GW1000", "EcowittGwAddr", EcowittGatewayAddr);
 			ini.SetValue("GW1000", "EcowittLocalAddr", EcowittLocalAddr);
 			ini.SetValue("GW1000", "EcowittCustomInterval", EcowittCustomInterval);
-
+			ini.SetValue("GW1000", "ExtraSetCustomServer", EcowittExtraSetCustomServer);
+			ini.SetValue("GW1000", "EcowittExtraGwAddr", EcowittExtraGatewayAddr);
+			ini.SetValue("GW1000", "EcowittExtraLocalAddr", EcowittExtraLocalAddr);
+			ini.SetValue("GW1000", "EcowittExtraCustomInterval", EcowittExtraCustomInterval);
+			// api
 			ini.SetValue("GW1000", "EcowittAppKey", EcowittApplicationKey);
 			ini.SetValue("GW1000", "EcowittUserKey", EcowittUserApiKey);
 			ini.SetValue("GW1000", "EcowittMacAddress", EcowittMacAddress);
@@ -6351,6 +6362,10 @@ namespace CumulusMX
 		public string EcowittGatewayAddr { get; set; }
 		public string EcowittLocalAddr { get; set; }
 		public int EcowittCustomInterval { get; set; }
+		public bool EcowittExtraSetCustomServer { get; set; }
+		public string EcowittExtraGatewayAddr { get; set; }
+		public string EcowittExtraLocalAddr { get; set; }
+		public int EcowittExtraCustomInterval { get; set; }
 
 		public bool AmbientExtraEnabled { get; set; }
 		public bool AmbientExtraUseSolar { get; set; }
@@ -6562,6 +6577,7 @@ namespace CumulusMX
 		public string Gw1000MacAddress;
 		public bool Gw1000AutoUpdateIpAddress = true;
 		public int Gw1000PrimaryTHSensor;
+		public int Gw1000PrimaryRainSensor;
 
 		public Timer WundTimer = new Timer();
 		public Timer WebTimer = new Timer();

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -209,6 +209,7 @@
     <Compile Include="ExtraSensorSettings.cs" />
     <Compile Include="FOStation.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="GW1000Api.cs" />
     <Compile Include="GW1000Station.cs" />
     <Compile Include="HttpStationAmbient.cs" />
     <Compile Include="HttpStationEcowitt.cs" />

--- a/CumulusMX/DavisAirLink.cs
+++ b/CumulusMX/DavisAirLink.cs
@@ -1567,7 +1567,7 @@ namespace CumulusMX
 
 		private void OnServiceChanged(object sender, ServiceAnnouncementEventArgs e)
 		{
-			cumulus.LogMessage($"ZeroConfig Service: AirLink {e.Announcement.Hostname} service has changed!");
+			cumulus.LogMessage($"ZeroConf Service: AirLink {e.Announcement.Hostname} service has changed!");
 			if (discovered.Hostname.Contains(e.Announcement.Hostname))
 			{
 				var idx = discovered.Hostname.IndexOf(e.Announcement.Hostname);
@@ -1578,10 +1578,10 @@ namespace CumulusMX
 
 		private void OnServiceRemoved(object sender, ServiceAnnouncementEventArgs e)
 		{
-			cumulus.LogMessage($"ZeroConfig Service: AirLink {e.Announcement.Hostname} service has been removed!");
+			cumulus.LogMessage($"ZeroConf Service: AirLink {e.Announcement.Hostname} service has been removed!");
 			if (discovered.Hostname.Contains(e.Announcement.Hostname))
 			{
-				//cumulus.LogDebugMessage($"ZeroConfig Service: Removing {e.Announcement.Hostname} / {e.Announcement.Addresses[0]} from the discovered device list");
+				//cumulus.LogDebugMessage($"ZeroConf Service: Removing {e.Announcement.Hostname} / {e.Announcement.Addresses[0]} from the discovered device list");
 				//discovered.Hostname.Remove(e.Announcement.Hostname);
 				//discovered.IP.Remove(e.Announcement.Addresses[0].ToString());
 			}
@@ -1605,11 +1605,11 @@ namespace CumulusMX
 				foreach (var ip in service.Addresses)
 				{
 					//ipaddr = service.Addresses[0].ToString();
-					cumulus.LogMessage($"ZeroConfig Service: AirLink found '{service.Hostname}', reporting its IP address as: {ip}");
+					cumulus.LogMessage($"ZeroConf Service: AirLink found '{service.Hostname}', reporting its IP address as: {ip}");
 
 					if (!discovered.Hostname.Contains(service.Hostname))
 					{
-						cumulus.LogDebugMessage($"ZeroConfig Service: Adding AirLink {service.Hostname} to list of discovered devices");
+						cumulus.LogDebugMessage($"ZeroConf Service: Adding AirLink {service.Hostname} to list of discovered devices");
 						discovered.IP.Add(ip.ToString());
 						discovered.Hostname.Add(service.Hostname);
 					}

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -1261,7 +1261,7 @@ namespace CumulusMX
 
 		private void OnServiceRemoved(object sender, ServiceAnnouncementEventArgs e)
 		{
-			cumulus.LogMessage("ZeroConfig Service: WLL service has been removed!");
+			cumulus.LogMessage("ZeroConf Service: WLL service has been removed!");
 		}
 
 		private void OnServiceAdded(object sender, ServiceAnnouncementEventArgs e)

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -40,7 +40,8 @@ namespace CumulusMX
 		private bool broadcastReceived;
 		private int weatherLinkArchiveInterval = 16 * 60; // Used to get historic Health, 16 minutes in seconds only for initial fetch after load
 		private bool wllVoltageLow;
-		private bool stop;
+		private CancellationTokenSource tokenSource = new CancellationTokenSource();
+		private CancellationToken cancellationToken;
 		private readonly List<WlSensor> sensorList = new List<WlSensor>();
 		private readonly bool useWeatherLinkDotCom = true;
 
@@ -280,6 +281,8 @@ namespace CumulusMX
 					cumulus.WriteIniFile();
 				}
 
+				cancellationToken = tokenSource.Token;
+
 				// Create a broadcast listener
 				Task.Run(() =>
 				{
@@ -290,15 +293,22 @@ namespace CumulusMX
 						udpClient.Client.ReceiveTimeout = 4000;  // We should get a message every 2.5 seconds
 						var from = new IPEndPoint(0, 0);
 
-						while (!stop)
+						while (!cancellationToken.IsCancellationRequested)
 						{
 							try
 							{
-								var jsonBtye = udpClient.Receive(ref from);
-								var jsonStr = Encoding.UTF8.GetString(jsonBtye);
-								if (!stop) // we may be waiting for a broadcast when a shutdown is started
+								// test is any data is available
+								if (udpClient.Client.Available > 0)
 								{
+									var jsonBtye = udpClient.Receive(ref from);
+									var jsonStr = Encoding.UTF8.GetString(jsonBtye);
 									DecodeBroadcast(jsonStr);
+								}
+								// if not, sleep and repeat, or exit on cancel
+								else if (cancellationToken.WaitHandle.WaitOne(200))
+								{
+									cumulus.LogMessage("WLL broadcast listener stop requested");
+									break;
 								}
 							}
 							catch (SocketException exp)
@@ -315,10 +325,9 @@ namespace CumulusMX
 								}
 							}
 						}
-						udpClient.Close();
-						cumulus.LogMessage("WLL broadcast listener stopped");
 					}
-				});
+					cumulus.LogMessage("WLL broadcast listener stopped");
+				}, cancellationToken);
 
 				cumulus.LogMessage($"WLL Now listening on broadcast port {port}");
 
@@ -352,7 +361,7 @@ namespace CumulusMX
 			cumulus.LogMessage("Closing WLL connections");
 			try
 			{
-				stop = true;
+				tokenSource.Cancel();
 				tmrRealtime.Stop();
 				tmrCurrent.Stop();
 				tmrBroadcastWatchdog.Stop();
@@ -726,11 +735,11 @@ namespace CumulusMX
 							{   // Check for Extra temperature/humidity settings
 								for (var tempTxId = 1; tempTxId <= 8; tempTxId++)
 								{
-									if (cumulus.WllExtraTempTx[tempTxId - 1] != data1.txid) continue;
+									if (cumulus.WllExtraTempTx[tempTxId] != data1.txid) continue;
 
 									try
 									{
-										if (cumulus.WllExtraTempTx[tempTxId - 1] == data1.txid)
+										if (cumulus.WllExtraTempTx[tempTxId] == data1.txid)
 										{
 											if (!data1.temp.HasValue || data1.temp.Value == -99)
 											{
@@ -743,7 +752,7 @@ namespace CumulusMX
 												DoExtraTemp(ConvertTempFToUser(data1.temp.Value), tempTxId);
 											}
 
-											if (cumulus.WllExtraHumTx[tempTxId - 1] && data1.hum.HasValue)
+											if (cumulus.WllExtraHumTx[tempTxId] && data1.hum.HasValue)
 											{
 												DoExtraHum(data1.hum.Value, tempTxId);
 											}
@@ -2032,7 +2041,7 @@ namespace CumulusMX
 						{   // Check for Extra temperature/humidity settings
 							for (var tempTxId = 1; tempTxId <= 8; tempTxId++)
 							{
-								if (cumulus.WllExtraTempTx[tempTxId - 1] != data11.tx_id) continue;
+								if (cumulus.WllExtraTempTx[tempTxId] != data11.tx_id) continue;
 
 								try
 								{
@@ -2053,7 +2062,7 @@ namespace CumulusMX
 									cumulus.LogDebugMessage($"WL.com historic: Exception {ex.Message}");
 								}
 
-								if (!cumulus.WllExtraHumTx[tempTxId - 1]) continue;
+								if (!cumulus.WllExtraHumTx[tempTxId]) continue;
 
 								try
 								{

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -90,7 +90,7 @@ namespace CumulusMX
 
 			// Request the data in the correct units
 			sb.Append($"&temp_unitid={cumulus.Units.Temp + 1}"); // 1=C, 2=F
-			sb.Append($"&pressue_unitid={(cumulus.Units.Press == 1 ? "3" : "2")}"); // 3=hPa, 4=inHg, 5=mmHg
+			sb.Append($"&pressure_unitid={(cumulus.Units.Press == 2 ? "4" : "3")}"); // 3=hPa, 4=inHg, 5=mmHg
 			string windUnit;
 			switch (cumulus.Units.Wind)
 			{
@@ -182,10 +182,12 @@ namespace CumulusMX
 
 			var url = sb.ToString();
 
+			var msg = $"Processing history data from {startTime.ToString("yyyy-MM-dd HH:mm")} to {endTime.AddMinutes(5).ToString("yyyy-MM-dd HH:mm")}...";
+			cumulus.LogMessage($"API.GetHistoricData: " + msg);
+			cumulus.LogConsoleMessage(msg);
+
 			var logUrl = url.Replace(cumulus.EcowittApplicationKey, "<<App-key>>").Replace(cumulus.EcowittUserApiKey, "<<User-key>>");
 			cumulus.LogDebugMessage($"Ecowitt URL = {logUrl}");
-
-			cumulus.LogConsoleMessage($"Processing history data from {startTime.ToString("yyyy-MM-dd HH:mm")} to {endTime.ToString("yyyy-MM-dd HH:mm")}...");
 
 			try
 			{
@@ -786,12 +788,12 @@ namespace CumulusMX
 
 								if (buffer.ContainsKey(itemDate))
 								{
-									buffer[itemDate].ExtraTemp[i - 1] = item.Value;
+									buffer[itemDate].ExtraTemp[i] = item.Value;
 								}
 								else
 								{
 									var newItem = new EcowittApi.HistoricData();
-									newItem.ExtraTemp[i - 1] = item.Value;
+									newItem.ExtraTemp[i] = item.Value;
 									buffer.Add(itemDate, newItem);
 								}
 							}
@@ -808,12 +810,12 @@ namespace CumulusMX
 
 								if (buffer.ContainsKey(itemDate))
 								{
-									buffer[itemDate].ExtraHumidity[i - 1] = item.Value;
+									buffer[itemDate].ExtraHumidity[i] = item.Value;
 								}
 								else
 								{
 									var newItem = new EcowittApi.HistoricData();
-									newItem.ExtraHumidity[i - 1] = item.Value;
+									newItem.ExtraHumidity[i] = item.Value;
 									buffer.Add(itemDate, newItem);
 								}
 							}
@@ -840,12 +842,12 @@ namespace CumulusMX
 
 							if (buffer.ContainsKey(itemDate))
 							{
-								buffer[itemDate].SoilMoist[i - 1] = item.Value;
+								buffer[itemDate].SoilMoist[i] = item.Value;
 							}
 							else
 							{
 								var newItem = new EcowittApi.HistoricData();
-								newItem.SoilMoist[i - 1] = item.Value;
+								newItem.SoilMoist[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
 						}
@@ -870,12 +872,12 @@ namespace CumulusMX
 
 							if (buffer.ContainsKey(itemDate))
 							{
-								buffer[itemDate].UserTemp[i - 1] = item.Value;
+								buffer[itemDate].UserTemp[i] = item.Value;
 							}
 							else
 							{
 								var newItem = new EcowittApi.HistoricData();
-								newItem.UserTemp[i - 1] = item.Value;
+								newItem.UserTemp[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
 						}
@@ -900,12 +902,12 @@ namespace CumulusMX
 
 							if (buffer.ContainsKey(itemDate))
 							{
-								buffer[itemDate].LeafWetness[i - 1] = item.Value;
+								buffer[itemDate].LeafWetness[i] = item.Value;
 							}
 							else
 							{
 								var newItem = new EcowittApi.HistoricData();
-								newItem.LeafWetness[i - 1] = item.Value;
+								newItem.LeafWetness[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
 						}
@@ -1123,12 +1125,12 @@ namespace CumulusMX
 
 							if (buffer.ContainsKey(itemDate))
 							{
-								buffer[itemDate].pm25[i - 1] = item.Value;
+								buffer[itemDate].pm25[i] = item.Value;
 							}
 							else
 							{
 								var newItem = new EcowittApi.HistoricData();
-								newItem.pm25[i - 1] = item.Value;
+								newItem.pm25[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
 						}
@@ -1385,9 +1387,9 @@ namespace CumulusMX
 				// === Extra Temperature ===
 				try
 				{
-					if (rec.Value.ExtraTemp[i - 1].HasValue)
+					if (rec.Value.ExtraTemp[i].HasValue)
 					{
-						var tempVal = (double)rec.Value.ExtraTemp[i - 1];
+						var tempVal = (double)rec.Value.ExtraTemp[i];
 						if (i == cumulus.Gw1000PrimaryTHSensor)
 						{
 							station.DoOutdoorTemp(tempVal, rec.Key);
@@ -1402,13 +1404,13 @@ namespace CumulusMX
 				// === Extra Humidity ===
 				try
 				{
-					if (rec.Value.ExtraHumidity[i - 1].HasValue)
+					if (rec.Value.ExtraHumidity[i].HasValue)
 					{
 						if (i == cumulus.Gw1000PrimaryTHSensor)
 						{
-							station.DoOutdoorHumidity(rec.Value.ExtraHumidity[i - 1].Value, rec.Key);
+							station.DoOutdoorHumidity(rec.Value.ExtraHumidity[i].Value, rec.Key);
 						}
-						station.DoExtraHum(rec.Value.ExtraHumidity[i - 1].Value, i);
+						station.DoExtraHum(rec.Value.ExtraHumidity[i].Value, i);
 					}
 				}
 				catch (Exception ex)
@@ -1420,9 +1422,16 @@ namespace CumulusMX
 				// === User Temperature ===
 				try
 				{
-					if (rec.Value.UserTemp[i - 1].HasValue)
+					if (rec.Value.UserTemp[i].HasValue)
 					{
-						station.DoUserTemp((double)rec.Value.UserTemp[i - 1], i);
+						if (cumulus.EcowittMapWN34[i] == 0)
+						{
+							station.DoUserTemp((double)rec.Value.UserTemp[i], i);
+						}
+						else
+						{
+							station.DoSoilTemp((double)rec.Value.UserTemp[i], cumulus.EcowittMapWN34[i]);
+						}
 					}
 				}
 				catch (Exception ex)
@@ -1433,9 +1442,9 @@ namespace CumulusMX
 				// === Soil Moisture ===
 				try
 				{
-					if (rec.Value.SoilMoist[i - 1].HasValue)
+					if (rec.Value.SoilMoist[i].HasValue)
 					{
-						station.DoSoilMoisture((double)rec.Value.SoilMoist[i - 1], i);
+						station.DoSoilMoisture((double)rec.Value.SoilMoist[i], i);
 					}
 				}
 				catch (Exception ex)
@@ -1501,9 +1510,9 @@ namespace CumulusMX
 			{
 				try
 				{
-					if (rec.Value.pm25[i - 1].HasValue)
+					if (rec.Value.pm25[i].HasValue)
 					{
-						station.DoAirQuality((double)rec.Value.pm25[i - 1].Value, i);
+						station.DoAirQuality((double)rec.Value.pm25[i].Value, i);
 					}
 				}
 				catch (Exception ex)
@@ -1799,12 +1808,12 @@ namespace CumulusMX
 
 			public HistoricData()
 			{
-				pm25 = new decimal?[4];
-				ExtraTemp = new decimal?[8];
-				ExtraHumidity = new int?[8];
-				SoilMoist = new int?[8];
-				UserTemp = new decimal?[8];
-				LeafWetness = new int?[8];
+				pm25 = new decimal?[5];
+				ExtraTemp = new decimal?[9];
+				ExtraHumidity = new int?[9];
+				SoilMoist = new int?[9];
+				UserTemp = new decimal?[9];
+				LeafWetness = new int?[9];
 			}
 		}
 

--- a/CumulusMX/ExtraSensorSettings.cs
+++ b/CumulusMX/ExtraSensorSettings.cs
@@ -43,7 +43,7 @@ namespace CumulusMX
 				outdoor = outdoor
 			};
 
-			var ecowitt = new JsonExtraSensorEcowittAmbient()
+			var ecowitt = new JsonExtraSensorEcowitt()
 			{
 				useSolar = cumulus.EcowittExtraUseSolar,
 				useUv = cumulus.EcowittExtraUseUv,
@@ -55,10 +55,17 @@ namespace CumulusMX
 				useAQI = cumulus.EcowittExtraUseAQI,
 				useCo2 = cumulus.EcowittExtraUseCo2,
 				useLightning = cumulus.EcowittExtraUseLightning,
-				useLeak = cumulus.EcowittExtraUseLeak
+				useLeak = cumulus.EcowittExtraUseLeak,
+
+				setcustom = cumulus.EcowittExtraSetCustomServer,
+				gwaddr = cumulus.EcowittExtraGatewayAddr,
+				localaddr = cumulus.EcowittExtraLocalAddr,
+				interval = cumulus.EcowittExtraCustomInterval,
+
+				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
 			};
 
-			var ambient = new JsonExtraSensorEcowittAmbient()
+			var ambient = new JsonExtraSensorAmbient()
 			{
 				useSolar = cumulus.AmbientExtraUseSolar,
 				useUv = cumulus.AmbientExtraUseUv,
@@ -236,6 +243,13 @@ namespace CumulusMX
 						cumulus.EcowittExtraUseLightning = settings.httpSensors.ecowitt.useLightning;
 						cumulus.EcowittExtraUseLeak = settings.httpSensors.ecowitt.useLeak;
 
+						cumulus.EcowittExtraSetCustomServer = settings.httpSensors.ecowitt.setcustom;
+						cumulus.EcowittExtraGatewayAddr = settings.httpSensors.ecowitt.gwaddr;
+						cumulus.EcowittExtraLocalAddr = settings.httpSensors.ecowitt.localaddr;
+						cumulus.EcowittExtraCustomInterval = settings.httpSensors.ecowitt.interval;
+
+						cumulus.Gw1000PrimaryTHSensor = settings.httpSensors.ecowitt.primaryTHsensor;
+
 						// Also enable extra logging if applicable
 						if (cumulus.EcowittExtraUseTempHum || cumulus.EcowittExtraUseSoilTemp || cumulus.EcowittExtraUseSoilMoist || cumulus.EcowittExtraUseLeafWet || cumulus.EcowittExtraUseUserTemp || cumulus.EcowittExtraUseAQI || cumulus.EcowittExtraUseCo2)
 						{
@@ -384,11 +398,11 @@ namespace CumulusMX
 	public class JsonExtraSensorHttp
 	{
 		public int extraStation { get; set; }
-		public JsonExtraSensorEcowittAmbient ecowitt { get; set; }
-		public JsonExtraSensorEcowittAmbient ambient { get; set; }
+		public JsonExtraSensorEcowitt ecowitt { get; set; }
+		public JsonExtraSensorAmbient ambient { get; set; }
 	}
 
-	public class JsonExtraSensorEcowittAmbient
+	public class JsonExtraSensorAmbient
 	{
 		public bool useSolar { get; set; }
 		public bool useUv { get; set; }
@@ -401,6 +415,16 @@ namespace CumulusMX
 		public bool useCo2 { get; set; }
 		public bool useLightning { get; set; }
 		public bool useLeak { get; set; }
+	}
+
+	public class JsonExtraSensorEcowitt : JsonExtraSensorAmbient
+	{
+		public bool setcustom { get; set; }
+		public string gwaddr { get; set; }
+		public string localaddr { get; set; }
+		public int interval { get; set; }
+		public int primaryTHsensor { get; set; }
+
 	}
 
 

--- a/CumulusMX/ExtraSensorSettings.cs
+++ b/CumulusMX/ExtraSensorSettings.cs
@@ -9,10 +9,16 @@ namespace CumulusMX
 	public class ExtraSensorSettings
 	{
 		private readonly Cumulus cumulus;
+		private WeatherStation station;
 
 		public ExtraSensorSettings(Cumulus cumulus)
 		{
 			this.cumulus = cumulus;
+		}
+
+		internal void SetStation(WeatherStation station)
+		{
+			this.station = station;
 		}
 
 		public string GetAlpacaFormData()
@@ -43,6 +49,20 @@ namespace CumulusMX
 				outdoor = outdoor
 			};
 
+			var ecowittwn34map = new JsonStationSettingsEcowittMappings()
+			{
+				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
+
+				wn34chan1 = cumulus.EcowittMapWN34[1],
+				wn34chan2 = cumulus.EcowittMapWN34[2],
+				wn34chan3 = cumulus.EcowittMapWN34[3],
+				wn34chan4 = cumulus.EcowittMapWN34[4],
+				wn34chan5 = cumulus.EcowittMapWN34[5],
+				wn34chan6 = cumulus.EcowittMapWN34[6],
+				wn34chan7 = cumulus.EcowittMapWN34[7],
+				wn34chan8 = cumulus.EcowittMapWN34[8]
+			};
+
 			var ecowitt = new JsonExtraSensorEcowitt()
 			{
 				useSolar = cumulus.EcowittExtraUseSolar,
@@ -62,7 +82,7 @@ namespace CumulusMX
 				localaddr = cumulus.EcowittExtraLocalAddr,
 				interval = cumulus.EcowittExtraCustomInterval,
 
-				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
+				mappings = ecowittwn34map
 			};
 
 			var ambient = new JsonExtraSensorAmbient()
@@ -248,7 +268,87 @@ namespace CumulusMX
 						cumulus.EcowittExtraLocalAddr = settings.httpSensors.ecowitt.localaddr;
 						cumulus.EcowittExtraCustomInterval = settings.httpSensors.ecowitt.interval;
 
-						cumulus.Gw1000PrimaryTHSensor = settings.httpSensors.ecowitt.primaryTHsensor;
+						cumulus.Gw1000PrimaryTHSensor = settings.httpSensors.ecowitt.mappings.primaryTHsensor;
+
+						if (cumulus.EcowittMapWN34[1] != settings.httpSensors.ecowitt.mappings.wn34chan1)
+						{
+							if (cumulus.EcowittMapWN34[1] == 0)
+								station.UserTemp[1] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[1]] = 0;
+
+							cumulus.EcowittMapWN34[1] = settings.httpSensors.ecowitt.mappings.wn34chan1;
+						}
+
+						if (cumulus.EcowittMapWN34[2] != settings.httpSensors.ecowitt.mappings.wn34chan2)
+						{
+							if (cumulus.EcowittMapWN34[2] == 0)
+								station.UserTemp[2] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[2]] = 0;
+
+							cumulus.EcowittMapWN34[2] = settings.httpSensors.ecowitt.mappings.wn34chan2;
+						}
+
+						if (cumulus.EcowittMapWN34[3] != settings.httpSensors.ecowitt.mappings.wn34chan3)
+						{
+							if (cumulus.EcowittMapWN34[3] == 0)
+								station.UserTemp[3] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[3]] = 0;
+
+							cumulus.EcowittMapWN34[3] = settings.httpSensors.ecowitt.mappings.wn34chan3;
+						}
+
+						if (cumulus.EcowittMapWN34[4] != settings.httpSensors.ecowitt.mappings.wn34chan4)
+						{
+							if (cumulus.EcowittMapWN34[4] == 0)
+								station.UserTemp[4] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[4]] = 0;
+
+							cumulus.EcowittMapWN34[4] = settings.httpSensors.ecowitt.mappings.wn34chan4;
+						}
+
+						if (cumulus.EcowittMapWN34[5] != settings.httpSensors.ecowitt.mappings.wn34chan5)
+						{
+							if (cumulus.EcowittMapWN34[5] == 0)
+								station.UserTemp[5] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[5]] = 0;
+
+							cumulus.EcowittMapWN34[5] = settings.httpSensors.ecowitt.mappings.wn34chan5;
+						}
+
+						if (cumulus.EcowittMapWN34[6] != settings.httpSensors.ecowitt.mappings.wn34chan6)
+						{
+							if (cumulus.EcowittMapWN34[6] == 0)
+								station.UserTemp[6] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[6]] = 0;
+
+							cumulus.EcowittMapWN34[6] = settings.httpSensors.ecowitt.mappings.wn34chan6;
+						}
+
+						if (cumulus.EcowittMapWN34[7] != settings.httpSensors.ecowitt.mappings.wn34chan7)
+						{
+							if (cumulus.EcowittMapWN34[7] == 0)
+								station.UserTemp[7] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[7]] = 0;
+
+							cumulus.EcowittMapWN34[7] = settings.httpSensors.ecowitt.mappings.wn34chan7;
+						}
+
+						if (cumulus.EcowittMapWN34[8] != settings.httpSensors.ecowitt.mappings.wn34chan8)
+						{
+							if (cumulus.EcowittMapWN34[8] == 0)
+								station.UserTemp[8] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[8]] = 0;
+
+							cumulus.EcowittMapWN34[8] = settings.httpSensors.ecowitt.mappings.wn34chan8;
+						}
 
 						// Also enable extra logging if applicable
 						if (cumulus.EcowittExtraUseTempHum || cumulus.EcowittExtraUseSoilTemp || cumulus.EcowittExtraUseSoilMoist || cumulus.EcowittExtraUseLeafWet || cumulus.EcowittExtraUseUserTemp || cumulus.EcowittExtraUseAQI || cumulus.EcowittExtraUseCo2)
@@ -419,12 +519,11 @@ namespace CumulusMX
 
 	public class JsonExtraSensorEcowitt : JsonExtraSensorAmbient
 	{
-		public bool setcustom { get; set; }
-		public string gwaddr { get; set; }
-		public string localaddr { get; set; }
-		public int interval { get; set; }
-		public int primaryTHsensor { get; set; }
-
+		internal bool setcustom { get; set; }
+		internal string gwaddr { get; set; }
+		internal string localaddr { get; set; }
+		internal int interval { get; set; }
+		internal JsonStationSettingsEcowittMappings mappings { get; set; }
 	}
 
 

--- a/CumulusMX/GW1000Api.cs
+++ b/CumulusMX/GW1000Api.cs
@@ -1,0 +1,654 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CumulusMX
+{
+	internal class GW1000Api
+	{
+		private Cumulus cumulus;
+		private NetworkStream stream;
+		private TcpClient socket;
+		private string ipAddress = null;
+		private int tcpPort =	0;
+		private bool connected = false;
+		private bool connecting = false;
+
+		internal GW1000Api(Cumulus cuml)
+		{
+			cumulus = cuml;
+		}
+
+
+		internal bool OpenTcpPort(string ipaddr, int port)
+		{
+			ipAddress = ipaddr;
+			tcpPort = port;
+			connecting = true;
+
+			CloseTcpPort();
+			int attempt = 0;
+
+			// Creating the new TCP socket effectively opens it - specify IP address or domain name and port
+			while (attempt < 5 && socket == null)
+			{
+				attempt++;
+				cumulus.LogDebugMessage("Ecowitt Gateway Connect attempt " + attempt);
+				try
+				{
+					socket = new TcpClient(ipaddr, port);
+
+					if (!socket.Connected)
+					{
+						try
+						{
+							socket.Close();
+						}
+						catch
+						{ }
+						socket = null;
+					}
+
+				}
+				catch (Exception ex)
+				{
+					cumulus.LogMessage("Error opening TCP port: " + ex.Message);
+				}
+				Thread.Sleep(5000);
+			}
+
+			// Set the timeout of the underlying stream
+			if (socket != null)
+			{
+				stream = socket.GetStream();
+				stream.ReadTimeout = 2500;
+				cumulus.LogDebugMessage("Ecowitt Gateway reconnected");
+				connecting = false;
+
+				connected = true;
+			}
+			else
+			{
+				cumulus.LogDebugMessage("Ecowitt Gateway connect failed");
+				connecting = false;
+				return false;
+			}
+
+			return true;
+		}
+
+		internal void CloseTcpPort()
+		{
+			try
+			{
+				if (socket != null)
+				{
+					socket.GetStream().WriteByte(10);
+					socket.Close();
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage("Error closing TCP port: " + ex.Message);
+				socket = null;
+			}
+			connected = false;
+		}
+
+		internal bool ReOpenTcpPort()
+		{
+			return OpenTcpPort(ipAddress, tcpPort);
+		}
+
+		internal byte[] DoCommand(Commands command, byte[] data = null)
+		{
+			if (!connected)
+			{
+				// Are we already reconnecting?
+				if (connecting)
+					// yep - so wait reconnect to complete
+					return null;
+				// no, try a reconnect
+				else if (!ReOpenTcpPort())
+					// that didn;t work, give up and return nothing
+					return null;
+			}
+
+			var buffer = new byte[2028];
+			var bytesRead = 0;
+			var cmdName = command.ToString();
+
+			var readBuffer = new byte[2028];
+
+			byte[] bytes;
+			if (data == null)
+			{
+				var payload = new CommandPayload(command);
+				bytes = payload.Serialise();
+			}
+			else
+			{
+				var payload = new CommandWritePayload(command, data);
+				bytes = payload.Serialise();
+			}
+
+			var tmrComm = new WeatherStation.CommTimer();
+
+			try
+			{
+				stream.Write(bytes, 0, bytes.Length);
+
+				tmrComm.Start(3000);
+
+				while (tmrComm.timedout == false)
+				{
+					if (stream.DataAvailable)
+					{
+						while (stream.DataAvailable)
+						{
+							// Read the current character
+							var ch = stream.ReadByte();
+							if (ch > -1)
+							{
+								buffer[bytesRead] = (byte)ch;
+								bytesRead++;
+								//cumulus.LogMessage("Received " + ch.ToString("X2"));
+							}
+						}
+						tmrComm.Stop();
+					}
+					else
+					{
+						Task.Delay(20).Wait();
+					}
+				}
+
+				// Check the response is to our command and checksum is OK
+				if (bytesRead == 0 || buffer[2] != (byte)command || !ChecksumOk(buffer, (int)Enum.Parse(typeof(CommandRespSize), cmdName)))
+				{
+					if (bytesRead > 0)
+					{
+						cumulus.LogMessage($"DoCommand({cmdName}): Invalid response");
+						cumulus.LogDebugMessage($"command resp={buffer[2]}, checksum=" + (ChecksumOk(buffer, (int)Enum.Parse(typeof(CommandRespSize), cmdName)) ? "OK" : "BAD"));
+						cumulus.LogDataMessage("Received " + BitConverter.ToString(buffer, 0, bytesRead - 1));
+					}
+					else
+					{
+						cumulus.LogMessage($"DoCommand({cmdName}): No response received");
+					}
+					return null;
+				}
+				else
+				{
+					cumulus.LogDebugMessage($"DoCommand({cmdName}): Valid response");
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage($"DoCommand({cmdName}): Error - " + ex.Message);
+				cumulus.LogMessage("Attempting to reopen the TCP port");
+				ReOpenTcpPort();
+				return null;
+			}
+			// Return the data we want out of the buffer
+			if (bytesRead > 0)
+			{
+				var data1 = new byte[bytesRead];
+				Array.Copy(buffer, data1, data1.Length);
+				cumulus.LogDataMessage("Received: " + BitConverter.ToString(data1));
+				return data1;
+			}
+
+			return null;
+		}
+
+		private bool ChecksumOk(byte[] data, int lengthBytes)
+		{
+			ushort size;
+
+			// general response 1 byte size         2 byte size
+			// 0   - 0xff - header                  0   - 0xff - header
+			// 1   - 0xff                           1   - 0xff
+			// 2   - command                        2   - command
+			// 3   - total size of response         3   - size1
+			// 4-X - data                           4   - size2
+			// X+1 - checksum                       5-X - data
+			//                                      X+1 - checksum
+
+			if (lengthBytes == 1)
+			{
+				size = data[3];
+			}
+			else
+			{
+				size = ConvertBigEndianUInt16(data, 3);
+			}
+
+			// sanity check the size
+			if (size + 3 + lengthBytes > data.Length)
+			{
+				cumulus.LogMessage($"Ckecksum: Error - Calculated data length [{size}] exceeds the buffer size!");
+				return false;
+			}
+
+			byte checksum = (byte)(data[2] + data[3]);
+			for (var i = 4; i <= size; i++)
+			{
+				checksum += data[i];
+			}
+
+			if (checksum != data[size + 1])
+			{
+				cumulus.LogMessage("Checksum: Error - Bad checksum");
+				return false;
+			}
+
+			return true;
+		}
+
+
+		internal enum Commands : byte
+		{
+			// General order
+			CMD_WRITE_SSID = 0x11,// send router SSID and Password to WiFi module
+			CMD_BROADCAST = 0x12,//looking for device inside network. Returned data size is 2 Byte
+			CMD_READ_ECOWITT = 0x1E,// read setting for Ecowitt.net
+			CMD_WRITE_ECOWITT = 0x1F, // write back setting for Ecowitt.net
+			CMD_READ_WUNDERGROUND = 0x20,// read back setting for Wunderground
+			CMD_WRITE_WUNDERGROUND = 0x21, // write back setting for Wunderground
+			CMD_READ_WOW = 0x22, // read setting for WeatherObservationsWebsite
+			CMD_WRITE_WOW = 0x23, // write back setting for WeatherObservationsWebsite
+			CMD_READ_WEATHERCLOUD = 0x24,// read setting for Weathercloud
+			CMD_WRITE_WEATHERCLOUD = 0x25, // write back setting for Weathercloud
+			CMD_READ_SATION_MAC = 0x26,// read  module MAC
+			CMD_READ_CUSTOMIZED = 0x2A,// read setting for Customized sever
+			CMD_WRITE_CUSTOMIZED = 0x2B, // write back customized sever setting
+			CMD_WRITE_UPDATE = 0x43,// update firmware
+			CMD_READ_FIRMWARE_VERSION = 0x50,// read back firmware version
+			CMD_READ_USER_PATH = 0x51,
+			CMD_WRITE_USER_PATH = 0x52,
+			// the following commands are only valid for GW1000 and WH2650：
+			CMD_GW1000_LIVEDATA = 0x27, // read current，return size is 2 Byte
+			CMD_GET_SOILHUMIAD = 0x28,// read Soil moisture Sensor calibration parameter
+			CMD_SET_SOILHUMIAD = 0x29, // write back Soil moisture Sensor calibration parameter
+			CMD_GET_MulCH_OFFSET = 0x2C, // read multi channel sensor OFFSET value
+			CMD_SET_MulCH_OFFSET = 0x2D, // write back multi sensor OFFSET value
+			CMD_GET_PM25_OFFSET = 0x2E, // read PM2.5OFFSET value
+			CMD_SET_PM25_OFFSET = 0x2F, // write back PM2.5OFFSET value
+			CMD_READ_SSSS = 0x30,// read sensor set-up ( sensor frequency, wh24/wh65 sensor)
+			CMD_WRITE_SSSS = 0x31,// write back sensor set-up
+			CMD_READ_RAINDATA = 0x34,// read rain data
+			CMD_WRITE_RAINDATA = 0x35, // write back rain data
+			CMD_READ_GAIN = 0x36, // read rain gain
+			CMD_WRITE_GAIN = 0x37, // write back rain gain
+			CMD_READ_CALIBRATION = 0x38,//  read multiple parameter offset( refer to command description below in detail)
+			CMD_WRITE_CALIBRATION = 0x39,//  write back multiple parameter offset
+			CMD_READ_SENSOR_ID = 0x3A,//  read Sensors ID
+			CMD_WRITE_SENSOR_ID = 0x3B, // write back Sensors ID
+			CMD_READ_SENSOR_ID_NEW = 0x3C,
+			CMD_WRITE_REBOOT = 0x40,// system reset
+			CMD_WRITE_RESET = 0x41,// system default setting reset
+			CMD_GET_CO2_OFFSET = 0x53,
+			CMD_SET_CO2_OFFSET = 0x54,
+			CMD_READ_RSTRAIN_TIME = 0x55,// read rain reset time
+			CMD_WRITE_RSTRAIN_TIME = 0x56// write back rain reset time
+		}
+
+		private enum CommandRespSize : int
+		{
+			bytes1 = 1,
+			bytes2 = 2,
+			CMD_WRITE_SSID = bytes1,
+			CMD_BROADCAST = bytes2,
+			CMD_READ_ECOWITT = bytes1,
+			CMD_WRITE_ECOWITT = bytes1,
+			CMD_READ_WUNDERGROUND = bytes1,
+			CMD_WRITE_WUNDERGROUND = bytes1,
+			CMD_READ_WOW = bytes1,
+			CMD_WRITE_WOW = bytes1,
+			CMD_READ_WEATHERCLOUD = bytes1,
+			CMD_WRITE_WEATHERCLOUD = bytes1,
+			CMD_READ_SATION_MAC = bytes1,
+			CMD_READ_CUSTOMIZED = bytes1,
+			CMD_WRITE_CUSTOMIZED = bytes1,
+			CMD_WRITE_UPDATE = bytes1,
+			CMD_READ_FIRMWARE_VERSION = bytes1,
+			CMD_READ_USER_PATH = bytes1,
+			CMD_WRITE_USER_PATH = bytes1,
+			// the following commands are only valid for GW1000 and WH2650：
+			CMD_GW1000_LIVEDATA = bytes2,
+			CMD_GET_SOILHUMIAD = bytes1,
+			CMD_SET_SOILHUMIAD = bytes1,
+			CMD_GET_MulCH_OFFSET = bytes1,
+			CMD_SET_MulCH_OFFSET = bytes1,
+			CMD_GET_PM25_OFFSET = bytes1,
+			CMD_SET_PM25_OFFSET = bytes1,
+			CMD_READ_SSSS = bytes1,
+			CMD_WRITE_SSSS = bytes1,
+			CMD_READ_RAINDATA = bytes1,
+			CMD_WRITE_RAINDATA = bytes1,
+			CMD_READ_GAIN = bytes1,
+			CMD_WRITE_GAIN = bytes1,
+			CMD_READ_CALIBRATION = bytes1,
+			CMD_WRITE_CALIBRATION = bytes1,
+			CMD_READ_SENSOR_ID = bytes1,
+			CMD_WRITE_SENSOR_ID = bytes1,
+			CMD_WRITE_REBOOT = bytes1,
+			CMD_WRITE_RESET = bytes1,
+			CMD_READ_SENSOR_ID_NEW = bytes2,
+			CMD_READ_RSTRAIN_TIME = bytes1,
+			CMD_WRITE_RSTRAIN_TIME = bytes1
+		}
+
+		internal enum SensorIds
+		{
+			Wh65,           // 0
+			Wh68,           // 1
+			Wh80,           // 2
+			Wh40,           // 3
+			Wh25,           // 4
+			Wh26,           // 5
+			Wh31Ch1,        // 6
+			Wh31Ch2,        // 7
+			Wh31Ch3,        // 8
+			Wh31Ch4,        // 9
+			Wh31Ch5,        // 10
+			Wh31Ch6,        // 11
+			Wh31Ch7,        // 12
+			Wh31Ch8,        // 13
+			Wh51Ch1,        // 14
+			Wh51Ch2,        // 15
+			Wh51Ch3,        // 16
+			Wh51Ch4,        // 17
+			Wh51Ch5,        // 18
+			Wh51Ch6,        // 19
+			Wh51Ch7,        // 20
+			Wh51Ch8,        // 21
+			Wh41Ch1,        // 22
+			Wh41Ch2,        // 23
+			Wh41Ch3,        // 24
+			Wh41Ch4,        // 25
+			Wh57,           // 26
+			Wh55Ch1,        // 27
+			Wh55Ch2,        // 28
+			Wh55Ch3,        // 29
+			Wh55Ch4,        // 30
+			Wh34Ch1,        // 31
+			Wh34Ch2,        // 32
+			Wh34Ch3,        // 33
+			Wh34Ch4,        // 34
+			Wh34Ch5,        // 35
+			Wh34Ch6,        // 36
+			Wh34Ch7,        // 37
+			Wh34Ch8,        // 38
+			Wh45,           // 39
+			Wh35Ch1,        // 40
+			Wh35Ch2,        // 41
+			Wh35Ch3,        // 42
+			Wh35Ch4,        // 43
+			Wh35Ch5,        // 44
+			Wh35Ch6,        // 45
+			Wh35Ch7,        // 46
+			Wh35Ch8,        // 47
+			Wh90            // 48
+		};
+
+
+		[Flags]
+		internal enum SigSen : byte
+		{
+			Wh40 = 1 << 4,
+			Wh26 = 1 << 5,
+			Wh25 = 1 << 6,
+			Wh24 = 1 << 7
+		}
+
+		[Flags]
+		internal enum Wh31Ch : byte
+		{
+			Ch1 = 1 << 0,
+			Ch2 = 1 << 1,
+			Ch3 = 1 << 2,
+			Ch4 = 1 << 3,
+			Ch5 = 1 << 4,
+			Ch6 = 1 << 5,
+			Ch7 = 1 << 6,
+			Ch8 = 1 << 7
+		}
+
+
+		/*
+		private enum _wh41_ch : UInt16
+		{
+			ch1 = 15 << 0,
+			ch2 = 15 << 4,
+			ch3 = 15 << 8,
+			ch4 = 15 << 12
+		}
+		*/
+
+		[Flags]
+		internal enum Wh51Ch : UInt32
+		{
+			Ch1 = 1 << 0,
+			Ch2 = 1 << 1,
+			Ch3 = 1 << 2,
+			Ch4 = 1 << 3,
+			Ch5 = 1 << 4,
+			Ch6 = 1 << 5,
+			Ch7 = 1 << 6,
+			Ch8 = 1 << 7,
+			Ch9 = 1 << 8,
+			Ch10 = 1 << 9,
+			Ch11 = 1 << 10,
+			Ch12 = 1 << 11,
+			Ch13 = 1 << 12,
+			Ch14 = 1 << 13,
+			Ch15 = 1 << 14,
+			Ch16 = 1 << 15
+		}
+
+		/*
+		private enum Wh55Ch : UInt32
+		{
+			Ch1 = 15 << 0,
+			Ch2 = 15 << 4,
+			Ch3 = 15 << 8,
+			Ch4 = 15 << 12
+		}
+		*/
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+		internal struct BatteryStatus
+		{
+			public byte single;
+			public byte wh31;
+			public UInt16 wh51;
+			public byte wh57;
+			public byte wh68;
+			public byte wh80;
+			public byte wh45;
+			public UInt16 wh41;
+			public byte wh55_ch1;
+			public byte wh55_ch2;
+			public byte wh55_ch3;
+			public byte wh55_ch4;
+		}
+
+		/*
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+		private struct BatteryStatusWH34
+		{
+			public byte single;
+			public byte ch1;
+			public byte ch2;
+			public byte ch3;
+			public byte ch4;
+			public byte ch5;
+			public byte ch6;
+			public byte ch7;
+			public byte ch8;
+		}
+		*/
+
+		/*
+		private struct SensorInfo
+		{
+			string type;
+			int id;
+			int signal;
+			int battery;
+			bool present;
+		}
+		*/
+
+		/*
+		private class Sensors
+		{
+			SensorInfo single { get; set; }
+			SensorInfo wh26;
+			SensorInfo wh31;
+			SensorInfo wh40;
+			SensorInfo wh41;
+			SensorInfo wh51;
+			SensorInfo wh65;
+			SensorInfo wh68;
+			SensorInfo wh80;
+			public Sensors()
+			{
+			}
+		}
+
+		private struct CO2Data
+		{
+			public Int16 temp;          // °C x10
+			public byte hum;			// %
+			public UInt16 pm10;			// μg/m³ x10
+			public UInt16 pm10_24hr;	// μg/m³ x10
+			public UInt16 pm2p5;		// μg/m³ x10
+			public UInt16 pm2p5_24hr;	// μg/m³ x10
+			public UInt16 co2;			// ppm
+			public UInt16 co2_24hr;		// ppm
+			public byte batt;			// 0-5
+		}
+		*/
+
+
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+		private struct CommandPayload
+		{
+			private readonly ushort Header;
+			private readonly byte Command;
+			private readonly byte Size;
+			private readonly byte Checksum;
+
+			public CommandPayload(Commands command) : this()
+			{
+				//ushort header;
+				Header = 0xffff;
+				Command = (byte)command;
+				Size = (byte)(Marshal.SizeOf(typeof(CommandPayload)) - 3);
+				Checksum = (byte)(Command + Size);
+			}
+			// This will be serialised in little endian format
+			public byte[] Serialise()
+			{
+				// allocate a byte array for the struct data
+				var buffer = new byte[Marshal.SizeOf(typeof(CommandPayload)) - 1];
+
+				// Allocate a GCHandle and get the array pointer
+				var gch = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+				var pBuffer = gch.AddrOfPinnedObject();
+
+				// copy data from struct to array and unpin the gc pointer
+				Marshal.StructureToPtr(this, pBuffer, false);
+				gch.Free();
+
+				return buffer;
+			}
+		}
+
+
+		[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+		private struct CommandWritePayload
+		{
+			private readonly ushort Header;
+			private readonly byte Command;
+			private readonly byte Size;
+			public byte[] Data;
+			private readonly byte Checksum;
+
+			public CommandWritePayload(Commands command, byte[] data) : this()
+			{
+				//ushort header;
+				Header = 0xffff;
+				Command = (byte)command;
+				if (data != null)
+				{
+				}
+				Data = data;
+				Size = (byte)(3 + data.Length);
+				Checksum = (byte)(Command + Size);
+				for (int i = 0; i < data.Length; i++)
+				{
+					Checksum += data[i];
+				}
+			}
+			// This will be serialised in little endian format
+			public byte[] Serialise()
+			{
+				// allocate a byte array for the struct data
+				// fixed size = header=2, command=1, size=1, checksum=1 = 5
+				// plus the data size
+				var totalSize = 5 + Data.Length;
+				var buffer = new byte[totalSize];
+
+				buffer[0] = 0xff;
+				buffer[1] = 0xff;
+				buffer[2] = Command;
+				buffer[3] = (byte)Size;
+				for (int i = 0; i < Data.Length; i++)
+				{
+					buffer[4 + i] = Data[i];
+				}
+				buffer[4 + Data.Length] = Checksum;
+
+				return buffer;
+			}
+		}
+
+		internal static UInt16 ConvertBigEndianUInt16(byte[] array, int start)
+		{
+			return (UInt16)(array[start] << 8 | array[start + 1]);
+		}
+
+		internal static Int16 ConvertBigEndianInt16(byte[] array, int start)
+		{
+			return (Int16)((array[start] << 8) + array[start + 1]);
+		}
+
+		internal static UInt32 ConvertBigEndianUInt32(byte[] array, int start)
+		{
+			return (UInt32)(array[start++] << 24 | array[start++] << 16 | array[start++] << 8 | array[start]);
+		}
+
+		internal static byte[] ConvertUInt16ToLittleEndianByteArray(UInt16 ui16)
+		{
+			var arr = BitConverter.GetBytes(ui16);
+			Array.Reverse(arr);
+			return arr;
+		}
+		internal static byte[] ConvertUInt16ToBigEndianByteArray(UInt16 ui16)
+		{
+			return BitConverter.GetBytes(ui16);
+		}
+
+
+	}
+}

--- a/CumulusMX/GW1000Api.cs
+++ b/CumulusMX/GW1000Api.cs
@@ -352,7 +352,7 @@ namespace CumulusMX
 			CMD_READ_SENSOR_ID_NEW = bytes2,
 			CMD_READ_RSTRAIN_TIME = bytes1,
 			CMD_WRITE_RSTRAIN_TIME = bytes1,
-			CMD_READ_RAIN = bytes1,
+			CMD_READ_RAIN = bytes2,
 			CMD_WRITE_RAIN = bytes1
 		}
 

--- a/CumulusMX/GW1000Api.cs
+++ b/CumulusMX/GW1000Api.cs
@@ -65,12 +65,19 @@ namespace CumulusMX
 			// Set the timeout of the underlying stream
 			if (socket != null)
 			{
-				stream = socket.GetStream();
-				stream.ReadTimeout = 2500;
-				cumulus.LogDebugMessage("Ecowitt Gateway reconnected");
-				connecting = false;
+				try
+				{
+					stream = socket.GetStream();
+					stream.ReadTimeout = 2500;
+					cumulus.LogDebugMessage("Ecowitt Gateway reconnected");
+					connecting = false;
 
-				connected = true;
+					connected = true;
+				}
+				catch(Exception ex)
+				{
+					cumulus.LogMessage("Error reconnecting Ecowitt Gateway: " + ex.Message);
+				}
 			}
 			else
 			{
@@ -296,7 +303,9 @@ namespace CumulusMX
 			CMD_GET_CO2_OFFSET = 0x53,
 			CMD_SET_CO2_OFFSET = 0x54,
 			CMD_READ_RSTRAIN_TIME = 0x55,// read rain reset time
-			CMD_WRITE_RSTRAIN_TIME = 0x56// write back rain reset time
+			CMD_WRITE_RSTRAIN_TIME = 0x56, // write back rain reset time
+			CMD_READ_RAIN = 0x57, // *new* read rain data
+			CMD_WRITE_RAIN = 0x58 // *new* write rain data
 		}
 
 		private enum CommandRespSize : int
@@ -342,60 +351,62 @@ namespace CumulusMX
 			CMD_WRITE_RESET = bytes1,
 			CMD_READ_SENSOR_ID_NEW = bytes2,
 			CMD_READ_RSTRAIN_TIME = bytes1,
-			CMD_WRITE_RSTRAIN_TIME = bytes1
+			CMD_WRITE_RSTRAIN_TIME = bytes1,
+			CMD_READ_RAIN = bytes1,
+			CMD_WRITE_RAIN = bytes1
 		}
 
 		internal enum SensorIds
 		{
-			Wh65,           // 0
-			Wh68,           // 1
-			Wh80,           // 2
-			Wh40,           // 3
-			Wh25,           // 4
-			Wh26,           // 5
-			Wh31Ch1,        // 6
-			Wh31Ch2,        // 7
-			Wh31Ch3,        // 8
-			Wh31Ch4,        // 9
-			Wh31Ch5,        // 10
-			Wh31Ch6,        // 11
-			Wh31Ch7,        // 12
-			Wh31Ch8,        // 13
-			Wh51Ch1,        // 14
-			Wh51Ch2,        // 15
-			Wh51Ch3,        // 16
-			Wh51Ch4,        // 17
-			Wh51Ch5,        // 18
-			Wh51Ch6,        // 19
-			Wh51Ch7,        // 20
-			Wh51Ch8,        // 21
-			Wh41Ch1,        // 22
-			Wh41Ch2,        // 23
-			Wh41Ch3,        // 24
-			Wh41Ch4,        // 25
-			Wh57,           // 26
-			Wh55Ch1,        // 27
-			Wh55Ch2,        // 28
-			Wh55Ch3,        // 29
-			Wh55Ch4,        // 30
-			Wh34Ch1,        // 31
-			Wh34Ch2,        // 32
-			Wh34Ch3,        // 33
-			Wh34Ch4,        // 34
-			Wh34Ch5,        // 35
-			Wh34Ch6,        // 36
-			Wh34Ch7,        // 37
-			Wh34Ch8,        // 38
-			Wh45,           // 39
-			Wh35Ch1,        // 40
-			Wh35Ch2,        // 41
-			Wh35Ch3,        // 42
-			Wh35Ch4,        // 43
-			Wh35Ch5,        // 44
-			Wh35Ch6,        // 45
-			Wh35Ch7,        // 46
-			Wh35Ch8,        // 47
-			Wh90            // 48
+			Wh65,           // 0 00
+			Wh68,           // 1 01
+			Wh80,           // 2 02
+			Wh40,           // 3 03
+			Wh25,           // 4 04
+			Wh26,           // 5 05
+			Wh31Ch1,        // 6 06
+			Wh31Ch2,        // 7 07 
+			Wh31Ch3,        // 8 08
+			Wh31Ch4,        // 9 09
+			Wh31Ch5,        // 10 0A
+			Wh31Ch6,        // 11 0B
+			Wh31Ch7,        // 12 0C
+			Wh31Ch8,        // 13 0D
+			Wh51Ch1,        // 14 0E
+			Wh51Ch2,        // 15 0F
+			Wh51Ch3,        // 16 10
+			Wh51Ch4,        // 17 11
+			Wh51Ch5,        // 18 12
+			Wh51Ch6,        // 19 13
+			Wh51Ch7,        // 20 14
+			Wh51Ch8,        // 21 15
+			Wh41Ch1,        // 22 16
+			Wh41Ch2,        // 23 17
+			Wh41Ch3,        // 24 18
+			Wh41Ch4,        // 25 19
+			Wh57,           // 26 1A
+			Wh55Ch1,        // 27 1B
+			Wh55Ch2,        // 28 1C
+			Wh55Ch3,        // 29 1D
+			Wh55Ch4,        // 30 1E
+			Wh34Ch1,        // 31 1F
+			Wh34Ch2,        // 32 20
+			Wh34Ch3,        // 33 21
+			Wh34Ch4,        // 34 22
+			Wh34Ch5,        // 35 23
+			Wh34Ch6,        // 36 24
+			Wh34Ch7,        // 37 25
+			Wh34Ch8,        // 38 26
+			Wh45,           // 39 27
+			Wh35Ch1,        // 40 28
+			Wh35Ch2,        // 41 29
+			Wh35Ch3,        // 42 2A
+			Wh35Ch4,        // 43 2B
+			Wh35Ch5,        // 44 2C
+			Wh35Ch6,        // 45 2D
+			Wh35Ch7,        // 46 2E
+			Wh35Ch8,        // 47 2F
+			Wh90            // 48 30
 		};
 
 

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -76,6 +76,8 @@ namespace CumulusMX
 			ipaddr = cumulus.Gw1000IpAddress;
 			macaddr = cumulus.Gw1000MacAddress;
 
+			Api = new GW1000Api(cumulus);
+
 			if (DoDiscovery())
 			{
 				cumulus.LogMessage("Using IP address = " + ipaddr + " Port = " + AtPort);
@@ -97,7 +99,7 @@ namespace CumulusMX
 				{
 					// Get the firmware version as check we are communicating
 					GW1000FirmwareVersion = GetFirmwareVersion();
-					cumulus.LogMessage($"GW1000 firmware version: {GW1000FirmwareVersion}");
+					cumulus.LogMessage($"Ecowitt firmware version: {GW1000FirmwareVersion}");
 					if (GW1000FirmwareVersion != "???")
 					{
 						var fwString = GW1000FirmwareVersion.Split(new string[] { "_V" }, StringSplitOptions.None);
@@ -143,7 +145,7 @@ namespace CumulusMX
 			DoDayResetIfNeeded();
 			DoTrendValues(DateTime.Now);
 
-			cumulus.LogMessage("Starting GW1000");
+			cumulus.LogMessage("Starting Ecowitt Local API");
 
 			cumulus.StartTimersAndSensors();
 
@@ -151,17 +153,27 @@ namespace CumulusMX
 			{
 				try
 				{
+					var piezoLastRead = DateTime.MinValue;
+
 					while (!stop)
 					{
 						if (connectedOk)
 						{
 							GetLiveData();
 
-							// at the start of every 20 minutes to trigger battery status check
+							// every 30 seconds read the rain rate
+							if (cumulus.Gw1000PrimaryRainSensor == 1 && (DateTime.Now - piezoLastRead).TotalSeconds >= 30)
+							{
+								GetPiezoRainData();
+								piezoLastRead = DateTime.Now;
+							}
+
 							var minute = DateTime.Now.Minute;
 							if (minute != lastMinute)
 							{
 								lastMinute = minute;
+
+								// at the start of every 20 minutes to trigger battery status check
 								if ((minute % 20) == 0)
 								{
 									GetSensorIdsNew();
@@ -170,11 +182,11 @@ namespace CumulusMX
 						}
 						else
 						{
-							cumulus.LogMessage("Attempting to reconnect to GW1000...");
+							cumulus.LogMessage("Attempting to reconnect to Ecowitt device...");
 							connectedOk = Api.OpenTcpPort(cumulus.Gw1000IpAddress, AtPort);
 							if (connectedOk)
 							{
-								cumulus.LogMessage("Reconnected to GW1000");
+								cumulus.LogMessage("Reconnected to Ecowitt device");
 								GetLiveData();
 							}
 						}
@@ -282,7 +294,7 @@ namespace CumulusMX
 
 					// Get the primary IP address
 					var myIP = Utils.GetIpWithDefaultGateway();
-					cumulus.LogDebugMessage($"Using local IP address {myIP} to discover the GW1000");
+					cumulus.LogDebugMessage($"Using local IP address {myIP} to discover the Ecowitt device");
 
 					// bind the cient to the primary address - broadcast does not work with .Any address :(
 					client.Client.Bind(new IPEndPoint(myIP, broadcastPort));
@@ -324,7 +336,7 @@ namespace CumulusMX
 											{
 												if (!discovered.IP.Contains(ipAddr))
 												{
-													cumulus.LogDebugMessage($"Discovered GW1000 device: IP={ipAddr}, MAC={macHex}");
+													cumulus.LogDebugMessage($"Discovered Ecowitt device: IP={ipAddr}, MAC={macHex}");
 													discovered.IP.Add(ipAddr);
 													discovered.Mac.Add(macHex);
 												}
@@ -353,7 +365,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogMessage("An error occurred during GW1000 auto-discovery");
+				cumulus.LogMessage("An error occurred during Ecowitt auto-discovery");
 				cumulus.LogMessage("Error: " + ex.Message);
 			}
 
@@ -364,7 +376,7 @@ namespace CumulusMX
 		{
 			if (cumulus.Gw1000AutoUpdateIpAddress || string.IsNullOrWhiteSpace(cumulus.Gw1000IpAddress))
 			{
-				var msg = "Running GW-1000 auto-discovery...";
+				var msg = "Running Ecowitt Local API auto-discovery...";
 				cumulus.LogMessage(msg);
 
 				var discoveredDevices = DiscoverGW1000();
@@ -372,17 +384,18 @@ namespace CumulusMX
 				if (discoveredDevices.IP.Count == 0)
 				{
 					// We didn't find anything on the network
-					msg = "Failed to discover any GW1000 devices";
+					msg = "Failed to discover any Ecowitt devices";
 					cumulus.LogMessage(msg);
 					cumulus.LogConsoleMessage(msg);
+					return false;
 				}
 				else if (discoveredDevices.IP.Count == 1 && (string.IsNullOrEmpty(macaddr) || discoveredDevices.Mac[0] == macaddr))
 				{
-					cumulus.LogDebugMessage("Discovered one GW1000 device");
+					cumulus.LogDebugMessage("Discovered one Ecowitt device");
 					// If only one device is discovered, and its MAC address matches (or our MAC is blank), then just use it
 					if (cumulus.Gw1000IpAddress != discoveredDevices.IP[0])
 					{
-						cumulus.LogMessage("Discovered a new IP address for the GW1000 that does not match our current one");
+						cumulus.LogMessage("Discovered a new IP address for the Ecowitt device that does not match our current one");
 						cumulus.LogMessage($"Changing previous IP address: {ipaddr} to {discoveredDevices.IP[0]}");
 						ipaddr = discoveredDevices.IP[0].Trim();
 						cumulus.Gw1000IpAddress = ipaddr;
@@ -397,13 +410,13 @@ namespace CumulusMX
 				{
 					// Multiple devices discovered, but we have a MAC address match
 
-					cumulus.LogDebugMessage("Matching GW-1000 MAC address found on the network");
+					cumulus.LogDebugMessage("Matching Ecowitt MAC address found on the network");
 
 					var idx = discoveredDevices.Mac.IndexOf(macaddr);
 
 					if (discoveredDevices.IP[idx] != ipaddr)
 					{
-						cumulus.LogMessage("Discovered a new IP address for the GW1000 that does not match our current one");
+						cumulus.LogMessage("Discovered a new IP address for the Ecowitt device that does not match our current one");
 						cumulus.LogMessage($"Changing previous IP address: {ipaddr} to {discoveredDevices.IP[idx]}");
 						ipaddr = discoveredDevices.IP[idx];
 						cumulus.Gw1000IpAddress = ipaddr;
@@ -415,7 +428,7 @@ namespace CumulusMX
 					// Multiple devices discovered, and we do not have a clue!
 
 					string iplist = "";
-					msg = "Discovered more than one potential GW1000 device.";
+					msg = "Discovered more than one potential Ecowitt device.";
 					cumulus.LogMessage(msg);
 					cumulus.LogConsoleMessage(msg);
 					msg = "Please select the IP address from the list and enter it manually into the configuration";
@@ -428,6 +441,7 @@ namespace CumulusMX
 					msg = "  discovered IPs = " + iplist;
 					cumulus.LogMessage(msg);
 					cumulus.LogConsoleMessage(msg);
+					return false;
 				}
 			}
 
@@ -489,7 +503,7 @@ namespace CumulusMX
 					var len = GW1000Api.ConvertBigEndianUInt16(data, 3);
 
 					// Only loop as far as last record (7 bytes) minus the checksum byte
-					for (int i = 5; i < len - 7; i += 7)
+					for (int i = 5; i <= len - 6; i += 7)
 					{
 						if (PrintSensorInfoNew(data, i))
 						{
@@ -583,8 +597,8 @@ namespace CumulusMX
 							cumulus.LogMessage($"PrintSensorInfoNew: WS90 sensor detected, changing the update rate from {updateRate / 1000} seconds to 4 seconds");
 							updateRate = 4000;
 						}
-						battV = data[battPos] * 0.1;
-						batt = $"{battV:f1}V ({TestBattery10(data[battPos])})";  // volts/10, low = 1.2V
+						battV = data[battPos] * 0.02;
+						batt = $"{battV:f1}V ({(battV > 2.4 ? "OK" : "Low")})";
 						break;
 
 					case string wh31 when wh31.StartsWith("WH31"):  // ch 1-8
@@ -614,7 +628,7 @@ namespace CumulusMX
 							updateRate = 4000;
 						}
 						battV = data[battPos] * 0.02;
-						batt = $"{battV:f1}V ({(battV > 1.2 ? "OK" : "Low")})";
+						batt = $"{battV:f1}V ({(battV > 2.4 ? "OK" : "Low")})";
 						break;
 
 					default:
@@ -769,11 +783,17 @@ namespace CumulusMX
 								idx += 2;
 								break;
 							case 0x0D: //Rain Event (mm)
-								StormRain = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt16(data, idx) / 10.0);
+								if (cumulus.Gw1000PrimaryRainSensor == 0)
+								{
+									StormRain = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt16(data, idx) / 10.0);
+								}
 								idx += 2;
 								break;
 							case 0x0E: //Rain Rate (mm/h)
-								rainRateLast = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt16(data, idx) / 10.0);
+								if (cumulus.Gw1000PrimaryRainSensor == 0)
+								{
+									rainRateLast = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt16(data, idx) / 10.0);
+								}
 								idx += 2;
 								break;
 							case 0x0F: //Rain hour (mm)
@@ -789,7 +809,10 @@ namespace CumulusMX
 								idx += 4;
 								break;
 							case 0x13: //Rain Year (mm)
-								rainLast = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt32(data, idx) / 10.0);
+								if (cumulus.Gw1000PrimaryRainSensor == 0)
+								{
+									rainLast = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt32(data, idx) / 10.0);
+								}
 								idx += 4;
 								break;
 							case 0x14: //Rain Totals (mm)
@@ -1027,6 +1050,41 @@ namespace CumulusMX
 								DoLeafWetness(data[idx], chan);
 								idx += 1;
 								break;
+							case 0x80: // Piezo Rain Rate
+								if (cumulus.Gw1000PrimaryRainSensor == 1)
+								{
+									rainRateLast = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt16(data, idx) / 10.0);
+								}
+								idx += 2;
+								break;
+							case 0x81: // Piezo Rain Event
+								idx += 2;
+								break;
+							case 0x82: // Piezo Hourly Rain
+								idx += 2;
+								break;
+							case 0x83: // Piezo Daily Rain
+								idx += 2;
+								break;
+							case 0x84: // Piezo Weekly Rain
+								idx += 2;
+								break;
+							case 0x85: // Piezo Monthly Rain
+								idx += 4;
+								break;
+							case 0x86: // Piezo Yearly Rain
+								if (cumulus.Gw1000PrimaryRainSensor == 1)
+								{
+									rainLast = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt32(data, idx) / 10.0);
+								}
+								idx += 4;
+								break;
+							case 0x87: // Piezo Gain - doc says size = 2*10 ?
+								idx += 20;
+								break;
+							case 0x88: // Piezo Rain Reset Time 
+								idx += 3;
+								break;
 							default:
 								cumulus.LogDebugMessage($"Error: Unknown sensor id found = {data[idx - 1]}, at position = {idx - 1}");
 								// We will have lost our place now, so bail out
@@ -1136,7 +1194,7 @@ namespace CumulusMX
 
 		private void GetSystemInfo()
 		{
-			cumulus.LogMessage("Reading GW1000 system info");
+			cumulus.LogMessage("Reading Ecowitt system info");
 
 			var data = Api.DoCommand(GW1000Api.Commands.CMD_READ_SSSS);
 
@@ -1151,6 +1209,12 @@ namespace CumulusMX
 			// 10  - time zone index (?)
 			// 11  - DST 0-1 - false/true
 			// 12  - 0x?? - checksum
+
+			if (data == null)
+			{
+				cumulus.LogMessage("Nothing returned from System Info!");
+				return;
+			}
 
 			if (data.Length != 13)
 			{
@@ -1182,6 +1246,61 @@ namespace CumulusMX
 			catch (Exception ex)
 			{
 				cumulus.LogMessage("Error processing System Info: " + ex.Message);
+			}
+		}
+
+		private void GetPiezoRainData()
+		{
+			cumulus.LogDebugMessage("GetPiezoRainData: Reading piezo rain data");
+
+			var data = Api.DoCommand(GW1000Api.Commands.CMD_READ_RAIN);
+
+
+			// expected response - units mm
+			// 0   - 0xff - header
+			// 1   - 0xff - header
+			// 2   - 0x57 - rain data
+			// 3-4 - size
+			// 05-06 - rain rate
+			// 07-10 - rain day
+			// 11-14 - rain week
+			// 15-18 - rain month
+			// 19-22 - rain year
+			// 23-24 - rain event
+			// 26-27 - rain event
+			// 28-29 - rain hour
+			// 30-31 - piezo rain rate
+			// 32-33 - piezo rain event
+			// 34-35 - piezo rain hour
+			// 36-39 - piezo rain day
+			// 40-43 - piezo rain week
+			// 44-47 - piezo rain month
+			// 48-51 - piezo rain year
+			// 52-71 - piezo gain 0-9 (2 bytes each)
+			// 72-74 - rain reset time (hr, day [sun-0], month [jan=0])
+			// 75 - checksum
+
+			if (data == null)
+			{
+				cumulus.LogMessage("GetPiezoRainData: Nothing returned from Read Rain!");
+				return;
+			}
+
+			if (data.Length != 76)
+			{
+				cumulus.LogMessage("GetPiezoRainData: Unexpected response to Read Rain!");
+				return;
+			}
+			try
+			{
+				var rRate = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt16(data, 30) / 10.0);
+				var rain = ConvertRainMMToUser(GW1000Api.ConvertBigEndianUInt16(data, 48) / 10.0);
+
+				DoRain(rain, rRate, DateTime.Now);
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage("GetPiezoRainData: Error processing Rain Info: " + ex.Message);
 			}
 		}
 

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -70,6 +70,7 @@ namespace CumulusMX
 			{
 				// We are not using the primary T/H sensor so MX must calculate the wind chill as well
 				cumulus.StationOptions.CalculatedWC = true;
+				cumulus.LogMessage("Overriding the default outdoor temp/hum data with Extra temp/hum sensor #" + cumulus.Gw1000PrimaryTHSensor);
 			}
 
 			ipaddr = cumulus.Gw1000IpAddress;

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -55,7 +55,12 @@ namespace CumulusMX
 				// does not provide pressure trend strings
 				cumulus.StationOptions.UseCumulusPresstrendstr = true;
 
-				if (cumulus.Gw1000PrimaryTHSensor != 0)
+				if (cumulus.Gw1000PrimaryTHSensor == 0)
+				{
+					// We are using the primary T/H sensor
+					cumulus.LogMessage("Using the default outdoor temp/hum sensor data");
+				}
+				else
 				{
 					// We are not using the primary T/H sensor
 					cumulus.LogMessage("Overriding the default outdoor temp/hum data with Extra temp/hum sensor #" + cumulus.Gw1000PrimaryTHSensor);
@@ -128,6 +133,7 @@ namespace CumulusMX
 			if (station == null)
 			{
 				StopMinuteTimer();
+				cumulus.LogMessage("HTTP Station (Ecowitt) Stopped");
 			}
 		}
 
@@ -205,6 +211,7 @@ namespace CumulusMX
 
 			if (starting || stopping)
 			{
+				cumulus.LogMessage($"Station {(starting ? "starting" : "stopping")}, incoming data ignored");
 				context.Response.StatusCode = 200;
 				return "success";
 			}
@@ -956,7 +963,14 @@ namespace CumulusMX
 			{
 				if (data["tf_ch" + i] != null)
 				{
-					station.DoUserTemp(ConvertTempFToUser(Convert.ToDouble(data["tf_ch" + i], invNum)), i);
+					if (cumulus.EcowittMapWN34[i] == 0)
+					{
+						station.DoUserTemp(ConvertTempFToUser(Convert.ToDouble(data["tf_ch" + i], invNum)), i);
+					}
+					else
+					{
+						station.DoSoilTemp(ConvertTempFToUser(Convert.ToDouble(data["tf_ch" + i], invNum)), cumulus.EcowittMapWN34[i]);
+					}
 				}
 			}
 		}

--- a/CumulusMX/IniFile.cs
+++ b/CumulusMX/IniFile.cs
@@ -97,7 +97,7 @@ namespace CumulusMX
 						{
 							if (s.Length > 2)
 							{
-								string SectionName = s.Substring(1,s.Length-2);
+								string SectionName = s.Substring(1, s.Length - 2);
 
 								// *** Only first occurrence of a section is loaded ***
 								if (m_Sections.ContainsKey(SectionName))
@@ -107,7 +107,7 @@ namespace CumulusMX
 								else
 								{
 									CurrentSection = new Dictionary<string, string>();
-									m_Sections.Add(SectionName,CurrentSection);
+									m_Sections.Add(SectionName, CurrentSection);
 								}
 							}
 						}
@@ -115,17 +115,27 @@ namespace CumulusMX
 						{
 							// *** Check for key+value pair ***
 							int i;
-							if ((i=s.IndexOf('=')) > 0)
+							if (s.StartsWith("#"))
 							{
+								// It's a comment
+								// *** Only first occurrence of a key is loaded ***
+								if (!CurrentSection.ContainsKey(s))
+								{
+									CurrentSection.Add(s, "");
+								}
+							}
+							else if ((i = s.IndexOf('=')) > 0)
+							{
+								// It's a value
 								int j = s.Length - i - 1;
-								string Key = s.Substring(0,i).Trim();
-								if (Key.Length  > 0)
+								string Key = s.Substring(0, i).Trim();
+								if (Key.Length > 0)
 								{
 									// *** Only first occurrence of a key is loaded ***
 									if (!CurrentSection.ContainsKey(Key))
 									{
-										string Value = (j > 0) ? (s.Substring(i+1,j).Trim()) : ("");
-										CurrentSection.Add(Key,Value);
+										string Value = (j > 0) ? (s.Substring(i + 1, j).Trim()) : ("");
+										CurrentSection.Add(Key, Value);
 									}
 								}
 							}
@@ -160,6 +170,8 @@ namespace CumulusMX
 						// *** Open the file ***
 						using (StreamWriter sw = new StreamWriter(m_FileName))
 						{
+							sw.WriteLine($"#Last updated: {DateTime.Now:G}");
+
 							// *** Cycle on all sections ***
 							bool First = false;
 							foreach (KeyValuePair<string, Dictionary<string, string>> SectionPair in m_Sections)
@@ -178,8 +190,12 @@ namespace CumulusMX
 								{
 									// *** Write the key+value pair ***
 									sw.Write(ValuePair.Key);
-									sw.Write('=');
-									sw.WriteLine(ValuePair.Value);
+									if (!ValuePair.Key.StartsWith("#"))
+									{
+										sw.Write('=');
+										sw.Write(ValuePair.Value);
+									}
+									sw.WriteLine();
 								}
 							}
 						}

--- a/CumulusMX/IniFile.cs
+++ b/CumulusMX/IniFile.cs
@@ -75,12 +75,12 @@ namespace CumulusMX
 					m_Sections.Clear();
 
 					// *** Open the INI file ***
-					try
+					if (File.Exists(m_FileName))
 					{
 						fs = new FileStream(m_FileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
 						sr = new StreamReader(fs);
 					}
-					catch (FileNotFoundException)
+					else
 					{
 						return;
 					}

--- a/CumulusMX/Program.cs
+++ b/CumulusMX/Program.cs
@@ -125,7 +125,11 @@ namespace CumulusMX
 						//allow main to run off
 						Thread.Sleep(500);
 					}
-					Trace.WriteLine("Cumulus has shutdown");
+					else
+					{
+						Trace.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff ") + "Ctrl+C pressed");
+					}
+					Trace.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff ") + "Cumulus has shutdown");
 					ev.Cancel = true;
 					exitSystem = true;
 				};
@@ -304,7 +308,7 @@ namespace CumulusMX
 		{
 			try
 			{
-				Trace.WriteLine("!!! Unhandled Exception !!!");
+				Trace.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff ") + "!!! Unhandled Exception !!!");
 				Trace.WriteLine(e.ExceptionObject.ToString());
 
 				if (service)
@@ -361,7 +365,7 @@ namespace CumulusMX
 		{
 			var reason = new[] { "Ctrl-C", "Ctrl-Break", "Close Main Window", "unknown", "unknown", "User Logoff", "System Shutdown" };
 
-			Trace.WriteLine("Exiting system due to external: " + reason[(int)sig]);
+			Trace.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff ") + "Exiting system due to external: " + reason[(int)sig]);
 
 			if (Program.cumulus != null)
 			{
@@ -372,11 +376,11 @@ namespace CumulusMX
 			}
 			else
 			{
-				Trace.WriteLine("Cumulus has not finished initialising, a clean exit is not possible, forcing exit");
+				Trace.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff ") + "Cumulus has not finished initialising, a clean exit is not possible, forcing exit");
 				Environment.Exit(2);
 			}
 
-			Trace.WriteLine("Cumulus has shutdown");
+			Trace.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff ") + "Cumulus has shutdown");
 			Console.WriteLine("Cumulus stopped");
 
 			Program.exitSystem = true;

--- a/CumulusMX/Program.cs
+++ b/CumulusMX/Program.cs
@@ -262,6 +262,8 @@ namespace CumulusMX
 				{
 					if (appMutex.WaitOne(0, false))
 					{
+						Trace.WriteLine(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff ") + "Releasing Mutex");
+						Trace.Flush();
 						appMutex.ReleaseMutex();
 					}
 					Environment.Exit(0);

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.15.3 - Build 3173")]
+[assembly: AssemblyDescription("Version 3.15.4 - Build 3174")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.15.3.3173")]
-[assembly: AssemblyFileVersion("3.15.3.3173")]
+[assembly: AssemblyVersion("3.15.4.3174")]
+[assembly: AssemblyFileVersion("3.15.4.3174")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.16.0 - Build 3178 - BETA")]
+[assembly: AssemblyDescription("Version 3.16.0 - Build 3182 - BETA")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.16.0.3178")]
-[assembly: AssemblyFileVersion("3.16.0.3178")]
+[assembly: AssemblyVersion("3.16.0.3182")]
+[assembly: AssemblyFileVersion("3.16.0.3182")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.15.4 - Build 3174")]
+[assembly: AssemblyDescription("Version 3.16.0 - Build 3174")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.15.4.3174")]
-[assembly: AssemblyFileVersion("3.15.4.3174")]
+[assembly: AssemblyVersion("3.16.0.3174")]
+[assembly: AssemblyFileVersion("3.16.0.3174")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.16.0 - Build 3175 - BETA")]
+[assembly: AssemblyDescription("Version 3.16.0 - Build 3178 - BETA")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.16.0.3175")]
-[assembly: AssemblyFileVersion("3.16.0.3175")]
+[assembly: AssemblyVersion("3.16.0.3178")]
+[assembly: AssemblyFileVersion("3.16.0.3178")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.16.0 - Build 3174")]
+[assembly: AssemblyDescription("Version 3.16.0 - Build 3175 - BETA")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.16.0.3174")]
-[assembly: AssemblyFileVersion("3.16.0.3174")]
+[assembly: AssemblyVersion("3.16.0.3175")]
+[assembly: AssemblyFileVersion("3.16.0.3175")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -134,6 +134,10 @@ namespace CumulusMX
 
 			var ecowitt = new JsonStationSettingsEcowitt()
 			{
+				setcustom = cumulus.EcowittSetCustomServer,
+				gwaddr = cumulus.EcowittGatewayAddr,
+				localaddr = cumulus.EcowittLocalAddr,
+				interval = cumulus.EcowittCustomInterval,
 				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor
 			};
 
@@ -436,12 +440,13 @@ namespace CumulusMX
 				davisvp2 = davisvp2,
 				daviswll = wll,
 				gw1000 = gw1000,
+				ecowitt = ecowitt,
+				ecowittapi = ecowittapi,
 				weatherflow = weatherflow,
 				fineoffset = fineoffset,
 				easyw = easyweather,
 				imet = imet,
 				wmr928 = wmr928,
-				ecowittapi = ecowittapi,
 				Options = options,
 				Forecast = forecast,
 				Solar = solar,
@@ -958,6 +963,10 @@ namespace CumulusMX
 				{
 					if (settings.ecowitt != null)
 					{
+						cumulus.EcowittSetCustomServer = settings.ecowitt.setcustom;
+						cumulus.EcowittGatewayAddr = settings.ecowitt.gwaddr;
+						cumulus.EcowittLocalAddr = settings.ecowitt.localaddr;
+						cumulus.EcowittCustomInterval = settings.ecowitt.interval;
 						cumulus.Gw1000PrimaryTHSensor = settings.ecowitt.primaryTHsensor;
 					}
 				}
@@ -1544,6 +1553,10 @@ namespace CumulusMX
 
 	internal class JsonStationSettingsEcowitt
 	{
+		public bool setcustom { get; set; }
+		public string gwaddr { get; set; }
+		public string localaddr { get; set; }
+		public int interval { get; set; }
 		public int primaryTHsensor { get; set; }
 	}
 

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -124,11 +124,17 @@ namespace CumulusMX
 			var weatherflow = new JsonStationSettingsWeatherFlow()
 				{deviceid = cumulus.WeatherFlowOptions.WFDeviceId, tcpport = cumulus.WeatherFlowOptions.WFTcpPort, token = cumulus.WeatherFlowOptions.WFToken, dayshistory = cumulus.WeatherFlowOptions.WFDaysHist};
 
-			var gw1000 = new JSonStationSettingsGw1000Conn()
+			var gw1000 = new JsonStationSettingsGw1000Conn()
 			{
 				ipaddress = cumulus.Gw1000IpAddress,
 				autoDiscover = cumulus.Gw1000AutoUpdateIpAddress,
-				macaddress = cumulus.Gw1000MacAddress
+				macaddress = cumulus.Gw1000MacAddress,
+				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor
+			};
+
+			var ecowitt = new JsonStationSettingsEcowitt()
+			{
+				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor
 			};
 
 			var ecowittapi = new JsonStationSettingsEcowittApi()
@@ -936,6 +942,7 @@ namespace CumulusMX
 						cumulus.Gw1000IpAddress = settings.gw1000.ipaddress;
 						cumulus.Gw1000AutoUpdateIpAddress = settings.gw1000.autoDiscover;
 						cumulus.Gw1000MacAddress = settings.gw1000.macaddress;
+						cumulus.Gw1000PrimaryTHSensor = settings.gw1000.primaryTHsensor;
 					}
 				}
 				catch (Exception ex)
@@ -945,6 +952,23 @@ namespace CumulusMX
 					errorMsg += msg + "\n\n";
 					context.Response.StatusCode = 500;
 				}
+
+				// Ecowitt configuration details
+				try
+				{
+					if (settings.ecowitt != null)
+					{
+						cumulus.Gw1000PrimaryTHSensor = settings.ecowitt.primaryTHsensor;
+					}
+				}
+				catch (Exception ex)
+				{
+					var msg = "Error processing Ecowitt settings: " + ex.Message;
+					cumulus.LogMessage(msg);
+					errorMsg += msg + "\n\n";
+					context.Response.StatusCode = 500;
+				}
+
 
 				// weatherflow connection details
 				try
@@ -1349,14 +1373,15 @@ namespace CumulusMX
 		public int stationid { get; set; }
 		public JsonStationGeneral general { get; set; }
 		public JsonStationSettingsDavisVp2 davisvp2 { get; set; }
-		public JSonStationSettingsGw1000Conn gw1000 { get; set; }
+		public JsonStationSettingsGw1000Conn gw1000 { get; set; }
+		public JsonStationSettingsEcowitt ecowitt { get; set; }
+		public JsonStationSettingsEcowittApi ecowittapi { get; set; }
 		public JsonStationSettingsWeatherFlow weatherflow { get; set; }
 		public JsonStationSettingsWLL daviswll { get; set; }
 		public JsonStationSettingsFineOffset fineoffset { get; set; }
 		public JsonStationSettingsEasyWeather easyw { get; set; }
 		public JsonStationSettingsImet imet { get; set; }
 		public JsonStationSettingsWMR928 wmr928 { get; set; }
-		public JsonStationSettingsEcowittApi ecowittapi { get; set; }
 		public JsonStationSettingsOptions Options { get; set; }
 		public JsonStationSettingsForecast Forecast { get; set; }
 		public JsonStationSettingsSolar Solar { get; set; }
@@ -1509,11 +1534,17 @@ namespace CumulusMX
 		public int dayshistory { get; set; }
 	}
 
-	internal class JSonStationSettingsGw1000Conn
+	internal class JsonStationSettingsGw1000Conn
 	{
 		public string ipaddress { get; set; }
 		public bool autoDiscover { get; set; }
 		public string macaddress { get; set; }
+		public int primaryTHsensor { get; set; }
+	}
+
+	internal class JsonStationSettingsEcowitt
+	{
+		public int primaryTHsensor { get; set; }
 	}
 
 	internal class JsonStationSettingsEcowittApi

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -122,25 +122,41 @@ namespace CumulusMX
 			};
 
 			var weatherflow = new JsonStationSettingsWeatherFlow()
-				{deviceid = cumulus.WeatherFlowOptions.WFDeviceId, tcpport = cumulus.WeatherFlowOptions.WFTcpPort, token = cumulus.WeatherFlowOptions.WFToken, dayshistory = cumulus.WeatherFlowOptions.WFDaysHist};
+			{
+				deviceid = cumulus.WeatherFlowOptions.WFDeviceId, 
+				tcpport = cumulus.WeatherFlowOptions.WFTcpPort, 
+				token = cumulus.WeatherFlowOptions.WFToken, 
+				dayshistory = cumulus.WeatherFlowOptions.WFDaysHist
+			};
+
+			var ecowittmaps = new JsonStationSettingsEcowittMappings()
+			{
+				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
+				primaryRainSensor = cumulus.Gw1000PrimaryRainSensor,
+				wn34chan1 = cumulus.EcowittMapWN34[1],
+				wn34chan2 = cumulus.EcowittMapWN34[2],
+				wn34chan3 = cumulus.EcowittMapWN34[3],
+				wn34chan4 = cumulus.EcowittMapWN34[4],
+				wn34chan5 = cumulus.EcowittMapWN34[5],
+				wn34chan6 = cumulus.EcowittMapWN34[6],
+				wn34chan7 = cumulus.EcowittMapWN34[7],
+				wn34chan8 = cumulus.EcowittMapWN34[8]
+			};
 
 			var gw1000 = new JsonStationSettingsGw1000Conn()
 			{
 				ipaddress = cumulus.Gw1000IpAddress,
 				autoDiscover = cumulus.Gw1000AutoUpdateIpAddress,
 				macaddress = cumulus.Gw1000MacAddress,
-				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
-				primaryRainSensor = cumulus.Gw1000PrimaryRainSensor
 			};
+
 
 			var ecowitt = new JsonStationSettingsEcowitt()
 			{
 				setcustom = cumulus.EcowittSetCustomServer,
 				gwaddr = cumulus.EcowittGatewayAddr,
 				localaddr = cumulus.EcowittLocalAddr,
-				interval = cumulus.EcowittCustomInterval,
-				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
-				primaryRainSensor = cumulus.Gw1000PrimaryRainSensor
+				interval = cumulus.EcowittCustomInterval
 			};
 
 			var ecowittapi = new JsonStationSettingsEcowittApi()
@@ -244,9 +260,9 @@ namespace CumulusMX
 				solarmin = cumulus.SolarOptions.SolarMinimum,
 				sunthreshold = cumulus.SolarOptions.SunThreshold,
 				solarcalc = cumulus.SolarOptions.SolarCalc,
-				transfactorJul = cumulus.SolarOptions.RStransfactorJul,
+				transfactorJun = cumulus.SolarOptions.RStransfactorJun,
 				transfactorDec = cumulus.SolarOptions.RStransfactorDec,
-				turbidityJul = cumulus.SolarOptions.BrasTurbidityJul,
+				turbidityJun = cumulus.SolarOptions.BrasTurbidityJun,
 				turbidityDec = cumulus.SolarOptions.BrasTurbidityDec
 			};
 
@@ -402,10 +418,10 @@ namespace CumulusMX
 			for (int i = 1; i <= 8; i++)
 			{
 				PropertyInfo propInfo = wllExtraTemp.GetType().GetProperty("extraTempTx" + i);
-				propInfo.SetValue(wllExtraTemp, Convert.ChangeType(cumulus.WllExtraTempTx[i - 1], propInfo.PropertyType), null);
+				propInfo.SetValue(wllExtraTemp, Convert.ChangeType(cumulus.WllExtraTempTx[i], propInfo.PropertyType), null);
 
 				propInfo = wllExtraTemp.GetType().GetProperty("extraHumTx" + i);
-				propInfo.SetValue(wllExtraTemp, Convert.ChangeType(cumulus.WllExtraHumTx[i - 1], propInfo.PropertyType), null);
+				propInfo.SetValue(wllExtraTemp, Convert.ChangeType(cumulus.WllExtraHumTx[i], propInfo.PropertyType), null);
 			};
 
 			var wll = new JsonStationSettingsWLL()
@@ -444,6 +460,7 @@ namespace CumulusMX
 				gw1000 = gw1000,
 				ecowitt = ecowitt,
 				ecowittapi = ecowittapi,
+				ecowittmaps = ecowittmaps,
 				weatherflow = weatherflow,
 				fineoffset = fineoffset,
 				easyw = easyweather,
@@ -649,12 +666,12 @@ namespace CumulusMX
 						cumulus.SolarOptions.SunThreshold = settings.Solar.sunthreshold;
 						if (cumulus.SolarOptions.SolarCalc == 0)
 						{
-							cumulus.SolarOptions.RStransfactorJul = settings.Solar.transfactorJul;
+							cumulus.SolarOptions.RStransfactorJun = settings.Solar.transfactorJun;
 							cumulus.SolarOptions.RStransfactorDec = settings.Solar.transfactorDec;
 						}
 						else
 						{
-							cumulus.SolarOptions.BrasTurbidityJul = settings.Solar.turbidityJul;
+							cumulus.SolarOptions.BrasTurbidityJun = settings.Solar.turbidityJun;
 							cumulus.SolarOptions.BrasTurbidityDec = settings.Solar.turbidityDec;
 						}
 					}
@@ -873,23 +890,23 @@ namespace CumulusMX
 						cumulus.WllExtraSoilTempTx3 = settings.daviswll.soilLeaf.extraSoilTemp.soilTempTx3;
 						cumulus.WllExtraSoilTempTx4 = settings.daviswll.soilLeaf.extraSoilTemp.soilTempTx4;
 
-						cumulus.WllExtraTempTx[0] = settings.daviswll.extraTemp.extraTempTx1;
-						cumulus.WllExtraTempTx[1] = settings.daviswll.extraTemp.extraTempTx2;
-						cumulus.WllExtraTempTx[2] = settings.daviswll.extraTemp.extraTempTx3;
-						cumulus.WllExtraTempTx[3] = settings.daviswll.extraTemp.extraTempTx4;
-						cumulus.WllExtraTempTx[4] = settings.daviswll.extraTemp.extraTempTx5;
-						cumulus.WllExtraTempTx[5] = settings.daviswll.extraTemp.extraTempTx6;
-						cumulus.WllExtraTempTx[6] = settings.daviswll.extraTemp.extraTempTx7;
-						cumulus.WllExtraTempTx[7] = settings.daviswll.extraTemp.extraTempTx8;
+						cumulus.WllExtraTempTx[1] = settings.daviswll.extraTemp.extraTempTx1;
+						cumulus.WllExtraTempTx[2] = settings.daviswll.extraTemp.extraTempTx2;
+						cumulus.WllExtraTempTx[3] = settings.daviswll.extraTemp.extraTempTx3;
+						cumulus.WllExtraTempTx[4] = settings.daviswll.extraTemp.extraTempTx4;
+						cumulus.WllExtraTempTx[5] = settings.daviswll.extraTemp.extraTempTx5;
+						cumulus.WllExtraTempTx[6] = settings.daviswll.extraTemp.extraTempTx6;
+						cumulus.WllExtraTempTx[7] = settings.daviswll.extraTemp.extraTempTx7;
+						cumulus.WllExtraTempTx[8] = settings.daviswll.extraTemp.extraTempTx8;
 
-						cumulus.WllExtraHumTx[0] = settings.daviswll.extraTemp.extraHumTx1;
-						cumulus.WllExtraHumTx[1] = settings.daviswll.extraTemp.extraHumTx2;
-						cumulus.WllExtraHumTx[2] = settings.daviswll.extraTemp.extraHumTx3;
-						cumulus.WllExtraHumTx[3] = settings.daviswll.extraTemp.extraHumTx4;
-						cumulus.WllExtraHumTx[4] = settings.daviswll.extraTemp.extraHumTx5;
-						cumulus.WllExtraHumTx[5] = settings.daviswll.extraTemp.extraHumTx6;
-						cumulus.WllExtraHumTx[6] = settings.daviswll.extraTemp.extraHumTx7;
-						cumulus.WllExtraHumTx[7] = settings.daviswll.extraTemp.extraHumTx8;
+						cumulus.WllExtraHumTx[1] = settings.daviswll.extraTemp.extraHumTx1;
+						cumulus.WllExtraHumTx[2] = settings.daviswll.extraTemp.extraHumTx2;
+						cumulus.WllExtraHumTx[3] = settings.daviswll.extraTemp.extraHumTx3;
+						cumulus.WllExtraHumTx[4] = settings.daviswll.extraTemp.extraHumTx4;
+						cumulus.WllExtraHumTx[5] = settings.daviswll.extraTemp.extraHumTx5;
+						cumulus.WllExtraHumTx[6] = settings.daviswll.extraTemp.extraHumTx6;
+						cumulus.WllExtraHumTx[7] = settings.daviswll.extraTemp.extraHumTx7;
+						cumulus.WllExtraHumTx[8] = settings.daviswll.extraTemp.extraHumTx8;
 
 						cumulus.DavisOptions.RainGaugeType = settings.daviswll.advanced.raingaugetype;
 						cumulus.DavisOptions.TCPPort = settings.daviswll.advanced.tcpport;
@@ -906,14 +923,7 @@ namespace CumulusMX
 							cumulus.WllExtraSoilTempTx2 > 0 ||
 							cumulus.WllExtraSoilTempTx3 > 0 ||
 							cumulus.WllExtraSoilTempTx4 > 0 ||
-							cumulus.WllExtraTempTx[0] > 0 ||
-							cumulus.WllExtraTempTx[1] > 0 ||
-							cumulus.WllExtraTempTx[2] > 0 ||
-							cumulus.WllExtraTempTx[3] > 0 ||
-							cumulus.WllExtraTempTx[4] > 0 ||
-							cumulus.WllExtraTempTx[5] > 0 ||
-							cumulus.WllExtraTempTx[6] > 0 ||
-							cumulus.WllExtraTempTx[7] > 0
+							Array.Exists(cumulus.WllExtraTempTx, el => el > 0)
 							)
 						{
 							cumulus.StationOptions.LogExtraSensors = true;
@@ -949,8 +959,6 @@ namespace CumulusMX
 						cumulus.Gw1000IpAddress = settings.gw1000.ipaddress;
 						cumulus.Gw1000AutoUpdateIpAddress = settings.gw1000.autoDiscover;
 						cumulus.Gw1000MacAddress = settings.gw1000.macaddress;
-						cumulus.Gw1000PrimaryTHSensor = settings.gw1000.primaryTHsensor;
-						cumulus.Gw1000PrimaryRainSensor = settings.gw1000.primaryRainSensor;
 					}
 				}
 				catch (Exception ex)
@@ -970,8 +978,6 @@ namespace CumulusMX
 						cumulus.EcowittGatewayAddr = settings.ecowitt.gwaddr;
 						cumulus.EcowittLocalAddr = settings.ecowitt.localaddr;
 						cumulus.EcowittCustomInterval = settings.ecowitt.interval;
-						cumulus.Gw1000PrimaryTHSensor = settings.ecowitt.primaryTHsensor;
-						cumulus.Gw1000PrimaryRainSensor = settings.ecowitt.primaryRainSensor;
 					}
 				}
 				catch (Exception ex)
@@ -982,6 +988,99 @@ namespace CumulusMX
 					context.Response.StatusCode = 500;
 				}
 
+				// Ecowitt sensor mappings
+				try
+				{
+					cumulus.Gw1000PrimaryTHSensor = settings.ecowittmaps.primaryTHsensor;
+					cumulus.Gw1000PrimaryRainSensor = settings.ecowittmaps.primaryRainSensor;
+
+					if (cumulus.EcowittMapWN34[1] != settings.ecowittmaps.wn34chan1)
+					{
+						if (cumulus.EcowittMapWN34[1] == 0)
+							station.UserTemp[1] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[1]] = 0;
+
+						cumulus.EcowittMapWN34[1] = settings.ecowittmaps.wn34chan1;
+					}
+
+					if (cumulus.EcowittMapWN34[2] != settings.ecowittmaps.wn34chan2)
+					{
+						if (cumulus.EcowittMapWN34[2] == 0)
+							station.UserTemp[2] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[2]] = 0;
+
+						cumulus.EcowittMapWN34[2] = settings.ecowittmaps.wn34chan2;
+					}
+
+					if (cumulus.EcowittMapWN34[3] != settings.ecowittmaps.wn34chan3)
+					{
+						if (cumulus.EcowittMapWN34[3] == 0)
+							station.UserTemp[3] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[3]] = 0;
+
+						cumulus.EcowittMapWN34[3] = settings.ecowittmaps.wn34chan3;
+					}
+
+					if (cumulus.EcowittMapWN34[4] != settings.ecowittmaps.wn34chan4)
+					{
+						if (cumulus.EcowittMapWN34[4] == 0)
+							station.UserTemp[4] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[4]] = 0;
+
+						cumulus.EcowittMapWN34[4] = settings.ecowittmaps.wn34chan4;
+					}
+
+					if (cumulus.EcowittMapWN34[5] != settings.ecowittmaps.wn34chan5)
+					{
+						if (cumulus.EcowittMapWN34[5] == 0)
+							station.UserTemp[5] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[5]] = 0;
+
+						cumulus.EcowittMapWN34[5] = settings.ecowittmaps.wn34chan5;
+					}
+
+					if (cumulus.EcowittMapWN34[6] != settings.ecowittmaps.wn34chan6)
+					{
+						if (cumulus.EcowittMapWN34[6] == 0)
+							station.UserTemp[6] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[6]] = 0;
+
+						cumulus.EcowittMapWN34[6] = settings.ecowittmaps.wn34chan6;
+					}
+
+					if (cumulus.EcowittMapWN34[7] != settings.ecowittmaps.wn34chan7)
+					{
+						if (cumulus.EcowittMapWN34[7] == 0)
+							station.UserTemp[7] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[7]] = 0;
+
+						cumulus.EcowittMapWN34[7] = settings.ecowittmaps.wn34chan7;
+					}
+
+					if (cumulus.EcowittMapWN34[8] != settings.ecowittmaps.wn34chan8)
+					{
+						if (cumulus.EcowittMapWN34[8] == 0)
+							station.UserTemp[8] = 0;
+						else
+							station.SoilTemp[cumulus.EcowittMapWN34[8]] = 0;
+
+						cumulus.EcowittMapWN34[8] = settings.ecowittmaps.wn34chan8;
+					}
+				}
+				catch (Exception ex)
+				{
+					var msg = "Error processing Ecowitt sensor mapping: " + ex.Message;
+					cumulus.LogMessage(msg);
+					errorMsg += msg + "\n\n";
+					context.Response.StatusCode = 500;
+				}
 
 				// weatherflow connection details
 				try
@@ -1389,6 +1488,7 @@ namespace CumulusMX
 		public JsonStationSettingsGw1000Conn gw1000 { get; set; }
 		public JsonStationSettingsEcowitt ecowitt { get; set; }
 		public JsonStationSettingsEcowittApi ecowittapi { get; set; }
+		public JsonStationSettingsEcowittMappings ecowittmaps { get; set; }
 		public JsonStationSettingsWeatherFlow weatherflow { get; set; }
 		public JsonStationSettingsWLL daviswll { get; set; }
 		public JsonStationSettingsFineOffset fineoffset { get; set; }
@@ -1562,8 +1662,6 @@ namespace CumulusMX
 		public string gwaddr { get; set; }
 		public string localaddr { get; set; }
 		public int interval { get; set; }
-		public int primaryTHsensor { get; set; }
-		public int primaryRainSensor { get; set; }
 	}
 
 	internal class JsonStationSettingsEcowittApi
@@ -1571,6 +1669,21 @@ namespace CumulusMX
 		public string applicationkey { get; set; }
 		public string userkey { get; set; }
 		public string mac { get; set; }
+	}
+
+	internal class JsonStationSettingsEcowittMappings
+	{
+		public int primaryTHsensor { get; set; }
+		public int primaryRainSensor { get; set; }
+
+		public int wn34chan1 { get; set; }
+		public int wn34chan2 { get; set; }
+		public int wn34chan3 { get; set; }
+		public int wn34chan4 { get; set; }
+		public int wn34chan5 { get; set; }
+		public int wn34chan6 { get; set; }
+		public int wn34chan7 { get; set; }
+		public int wn34chan8 { get; set; }
 	}
 
 	internal class JsonStationSettingsWMR928
@@ -1633,9 +1746,9 @@ namespace CumulusMX
 		public int sunthreshold { get; set; }
 		public int solarmin { get; set; }
 		public int solarcalc { get; set; }
-		public double transfactorJul { get; set; }
+		public double transfactorJun { get; set; }
 		public double transfactorDec { get; set; }
-		public double turbidityJul { get; set; }
+		public double turbidityJun { get; set; }
 		public double turbidityDec { get; set; }
 	}
 

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -129,7 +129,8 @@ namespace CumulusMX
 				ipaddress = cumulus.Gw1000IpAddress,
 				autoDiscover = cumulus.Gw1000AutoUpdateIpAddress,
 				macaddress = cumulus.Gw1000MacAddress,
-				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor
+				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
+				primaryRainSensor = cumulus.Gw1000PrimaryRainSensor
 			};
 
 			var ecowitt = new JsonStationSettingsEcowitt()
@@ -138,7 +139,8 @@ namespace CumulusMX
 				gwaddr = cumulus.EcowittGatewayAddr,
 				localaddr = cumulus.EcowittLocalAddr,
 				interval = cumulus.EcowittCustomInterval,
-				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor
+				primaryTHsensor = cumulus.Gw1000PrimaryTHSensor,
+				primaryRainSensor = cumulus.Gw1000PrimaryRainSensor
 			};
 
 			var ecowittapi = new JsonStationSettingsEcowittApi()
@@ -948,6 +950,7 @@ namespace CumulusMX
 						cumulus.Gw1000AutoUpdateIpAddress = settings.gw1000.autoDiscover;
 						cumulus.Gw1000MacAddress = settings.gw1000.macaddress;
 						cumulus.Gw1000PrimaryTHSensor = settings.gw1000.primaryTHsensor;
+						cumulus.Gw1000PrimaryRainSensor = settings.gw1000.primaryRainSensor;
 					}
 				}
 				catch (Exception ex)
@@ -968,6 +971,7 @@ namespace CumulusMX
 						cumulus.EcowittLocalAddr = settings.ecowitt.localaddr;
 						cumulus.EcowittCustomInterval = settings.ecowitt.interval;
 						cumulus.Gw1000PrimaryTHSensor = settings.ecowitt.primaryTHsensor;
+						cumulus.Gw1000PrimaryRainSensor = settings.ecowitt.primaryRainSensor;
 					}
 				}
 				catch (Exception ex)
@@ -1549,6 +1553,7 @@ namespace CumulusMX
 		public bool autoDiscover { get; set; }
 		public string macaddress { get; set; }
 		public int primaryTHsensor { get; set; }
+		public int primaryRainSensor { get; set; }
 	}
 
 	internal class JsonStationSettingsEcowitt
@@ -1558,6 +1563,7 @@ namespace CumulusMX
 		public string localaddr { get; set; }
 		public int interval { get; set; }
 		public int primaryTHsensor { get; set; }
+		public int primaryRainSensor { get; set; }
 	}
 
 	internal class JsonStationSettingsEcowittApi

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -4923,6 +4923,7 @@ namespace CumulusMX
 					ThisMonth.LowPress.Val = Pressure;
 					ThisMonth.HighRainRate.Val = RainRate;
 					ThisMonth.HourlyRain.Val = RainLastHour;
+					ThisMonth.Rain24Hours.Val = Cumulus.DefaultHiVal;
 					ThisMonth.DailyRain.Val = Cumulus.DefaultHiVal;
 					ThisMonth.HighHumidity.Val = OutdoorHumidity;
 					ThisMonth.LowHumidity.Val = OutdoorHumidity;
@@ -4952,6 +4953,7 @@ namespace CumulusMX
 					ThisMonth.LowPress.Ts = timestamp;
 					ThisMonth.HighRainRate.Ts = timestamp;
 					ThisMonth.HourlyRain.Ts = timestamp;
+					ThisMonth.Rain24Hours.Ts = timestamp;
 					ThisMonth.DailyRain.Ts = timestamp;
 					ThisMonth.HighHumidity.Ts = timestamp;
 					ThisMonth.LowHumidity.Ts = timestamp;
@@ -4990,6 +4992,7 @@ namespace CumulusMX
 					ThisYear.LowPress.Val = Pressure;
 					ThisYear.HighRainRate.Val = RainRate;
 					ThisYear.HourlyRain.Val = RainLastHour;
+					ThisYear.Rain24Hours.Val = Cumulus.DefaultHiVal;
 					ThisYear.DailyRain.Val = Cumulus.DefaultHiVal;
 					ThisYear.MonthlyRain.Val = Cumulus.DefaultHiVal;
 					ThisYear.HighHumidity.Val = OutdoorHumidity;
@@ -5020,6 +5023,7 @@ namespace CumulusMX
 					ThisYear.LowPress.Ts = timestamp;
 					ThisYear.HighRainRate.Ts = timestamp;
 					ThisYear.HourlyRain.Ts = timestamp;
+					ThisYear.Rain24Hours.Ts = timestamp;
 					ThisYear.DailyRain.Ts = timestamp;
 					ThisYear.MonthlyRain.Ts = timestamp;
 					ThisYear.HighHumidity.Ts = timestamp;
@@ -8029,6 +8033,7 @@ namespace CumulusMX
 			ThisMonth.LowPress.Val = Cumulus.DefaultLoVal;
 			ThisMonth.HighRainRate.Val = Cumulus.DefaultHiVal;
 			ThisMonth.HourlyRain.Val = Cumulus.DefaultHiVal;
+			ThisMonth.Rain24Hours.Val = Cumulus.DefaultHiVal;
 			ThisMonth.DailyRain.Val = Cumulus.DefaultHiVal;
 			ThisMonth.HighHumidity.Val = Cumulus.DefaultHiVal;
 			ThisMonth.LowHumidity.Val = Cumulus.DefaultLoVal;
@@ -8056,6 +8061,7 @@ namespace CumulusMX
 			ThisMonth.LowPress.Ts = cumulus.defaultRecordTS;
 			ThisMonth.HighRainRate.Ts = cumulus.defaultRecordTS;
 			ThisMonth.HourlyRain.Ts = cumulus.defaultRecordTS;
+			ThisMonth.Rain24Hours.Ts = cumulus.defaultRecordTS;
 			ThisMonth.DailyRain.Ts = cumulus.defaultRecordTS;
 			ThisMonth.HighHumidity.Ts = cumulus.defaultRecordTS;
 			ThisMonth.LowHumidity.Ts = cumulus.defaultRecordTS;
@@ -8440,6 +8446,7 @@ namespace CumulusMX
 			ThisYear.LowPress.Val = Cumulus.DefaultLoVal;
 			ThisYear.HighRainRate.Val = Cumulus.DefaultHiVal;
 			ThisYear.HourlyRain.Val = Cumulus.DefaultHiVal;
+			ThisYear.Rain24Hours.Val = Cumulus.DefaultHiVal;
 			ThisYear.DailyRain.Val = Cumulus.DefaultHiVal;
 			ThisYear.MonthlyRain.Val = Cumulus.DefaultHiVal;
 			ThisYear.HighHumidity.Val = Cumulus.DefaultHiVal;
@@ -8469,6 +8476,7 @@ namespace CumulusMX
 			ThisYear.HighRainRate.Ts = cumulus.defaultRecordTS;
 			ThisYear.HourlyRain.Ts = cumulus.defaultRecordTS;
 			ThisYear.DailyRain.Ts = cumulus.defaultRecordTS;
+			ThisYear.Rain24Hours.Ts = cumulus.defaultRecordTS;
 			ThisYear.MonthlyRain.Ts = cumulus.defaultRecordTS;
 			ThisYear.HighHumidity.Ts = cumulus.defaultRecordTS;
 			ThisYear.LowHumidity.Ts = cumulus.defaultRecordTS;

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -367,6 +367,7 @@ namespace CumulusMX
 			ExtraHum = new double[11];
 			ExtraDewPoint = new double[11];
 			UserTemp = new double[9];
+			SoilTemp = new double[17];
 
 			windcounts = new double[16];
 			WindRecent = new TWindRecent[MaxWindRecent];
@@ -1235,36 +1236,9 @@ namespace CumulusMX
 		public double[] ExtraDewPoint { get; set; }
 
 		/// <summary>
-		/// Soil Temp 1 in C
+		/// Soil Temp 1-16 in C
 		/// </summary>
-		public double SoilTemp1 { get; set; }
-
-		/// <summary>
-		/// Soil Temp 2 in C
-		/// </summary>
-		public double SoilTemp2 { get; set; }
-
-		/// <summary>
-		/// Soil Temp 3 in C
-		/// </summary>
-		public double SoilTemp3 { get; set; }
-
-		/// <summary>
-		/// Soil Temp 4 in C
-		/// </summary>
-		public double SoilTemp4 { get; set; }
-		public double SoilTemp5 { get; set; }
-		public double SoilTemp6 { get; set; }
-		public double SoilTemp7 { get; set; }
-		public double SoilTemp8 { get; set; }
-		public double SoilTemp9 { get; set; }
-		public double SoilTemp10 { get; set; }
-		public double SoilTemp11 { get; set; }
-		public double SoilTemp12 { get; set; }
-		public double SoilTemp13 { get; set; }
-		public double SoilTemp14 { get; set; }
-		public double SoilTemp15 { get; set; }
-		public double SoilTemp16 { get; set; }
+		public double[] SoilTemp { get; set; }
 
 		public double RainYesterday { get; set; }
 
@@ -1900,14 +1874,6 @@ namespace CumulusMX
 			{
 				DoForecast("", true);
 			}
-
-
-			if (DataStopped)
-			{
-				// No data coming in, do not do anything else
-				return;
-			}
-
 
 			if (now.Hour == 0)
 			{
@@ -4934,8 +4900,8 @@ namespace CumulusMX
 					ThisMonth.HighDewPoint.Val = OutdoorDewpoint;
 					ThisMonth.LowDewPoint.Val = OutdoorDewpoint;
 					ThisMonth.HighWindRun.Val = Cumulus.DefaultHiVal;
-					ThisMonth.LongestDryPeriod.Val = Cumulus.DefaultHiVal;
-					ThisMonth.LongestWetPeriod.Val = Cumulus.DefaultHiVal;
+					ThisMonth.LongestDryPeriod.Val = 0;
+					ThisMonth.LongestWetPeriod.Val = 0;
 					ThisMonth.HighDailyTempRange.Val = Cumulus.DefaultHiVal;
 					ThisMonth.LowDailyTempRange.Val = Cumulus.DefaultLoVal;
 
@@ -5004,8 +4970,8 @@ namespace CumulusMX
 					ThisYear.HighDewPoint.Val = OutdoorDewpoint;
 					ThisYear.LowDewPoint.Val = OutdoorDewpoint;
 					ThisYear.HighWindRun.Val = Cumulus.DefaultHiVal;
-					ThisYear.LongestDryPeriod.Val = Cumulus.DefaultHiVal;
-					ThisYear.LongestWetPeriod.Val = Cumulus.DefaultHiVal;
+					ThisYear.LongestDryPeriod.Val = 0;
+					ThisYear.LongestWetPeriod.Val = 0;
 					ThisYear.HighDailyTempRange.Val = Cumulus.DefaultHiVal;
 					ThisYear.LowDailyTempRange.Val = Cumulus.DefaultLoVal;
 
@@ -7255,57 +7221,8 @@ namespace CumulusMX
 
 		public void DoSoilTemp(double value, int index)
 		{
-			switch (index)
-			{
-				case 1:
-					SoilTemp1 = value;
-					break;
-				case 2:
-					SoilTemp2 = value;
-					break;
-				case 3:
-					SoilTemp3 = value;
-					break;
-				case 4:
-					SoilTemp4 = value;
-					break;
-				case 5:
-					SoilTemp5 = value;
-					break;
-				case 6:
-					SoilTemp6 = value;
-					break;
-				case 7:
-					SoilTemp7 = value;
-					break;
-				case 8:
-					SoilTemp8 = value;
-					break;
-				case 9:
-					SoilTemp9 = value;
-					break;
-				case 10:
-					SoilTemp10 = value;
-					break;
-				case 11:
-					SoilTemp11 = value;
-					break;
-				case 12:
-					SoilTemp12 = value;
-					break;
-				case 13:
-					SoilTemp13 = value;
-					break;
-				case 14:
-					SoilTemp14 = value;
-					break;
-				case 15:
-					SoilTemp15 = value;
-					break;
-				case 16:
-					SoilTemp16 = value;
-					break;
-			}
+			if (index > 0 && index < SoilTemp.Length)
+				SoilTemp[index] = value;
 		}
 
 		public void DoAirQuality(double value, int index)
@@ -7747,10 +7664,10 @@ namespace CumulusMX
 			AllTime.MonthlyRain.Val = ini.GetValue("Rain", "highmonthlyrainvalue", Cumulus.DefaultHiVal);
 			AllTime.MonthlyRain.Ts = ini.GetValue("Rain", "highmonthlyraintime", cumulus.defaultRecordTS);
 
-			AllTime.LongestDryPeriod.Val = ini.GetValue("Rain", "longestdryperiodvalue", Cumulus.DefaultHiVal);
+			AllTime.LongestDryPeriod.Val = ini.GetValue("Rain", "longestdryperiodvalue", 0);
 			AllTime.LongestDryPeriod.Ts = ini.GetValue("Rain", "longestdryperiodtime", cumulus.defaultRecordTS);
 
-			AllTime.LongestWetPeriod.Val = ini.GetValue("Rain", "longestwetperiodvalue", Cumulus.DefaultHiVal);
+			AllTime.LongestWetPeriod.Val = ini.GetValue("Rain", "longestwetperiodvalue", 0);
 			AllTime.LongestWetPeriod.Ts = ini.GetValue("Rain", "longestwetperiodtime", cumulus.defaultRecordTS);
 
 			AllTime.HighPress.Val = ini.GetValue("Pressure", "highpressurevalue", Cumulus.DefaultHiVal);
@@ -8122,9 +8039,9 @@ namespace CumulusMX
 				ThisMonth.DailyRain.Ts = ini.GetValue("Rain", "HDailyTime", cumulus.defaultRecordTS);
 				ThisMonth.Rain24Hours.Val = ini.GetValue("Rain", "24Hour", Cumulus.DefaultHiVal);
 				ThisMonth.Rain24Hours.Ts = ini.GetValue("Rain", "24HourTime", cumulus.defaultRecordTS);
-				ThisMonth.LongestDryPeriod.Val = ini.GetValue("Rain", "LongestDryPeriod", Cumulus.DefaultHiVal);
+				ThisMonth.LongestDryPeriod.Val = ini.GetValue("Rain", "LongestDryPeriod", 0);
 				ThisMonth.LongestDryPeriod.Ts = ini.GetValue("Rain", "LongestDryPeriodTime", cumulus.defaultRecordTS);
-				ThisMonth.LongestWetPeriod.Val = ini.GetValue("Rain", "LongestWetPeriod", Cumulus.DefaultHiVal);
+				ThisMonth.LongestWetPeriod.Val = ini.GetValue("Rain", "LongestWetPeriod", 0);
 				ThisMonth.LongestWetPeriod.Ts = ini.GetValue("Rain", "LongestWetPeriodTime", cumulus.defaultRecordTS);
 				// humidity
 				ThisMonth.LowHumidity.Val = ini.GetValue("Humidity", "Low", Cumulus.DefaultLoVal);
@@ -8300,9 +8217,9 @@ namespace CumulusMX
 				ThisYear.Rain24Hours.Ts = ini.GetValue("Rain", "24HourTime", cumulus.defaultRecordTS);
 				ThisYear.MonthlyRain.Val = ini.GetValue("Rain", "MonthlyHigh", Cumulus.DefaultHiVal);
 				ThisYear.MonthlyRain.Ts = ini.GetValue("Rain", "HMonthlyTime", cumulus.defaultRecordTS);
-				ThisYear.LongestDryPeriod.Val = ini.GetValue("Rain", "LongestDryPeriod", Cumulus.DefaultHiVal);
+				ThisYear.LongestDryPeriod.Val = ini.GetValue("Rain", "LongestDryPeriod", 0);
 				ThisYear.LongestDryPeriod.Ts = ini.GetValue("Rain", "LongestDryPeriodTime", cumulus.defaultRecordTS);
-				ThisYear.LongestWetPeriod.Val = ini.GetValue("Rain", "LongestWetPeriod", Cumulus.DefaultHiVal);
+				ThisYear.LongestWetPeriod.Val = ini.GetValue("Rain", "LongestWetPeriod", 0);
 				ThisYear.LongestWetPeriod.Ts = ini.GetValue("Rain", "LongestWetPeriodTime", cumulus.defaultRecordTS);
 				// humidity
 				ThisYear.LowHumidity.Val = ini.GetValue("Humidity", "Low", Cumulus.DefaultLoVal);
@@ -8748,10 +8665,10 @@ namespace CumulusMX
 			if (cumulus.AWEKAS.SendSoilTemp)
 			{
 				if (started) sb.Append("&"); else started = true;
-				sb.Append("soiltemp1=" + ConvertUserTempToC(SoilTemp1).ToString("F1", InvC));
-				sb.Append("&soiltemp2=" + ConvertUserTempToC(SoilTemp2).ToString("F1", InvC));
-				sb.Append("&soiltemp3=" + ConvertUserTempToC(SoilTemp3).ToString("F1", InvC));
-				sb.Append("&soiltemp4=" + ConvertUserTempToC(SoilTemp4).ToString("F1", InvC));
+				for (var i = 1; i <= 4; i++)
+				{
+					sb.Append($"soiltemp{i}=" + ConvertUserTempToC(SoilTemp[i]).ToString("F1", InvC));
+				}
 			}
 
 			if (cumulus.AWEKAS.SendSoilMoisture)
@@ -8858,7 +8775,7 @@ namespace CumulusMX
 			}
 
 			if (cumulus.AWEKAS.SendSoilTemp)
-				sb.Append(ConvertUserTempToC(SoilTemp1).ToString("F1", InvC) + sep);        // 21
+				sb.Append(ConvertUserTempToC(SoilTemp[1]).ToString("F1", InvC) + sep);        // 21
 			else
 				sb.Append(sep);
 
@@ -9004,13 +8921,13 @@ namespace CumulusMX
 			}
 			// Davis soil and leaf sensors
 			if (cumulus.Wund.SendSoilTemp1)
-				Data.Append($"&soiltempf={TempFstr(SoilTemp1)}");
+				Data.Append($"&soiltempf={TempFstr(SoilTemp[1])}");
 			if (cumulus.Wund.SendSoilTemp2)
-				Data.Append($"&soiltempf2={TempFstr(SoilTemp2)}");
+				Data.Append($"&soiltempf2={TempFstr(SoilTemp[2])}");
 			if (cumulus.Wund.SendSoilTemp3)
-				Data.Append($"&soiltempf3={TempFstr(SoilTemp3)}");
+				Data.Append($"&soiltempf3={TempFstr(SoilTemp[3])}");
 			if (cumulus.Wund.SendSoilTemp4)
-				Data.Append($"&soiltempf4={TempFstr(SoilTemp4)}");
+				Data.Append($"&soiltempf4={TempFstr(SoilTemp[4])}");
 
 			if (cumulus.Wund.SendSoilMoisture1)
 				Data.Append($"&soilmoisture={SoilMoisture1}");
@@ -9337,57 +9254,7 @@ namespace CumulusMX
 			}
 			if (cumulus.WOW.SendSoilTemp)
 			{
-				switch (cumulus.WOW.SoilTempSensor)
-				{
-					case 1:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp1));
-						break;
-					case 2:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp2));
-						break;
-					case 3:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp3));
-						break;
-					case 4:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp4));
-						break;
-					case 5:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp5));
-						break;
-					case 6:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp6));
-						break;
-					case 7:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp7));
-						break;
-					case 8:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp8));
-						break;
-					case 9:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp9));
-						break;
-					case 10:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp10));
-						break;
-					case 11:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp11));
-						break;
-					case 12:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp12));
-						break;
-					case 13:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp13));
-						break;
-					case 14:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp14));
-						break;
-					case 15:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp15));
-						break;
-					case 16:
-						Data.Append($"&soiltempf=" + TempFstr(SoilTemp16));
-						break;
-				}
+				Data.Append($"&soiltempf=" + TempFstr(SoilTemp[cumulus.WOW.SoilTempSensor]));
 			}
 
 			Data.Append("&softwaretype=Cumulus%20v" + cumulus.Version);
@@ -9882,22 +9749,11 @@ namespace CumulusMX
 		{
 			var json = new StringBuilder("{\"data\":[", 2048);
 
-			json.Append($"[\"{cumulus.SoilTempCaptions[1]}\",\"{SoilTemp1.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[2]}\",\"{SoilTemp2.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[3]}\",\"{SoilTemp3.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[4]}\",\"{SoilTemp4.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[5]}\",\"{SoilTemp5.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[6]}\",\"{SoilTemp6.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[7]}\",\"{SoilTemp7.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[8]}\",\"{SoilTemp8.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[9]}\",\"{SoilTemp9.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[10]}\",\"{SoilTemp10.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[11]}\",\"{SoilTemp11.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[12]}\",\"{SoilTemp12.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[13]}\",\"{SoilTemp13.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[14]}\",\"{SoilTemp14.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[15]}\",\"{SoilTemp15.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
-			json.Append($"[\"{cumulus.SoilTempCaptions[16]}\",\"{SoilTemp16.ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"]");
+			for (var i = 1; i <= 16; i++)
+			{
+				json.Append($"[\"{cumulus.SoilTempCaptions[i]}\",\"{SoilTemp[i].ToString(cumulus.TempFormat)}\",\"&deg;{cumulus.Units.TempText[1]}\"],");
+			}
+			json.Length--;
 			json.Append("]}");
 			return json.ToString();
 		}

--- a/CumulusMX/Wizard.cs
+++ b/CumulusMX/Wizard.cs
@@ -83,7 +83,7 @@ namespace CumulusMX
 			var weatherflow = new JsonStationSettingsWeatherFlow()
 				{deviceid = cumulus.WeatherFlowOptions.WFDeviceId, tcpport = cumulus.WeatherFlowOptions.WFTcpPort, token = cumulus.WeatherFlowOptions.WFToken, dayshistory = cumulus.WeatherFlowOptions.WFDaysHist};
 
-			var gw1000 = new JSonStationSettingsGw1000Conn()
+			var gw1000 = new JsonStationSettingsGw1000Conn()
 			{
 				ipaddress = cumulus.Gw1000IpAddress,
 				autoDiscover = cumulus.Gw1000AutoUpdateIpAddress,
@@ -668,7 +668,7 @@ namespace CumulusMX
 		public string stationmodel { get; set; }
 		public JsonWizardDavisVp davisvp2 { get; set; }
 		public JsonWizardDavisWll daviswll { get; set; }
-		public JSonStationSettingsGw1000Conn gw1000 { get; set; }
+		public JsonStationSettingsGw1000Conn gw1000 { get; set; }
 		public JsonWizardFineOffset fineoffset { get; set; }
 		public JsonWizardEasyWeather easyw { get; set; }
 		public JsonWizardImet imet { get; set; }

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -3352,13 +3352,13 @@ namespace CumulusMX
 				return "n/a";
 
 			// subtract today from yesterday, unless it has been reset, then its just today
-			var hrs = station.ChillHours > station.YestChillHours ? station.ChillHours - station.YestChillHours : station.ChillHours;
+			var hrs = station.ChillHours >= station.YestChillHours ? station.ChillHours - station.YestChillHours : station.ChillHours;
 			return CheckRcDp(hrs, tagParams, 1);
 		}
 
 		private string TagChillHoursYesterday(Dictionary<string, string> tagParams)
 		{
-			var dayb4yest = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day).AddDays(-2);
+			var dayb4yest = DateTime.Now.Date.AddDays(-2);
 			WeatherStation.dayfilerec rec;
 			try
 			{
@@ -3374,14 +3374,13 @@ namespace CumulusMX
 			if (station.YestChillHours == -1)
 				return "n/a";
 
-			if (station.YestChillHours > rec.ChillHours)
+			if (Math.Round(station.YestChillHours, 1) >= rec.ChillHours)
 				hrs = station.YestChillHours - rec.ChillHours;
 			else
 				hrs = station.YestChillHours;
 
 			return CheckRcDp(hrs, tagParams, 1);
 		}
-
 
 		private string TagYChillHours(Dictionary<string, string> tagParams)
 		{
@@ -3571,82 +3570,82 @@ namespace CumulusMX
 
 		private string TagSoilTemp1(Dictionary<string,string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp1, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[1], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp2(Dictionary<string,string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp2, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[2], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp3(Dictionary<string,string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp3, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[3], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp4(Dictionary<string,string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp4, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[4], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp5(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp5, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[5], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp6(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp6, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[6], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp7(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp7, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[7], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp8(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp8, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[8], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp9(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp9, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[9], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp10(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp10, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[10], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp11(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp11, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[11], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp12(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp12, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[12], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp13(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp13, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[13], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp14(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp14, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[14], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp15(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp15, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[15], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilTemp16(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.SoilTemp16, tagParams, cumulus.TempDPlaces);
+			return CheckRcDp(station.SoilTemp[16], tagParams, cumulus.TempDPlaces);
 		}
 
 		private string TagSoilMoisture1(Dictionary<string,string> tagParams)

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -1385,6 +1385,7 @@ namespace CumulusMX
 			if (station.AllTime.HighRainRate.Ts >= threshold ||
 				station.AllTime.DailyRain.Ts >= threshold ||
 				station.AllTime.HourlyRain.Ts >= threshold ||
+				station.AllTime.Rain24Hours.Ts >= threshold ||
 				station.AllTime.LongestDryPeriod.Ts >= threshold ||
 				station.AllTime.LongestWetPeriod.Ts >= threshold ||
 				station.AllTime.MonthlyRain.Ts >= threshold
@@ -1504,6 +1505,11 @@ namespace CumulusMX
 		private string TagHighDailyRainRecordSet(Dictionary<string,string> tagParams)
 		{
 			return station.AllTime.DailyRain.Ts < DateTime.Now.AddHours(-cumulus.RecordSetTimeoutHrs) ? "0" : "1";
+		}
+
+		private string TagHighRain24HourRecordSet(Dictionary<string, string> tagParams)
+		{
+			return station.AllTime.Rain24Hours.Ts < DateTime.Now.AddHours(-cumulus.RecordSetTimeoutHrs) ? "0" : "1";
 		}
 
 		private string TagHighMonthlyRainRecordSet(Dictionary<string,string> tagParams)
@@ -2269,24 +2275,34 @@ namespace CumulusMX
 			return GetFormattedDateTime(station.AllTime.DailyRain.Ts, "o\\n dd MMMM yyyy", tagParams);
 		}
 
+		private string Tagr24hourH(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AllTime.Rain24Hours.Val, tagParams, cumulus.RainDPlaces);
+		}
+
+		private string TagTr24hourH(Dictionary<string, string> tagParams)
+		{
+			return GetFormattedDateTime(station.AllTime.Rain24Hours.Ts, "\\a\\t HH:mm o\\n dd MMMM yyyy", tagParams);
+		}
+
 		private string TagLongestDryPeriod(Dictionary<string,string> tagParams)
 		{
-			return station.AllTime.LongestDryPeriod.Val.ToString("F0");
+			return station.AllTime.LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : station.AllTime.LongestDryPeriod.Val.ToString("F0");
 		}
 
 		private string TagTLongestDryPeriod(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(station.AllTime.LongestDryPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
+			return station.AllTime.LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.AllTime.LongestDryPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
 		}
 
 		private string TagLongestWetPeriod(Dictionary<string,string> tagParams)
 		{
-			return station.AllTime.LongestWetPeriod.Val.ToString("F0");
+			return station.AllTime.LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : station.AllTime.LongestWetPeriod.Val.ToString("F0");
 		}
 
 		private string TagTLongestWetPeriod(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(station.AllTime.LongestWetPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
+			return station.AllTime.LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.AllTime.LongestWetPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
 		}
 
 		private string TagLowDailyTempRange(Dictionary<string,string> tagParams)
@@ -2595,28 +2611,41 @@ namespace CumulusMX
 			return GetFormattedDateTime(station.MonthlyRecs[month].DailyRain.Ts, "o\\n dd MMMM yyyy", tagParams);
 		}
 
+		private string TagByMonthRain24HourH(Dictionary<string, string> tagParams)
+		{
+			var month = GetMonthParam(tagParams);
+			return GetMonthlyAlltimeValueStr(station.MonthlyRecs[month].Rain24Hours, tagParams, cumulus.RainDPlaces);
+		}
+
+		private string TagByMonthRain24HourHt(Dictionary<string, string> tagParams)
+		{
+			var month = GetMonthParam(tagParams);
+			return GetFormattedDateTime(station.MonthlyRecs[month].Rain24Hours.Ts, "\\a\\t HH:mm o\\n dd MMMM yyyy", tagParams);
+		}
+
+
 		private string TagByMonthLongestDryPeriod(Dictionary<string,string> tagParams)
 		{
 			var month = GetMonthParam(tagParams);
-			return GetMonthlyAlltimeValueStr(station.MonthlyRecs[month].LongestDryPeriod, tagParams, 0);
+			return station.MonthlyRecs[month].LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetMonthlyAlltimeValueStr(station.MonthlyRecs[month].LongestDryPeriod, tagParams, 0);
 		}
 
 		private string TagByMonthLongestDryPeriodT(Dictionary<string,string> tagParams)
 		{
 			var month = GetMonthParam(tagParams);
-			return GetFormattedDateTime(station.MonthlyRecs[month].LongestDryPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
+			return station.MonthlyRecs[month].LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.MonthlyRecs[month].LongestDryPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
 		}
 
 		private string TagByMonthLongestWetPeriod(Dictionary<string,string> tagParams)
 		{
 			var month = GetMonthParam(tagParams);
-			return GetMonthlyAlltimeValueStr(station.MonthlyRecs[month].LongestWetPeriod, tagParams, 0);
+			return station.MonthlyRecs[month].LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetMonthlyAlltimeValueStr(station.MonthlyRecs[month].LongestWetPeriod, tagParams, 0);
 		}
 
 		private string TagByMonthLongestWetPeriodT(Dictionary<string,string> tagParams)
 		{
 			var month = GetMonthParam(tagParams);
-			return GetFormattedDateTime(station.MonthlyRecs[month].LongestWetPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
+			return station.MonthlyRecs[month].LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.MonthlyRecs[month].LongestWetPeriod.Ts, "\\to dd MMMM yyyy", tagParams);
 		}
 
 		private string TagByMonthLowDailyTempRange(Dictionary<string,string> tagParams)
@@ -4204,14 +4233,20 @@ namespace CumulusMX
 			return CheckRcDp(station.ThisMonth.DailyRain.Val, tagParams, cumulus.RainDPlaces);
 		}
 
+		private string TagMonthRain24HourH(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.ThisMonth.Rain24Hours.Val, tagParams, cumulus.RainDPlaces);
+		}
+
+
 		private string TagMonthLongestDryPeriod(Dictionary<string,string> tagParams)
 		{
-			return station.ThisMonth.LongestDryPeriod.Val.ToString();
+			return station.ThisMonth.LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : station.ThisMonth.LongestDryPeriod.Val.ToString();
 		}
 
 		private string TagMonthLongestWetPeriod(Dictionary<string,string> tagParams)
 		{
-			return station.ThisMonth.LongestWetPeriod.Val.ToString();
+			return station.ThisMonth.LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : station.ThisMonth.LongestWetPeriod.Val.ToString();
 		}
 
 		private string TagMonthHighDailyTempRange(Dictionary<string,string> tagParams)
@@ -4320,6 +4355,12 @@ namespace CumulusMX
 			return GetFormattedDateTime(station.ThisMonth.HourlyRain.Ts, "t", tagParams);
 		}
 
+		private string TagMonthRain24HourHt(Dictionary<string, string> tagParams)
+		{
+			return GetFormattedDateTime(station.ThisMonth.Rain24Hours.Ts, "t", tagParams);
+		}
+
+
 		// Monthly highs and lows - dates
 		private string TagMonthTempHd(Dictionary<string,string> tagParams)
 		{
@@ -4426,6 +4467,11 @@ namespace CumulusMX
 			return GetFormattedDateTime(station.ThisMonth.HourlyRain.Ts, "dd MMMM", tagParams);
 		}
 
+		private string TagMonthRain24HourHd(Dictionary<string, string> tagParams)
+		{
+			return GetFormattedDateTime(station.ThisMonth.Rain24Hours.Ts, "dd MMMM", tagParams);
+		}
+
 		private string TagMonthHighDailyTempRangeD(Dictionary<string,string> tagParams)
 		{
 			return station.ThisMonth.HighDailyTempRange.Val < 999 ? GetFormattedDateTime(station.ThisMonth.HighDailyTempRange.Ts, "dd MMMM", tagParams) : "------";
@@ -4448,12 +4494,12 @@ namespace CumulusMX
 
 		private string TagMonthLongestDryPeriodD(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisMonth.LongestDryPeriod.Ts, "dd MMMM", tagParams);
+			return station.ThisMonth.LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.ThisMonth.LongestDryPeriod.Ts, "dd MMMM", tagParams);
 		}
 
 		private string TagMonthLongestWetPeriodD(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisMonth.LongestWetPeriod.Ts, "dd MMMM", tagParams);
+			return station.ThisMonth.LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.ThisMonth.LongestWetPeriod.Ts, "dd MMMM", tagParams);
 		}
 
 		// Yearly highs and lows - values
@@ -4572,14 +4618,20 @@ namespace CumulusMX
 			return CheckRcDp(station.ThisYear.DailyRain.Val, tagParams, cumulus.RainDPlaces);
 		}
 
+		private string TagYearRain24HourH(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.ThisYear.Rain24Hours.Val, tagParams, cumulus.RainDPlaces);
+		}
+
+
 		private string TagYearLongestDryPeriod(Dictionary<string,string> tagParams)
 		{
-			return station.ThisYear.LongestDryPeriod.Val.ToString();
+			return station.ThisYear.LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : station.ThisYear.LongestDryPeriod.Val.ToString();
 		}
 
 		private string TagYearLongestWetPeriod(Dictionary<string,string> tagParams)
 		{
-			return station.ThisYear.LongestWetPeriod.Val.ToString();
+			return station.ThisYear.LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : station.ThisYear.LongestWetPeriod.Val.ToString();
 		}
 
 		private string TagYearHighDailyTempRange(Dictionary<string,string> tagParams)
@@ -4692,6 +4744,12 @@ namespace CumulusMX
 			return GetFormattedDateTime(station.ThisYear.HourlyRain.Ts, "t", tagParams);
 		}
 
+		private string TagYearRain24HourHt(Dictionary<string, string> tagParams)
+		{
+			return GetFormattedDateTime(station.ThisYear.Rain24Hours.Ts, "t", tagParams);
+		}
+
+
 		// Yearly highs and lows - dates
 		private string TagYearTempHd(Dictionary<string,string> tagParams)
 		{
@@ -4797,6 +4855,12 @@ namespace CumulusMX
 			return GetFormattedDateTime(station.ThisYear.HourlyRain.Ts, "dd MMMM", tagParams);
 		}
 
+		private string TagYearRain24HourHd(Dictionary<string, string> tagParams)
+		{
+			return GetFormattedDateTime(station.ThisYear.Rain24Hours.Ts, "dd MMMM", tagParams);
+		}
+
+
 		private string TagYearHighDailyTempRangeD(Dictionary<string,string> tagParams)
 		{
 			return station.ThisYear.HighDailyTempRange.Val > -999 ? GetFormattedDateTime(station.ThisYear.HighDailyTempRange.Ts, "dd MMMM", tagParams) : "------";
@@ -4819,12 +4883,12 @@ namespace CumulusMX
 
 		private string TagYearLongestDryPeriodD(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisYear.LongestDryPeriod.Ts, "dd MMMM", tagParams);
+			return station.ThisYear.LongestDryPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.ThisYear.LongestDryPeriod.Ts, "dd MMMM", tagParams);
 		}
 
 		private string TagYearLongestWetPeriodD(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisYear.LongestWetPeriod.Ts, "dd MMMM", tagParams);
+			return station.ThisYear.LongestWetPeriod.Val == Cumulus.DefaultHiVal ? "--" : GetFormattedDateTime(station.ThisYear.LongestWetPeriod.Ts, "dd MMMM", tagParams);
 		}
 
 		private string TagYearMonthlyRainHd(Dictionary<string,string> tagParams)
@@ -5372,6 +5436,7 @@ namespace CumulusMX
 				{ "HighRainRateRecordSet", TagHighRainRateRecordSet },
 				{ "HighHourlyRainRecordSet", TagHighHourlyRainRecordSet },
 				{ "HighDailyRainRecordSet", TagHighDailyRainRecordSet },
+				{ "HighRain24HourRecordSet", TagHighRain24HourRecordSet },
 				{ "HighMonthlyRainRecordSet", TagHighMonthlyRainRecordSet },
 				{ "HighHumidityRecordSet", TagHighHumidityRecordSet },
 				{ "LowHumidityRecordSet", TagLowHumidityRecordSet },
@@ -5511,6 +5576,8 @@ namespace CumulusMX
 				{ "TrrateM", TagTrrateM },
 				{ "rfallH", TagrfallH },
 				{ "TrfallH", TagTrfallH },
+				{ "r24hourH", Tagr24hourH },
+				{ "Tr24hourH", TagTr24hourH },
 				{ "rfallhH", TagrfallhH },
 				{ "TrfallhH", TagTrfallhH },
 				{ "rfallmH", TagrfallmH },
@@ -5843,6 +5910,7 @@ namespace CumulusMX
 				{ "MonthWindH", TagMonthWindH },
 				{ "MonthRainRateH", TagMonthRainRateH },
 				{ "MonthHourlyRainH", TagMonthHourlyRainH },
+				{ "MonthRain24HourH", TagMonthRain24HourH },
 				{ "MonthDailyRainH", TagMonthDailyRainH },
 				{ "MonthDewPointH", TagMonthDewPointH },
 				{ "MonthDewPointL", TagMonthDewPointL },
@@ -5869,6 +5937,7 @@ namespace CumulusMX
 				{ "MonthWindHT", TagMonthWindHt },
 				{ "MonthRainRateHT", TagMonthRainRateHt },
 				{ "MonthHourlyRainHT", TagMonthHourlyRainHt },
+				{ "MonthRain24HourHT", TagMonthRain24HourHt },
 				{ "MonthDewPointHT", TagMonthDewPointHt },
 				{ "MonthDewPointLT", TagMonthDewPointLt },
 				// This month"s highs and lows - dates
@@ -5891,6 +5960,7 @@ namespace CumulusMX
 				{ "MonthWindHD", TagMonthWindHd },
 				{ "MonthRainRateHD", TagMonthRainRateHd },
 				{ "MonthHourlyRainHD", TagMonthHourlyRainHd },
+				{ "MonthRain24HourHD", TagMonthRain24HourHd },
 				{ "MonthDailyRainHD", TagMonthDailyRainHd },
 				{ "MonthDewPointHD", TagMonthDewPointHd },
 				{ "MonthDewPointLD", TagMonthDewPointLd },
@@ -5919,6 +5989,7 @@ namespace CumulusMX
 				{ "YearWindH", TagYearWindH },
 				{ "YearRainRateH", TagYearRainRateH },
 				{ "YearHourlyRainH", TagYearHourlyRainH },
+				{ "YearRain24HourH", TagYearRain24HourH },
 				{ "YearDailyRainH", TagYearDailyRainH },
 				{ "YearMonthlyRainH", TagYearMonthlyRainH },
 				{ "YearDewPointH", TagYearDewPointH },
@@ -5946,6 +6017,7 @@ namespace CumulusMX
 				{ "YearWindHT", TagYearWindHt },
 				{ "YearRainRateHT", TagYearRainRateHt },
 				{ "YearHourlyRainHT", TagYearHourlyRainHt },
+				{ "YearRain24HourHT", TagYearRain24HourHt },
 				{ "YearDewPointHT", TagYearDewPointHt },
 				{ "YearDewPointLT", TagYearDewPointLt },
 				// Yearly highs and lows - dates
@@ -5968,6 +6040,7 @@ namespace CumulusMX
 				{ "YearWindHD", TagYearWindHd },
 				{ "YearRainRateHD", TagYearRainRateHd },
 				{ "YearHourlyRainHD", TagYearHourlyRainHd },
+				{ "YearRain24HourHD", TagYearRain24HourHd },
 				{ "YearDailyRainHD", TagYearDailyRainHd },
 				{ "YearMonthlyRainHD", TagYearMonthlyRainHd },
 				{ "YearDewPointHD", TagYearDewPointHd },
@@ -6056,6 +6129,7 @@ namespace CumulusMX
 				{ "ByMonthRainRateH", TagByMonthRainRateH },
 				{ "ByMonthDailyRainH", TagByMonthDailyRainH },
 				{ "ByMonthHourlyRainH", TagByMonthHourlyRainH },
+				{ "ByMonthRain24HourH", TagByMonthRain24HourH },
 				{ "ByMonthMonthlyRainH", TagByMonthMonthlyRainH },
 				{ "ByMonthPressH", TagByMonthPressH },
 				{ "ByMonthPressL", TagByMonthPressL },
@@ -6087,6 +6161,7 @@ namespace CumulusMX
 				{ "ByMonthDailyRainHT", TagByMonthDailyRainHt },
 				{ "ByMonthHourlyRainHT", TagByMonthHourlyRainHt },
 				{ "ByMonthMonthlyRainHT", TagByMonthMonthlyRainHt },
+				{ "ByMonthRain24HourHT", TagByMonthRain24HourHt },
 				{ "ByMonthPressHT", TagByMonthPressHt },
 				{ "ByMonthPressLT", TagByMonthPressLt },
 				{ "ByMonthHumHT", TagByMonthHumHt },

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,5 +1,19 @@
-3.16.0 - b3174
+3.16.0 - b3178
 ——————————————
+Beta#4
+Change: Ecowitt historic data is now requested in the user units and not converted
+Change: Ecowitt Local API - piezo rain is now read every 30 secs using the new Read_Rain command
+
+Beta#3
+Fix: Ecowitt using extra T/H sensor was not converting F -> user units during catch-up
+Fix: Ecowitt catch-up not processing rain data - and nobody has noticed!
+New: Ecowitt rain sensor is now selectable between tipping bucket and piezo sensors - both Local API and HTTP Ecowitt protocols
+
+Beta#2
+Fix: GW1000 station crash on start-up
+New: Adds ability for CMX to configure Ecowitt custom server when using it for Extra Sensors
+======
+
 - Fix: CPU temp check on Linux?
 - Fix: Start-up PING is now run in a separate thread so if it hangs CMX can continue
 - Fix: Ecowitt Local API station not performing a battery check every 20 minutes

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,11 +1,12 @@
-3.15.4 - b3174
+3.16.0 - b3174
 ——————————————
 - Fix: CPU temp check on Linux?
 - Fix: Start-up PING is now run in a separate thread so if it hangs CMX can continue
 - Fix: Ecowitt Local API station not performing a battery check every 20 minutes
 - Fix: Longest dry/wet web tags from outputting -9999 values, if uninitialised they now output "--"
 
-- New: Ecowitt stations, adds the ability to over-ride the default outdoor temp/humidity values by specifying and extra T/H sensor channel
+- New: HTTP Ecowitt stations, Cumulus MX will now configure the custom server config for you - optional
+- New: Ecowitt stations (Local API and HHTP), adds the ability to over-ride the default outdoor temp/humidity values by specifying and extra T/H sensor channel
 - New: Adds last 24 hours rain to the dashboard "Now" page
 - New: Adds records for 24 hour rainfall - This Month, This Year, Monthly, and All Time
 	- New web tags:

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,7 +6,7 @@
 - Fix: Longest dry/wet web tags from outputting -9999 values, if uninitialised they now output "--"
 
 - New: HTTP Ecowitt stations, Cumulus MX will now configure the custom server config for you - optional
-- New: Ecowitt stations (Local API and HHTP), adds the ability to over-ride the default outdoor temp/humidity values by specifying and extra T/H sensor channel
+- New: Ecowitt stations (Local API and HTTP), adds the ability to override the default outdoor temp/humidity values by specifying and extra T/H sensor channel
 - New: Adds last 24 hours rain to the dashboard "Now" page
 - New: Adds records for 24 hour rainfall - This Month, This Year, Monthly, and All Time
 	- New web tags:

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,43 +1,17 @@
 3.16.0 - b3182
 ——————————————
-Beta 3182
-Change: Fix mislabelled July solar transmission factors to June
-
-Beta 3181
-Fix: Web tags <#chillhoursToday>, <#chillhoursYest> when chill hours not increasing
-Fix: Live piezo rain data decode
-
-Beta 3180
-Fix: Alarm settings could not be saved unless a valid from-email address was entered. Now it is only mandatory if an alert has the email option checked
-Fix: WS90 piezo rain extraction from local api response
-Fix: Ecowitt historic catchup broken in 3179 for users using pressure units of mb or inHg
-
-Changes: internal changes to improve CMX start-up and shutdown
-
-Beta 3179
-New: Ecowitt WN34 sensors can now be mapped from User temp to Soil Temp
-Fix: Ecowitt piezo rain packet decode - basically nothing like it is documented!
-Fix: Ecowitt historic data pressure was not being requested in "user" units correctly (broken in 3178 change)
-
-Beta 3178
-Change: Ecowitt historic data is now requested in the user units and not converted
-Change: Ecowitt Local API - piezo rain is now read every 30 secs using the new Read_Rain command
-
-Beta 3177
-Fix: Ecowitt using extra T/H sensor was not converting F -> user units during catch-up
-Fix: Ecowitt catch-up not processing rain data - and nobody has noticed!
-New: Ecowitt rain sensor is now selectable between tipping bucket and piezo sensors - both Local API and HTTP Ecowitt protocols
-
-Beta 3176
-Fix: GW1000 station crash on start-up
-New: Adds ability for CMX to configure Ecowitt custom server when using it for Extra Sensors
-======
-
+- Fix: Fix mislabelled July solar transmission factors to June
+- Fix: Web tags <#chillhoursToday>, <#chillhoursYest> when chill hours not increasing
+- Fix: Alarm settings could not be saved unless a valid from-email address was entered. Now it is only mandatory if an alert has the email option checked
+- Fix: Ecowitt catch-up not processing rain data - and nobody has noticed!
 - Fix: CPU temp check on Linux?
 - Fix: Start-up PING is now run in a separate thread so if it hangs CMX can continue
 - Fix: Ecowitt Local API station not performing a battery check every 20 minutes
 - Fix: Longest dry/wet web tags from outputting -9999 values, if uninitialised they now output "--"
 
+- New: Ecowitt WN34 sensors can now be mapped from User temp to Soil Temp
+- New: Ecowitt rain sensor is now selectable between tipping bucket and piezo sensors - both Local API and HTTP Ecowitt protocols
+- New: Adds ability for CMX to configure Ecowitt custom server when using it for Extra Sensors
 - New: HTTP Ecowitt stations, Cumulus MX will now configure the custom server config for you - optional
 - New: Ecowitt stations (Local API and HTTP), adds the ability to override the default outdoor temp/humidity values by specifying and extra T/H sensor channel
 - New: Adds last 24 hours rain to the dashboard "Now" page
@@ -54,6 +28,7 @@ New: Adds ability for CMX to configure Ecowitt custom server when using it for E
 	- Note: It is not currently possible to edit these records via the built-in records editor
 
 - Change: You can now use comment lines within sections in .ini files that start with a # character
+
 
 
 3.15.3 - b3173

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,15 +1,34 @@
-3.16.0 - b3178
+3.16.0 - b3182
 ——————————————
-Beta#4
+Beta 3182
+Change: Fix mislabelled July solar transmission factors to June
+
+Beta 3181
+Fix: Web tags <#chillhoursToday>, <#chillhoursYest> when chill hours not increasing
+Fix: Live piezo rain data decode
+
+Beta 3180
+Fix: Alarm settings could not be saved unless a valid from-email address was entered. Now it is only mandatory if an alert has the email option checked
+Fix: WS90 piezo rain extraction from local api response
+Fix: Ecowitt historic catchup broken in 3179 for users using pressure units of mb or inHg
+
+Changes: internal changes to improve CMX start-up and shutdown
+
+Beta 3179
+New: Ecowitt WN34 sensors can now be mapped from User temp to Soil Temp
+Fix: Ecowitt piezo rain packet decode - basically nothing like it is documented!
+Fix: Ecowitt historic data pressure was not being requested in "user" units correctly (broken in 3178 change)
+
+Beta 3178
 Change: Ecowitt historic data is now requested in the user units and not converted
 Change: Ecowitt Local API - piezo rain is now read every 30 secs using the new Read_Rain command
 
-Beta#3
+Beta 3177
 Fix: Ecowitt using extra T/H sensor was not converting F -> user units during catch-up
 Fix: Ecowitt catch-up not processing rain data - and nobody has noticed!
 New: Ecowitt rain sensor is now selectable between tipping bucket and piezo sensors - both Local API and HTTP Ecowitt protocols
 
-Beta#2
+Beta 3176
 Fix: GW1000 station crash on start-up
 New: Adds ability for CMX to configure Ecowitt custom server when using it for Extra Sensors
 ======

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,27 @@
+3.15.4 - b3174
+——————————————
+- Fix: CPU temp check on Linux?
+- Fix: Start-up PING is now run in a separate thread so if it hangs CMX can continue
+- Fix: Ecowitt Local API station not performing a battery check every 20 minutes
+- Fix: Longest dry/wet web tags from outputting -9999 values, if uninitialised they now output "--"
+
+- New: Ecowitt stations, adds the ability to over-ride the default outdoor temp/humidity values by specifying and extra T/H sensor channel
+- New: Adds last 24 hours rain to the dashboard "Now" page
+- New: Adds records for 24 hour rainfall - This Month, This Year, Monthly, and All Time
+	- New web tags:
+		<#HighRain24HourRecordSet>
+		<#ByMonthRain24HourH>, <#ByMonthRain24HourHT>
+		<#MonthRain24HourH>, <#MonthRain24HourHT>, <#MonthRain24HourHD>
+		<#YearRain24HourH>, <#YearRain24HourHT>, <#YearRain24HourHD>
+		<#r24hourH>, <#Tr24hourH>
+	- Existing web tags updated:
+		<#newrecord>
+		<#RainRecordSet>
+	- Note: It is not currently possible to edit these records via the built-in records editor
+
+- Change: You can now use comment lines within sections in .ini files that start with a # character
+
+
 3.15.3 - b3173
 ——————————————
 - Fix: Broken start-up ping in 3.15.2 - doh!


### PR DESCRIPTION
- Fix: Fix mislabelled July solar transmission factors to June
- Fix: Web tags <#chillhoursToday>, <#chillhoursYest> when chill hours not increasing
- Fix: Alarm settings could not be saved unless a valid from-email address was entered. Now it is only mandatory if an alert has the email option checked
- Fix: Ecowitt catch-up not processing rain data - and nobody has noticed!
- Fix: CPU temp check on Linux?
- Fix: Start-up PING is now run in a separate thread so if it hangs CMX can continue
- Fix: Ecowitt Local API station not performing a battery check every 20 minutes
- Fix: Longest dry/wet web tags from outputting -9999 values, if uninitialised they now output "--"

- New: Ecowitt WN34 sensors can now be mapped from User temp to Soil Temp
- New: Ecowitt rain sensor is now selectable between tipping bucket and piezo sensors - both Local API and HTTP Ecowitt protocols
- New: Adds ability for CMX to configure Ecowitt custom server when using it for Extra Sensors
- New: HTTP Ecowitt stations, Cumulus MX will now configure the custom server config for you - optional
- New: Ecowitt stations (Local API and HTTP), adds the ability to override the default outdoor temp/humidity values by specifying an extra T/H sensor channel
- New: Adds last 24 hours rain to the dashboard "Now" page
- New: Adds records for 24 hour rainfall - This Month, This Year, Monthly, and All Time
	- New web tags:
		<#HighRain24HourRecordSet>
		<#ByMonthRain24HourH>, <#ByMonthRain24HourHT>
		<#MonthRain24HourH>, <#MonthRain24HourHT>, <#MonthRain24HourHD>
		<#YearRain24HourH>, <#YearRain24HourHT>, <#YearRain24HourHD>
		<#r24hourH>, <#Tr24hourH>
	- Existing web tags updated:
		<#newrecord>
		<#RainRecordSet>
	- Note: It is not currently possible to edit these records via the built-in records editor

- Change: You can now use comment lines within sections in .ini files that start with a # character