### PR TITLE
v3.16.1

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -733,9 +733,23 @@ namespace CumulusMX
 
 		public string[] StationDesc =
 		{
-			"Davis Vantage Pro", "Davis Vantage Pro2", "Oregon Scientific WMR-928", "Oregon Scientific WM-918", "EasyWeather", "Fine Offset",
-			"LaCrosse WS2300", "Fine Offset with Solar", "Oregon Scientific WMR100", "Oregon Scientific WMR200", "Instromet", "Davis WLL", "GW1000",
-			"HTTP WUnderground", "HTTP Ecowitt", "HTTP Ambient", "WeatherFlow Tempest"
+			"Davis Vantage Pro",			// 0
+			"Davis Vantage Pro2",			// 1
+			"Oregon Scientific WMR-928",	// 2
+			"Oregon Scientific WM-918",		// 3
+			"EasyWeather",					// 4
+			"Fine Offset",					// 5
+			"LaCrosse WS2300",				// 6
+			"Fine Offset with Solar",		// 7
+			"Oregon Scientific WMR100",		// 8
+			"Oregon Scientific WMR200",		// 9
+			"Instromet",					// 10
+			"Davis WLL",					// 11
+			"GW1000",						// 12
+			"HTTP WUnderground",			// 13
+			"HTTP Ecowitt",					// 14
+			"HTTP Ambient",					// 15
+			"WeatherFlow Tempest"			// 16
 		};
 
 		public string[] APRSstationtype = { "DsVP", "DsVP", "WMR928", "WM918", "EW", "FO", "WS2300", "FOs", "WMR100", "WMR200", "IMET", "DsVP", "Ecow", "Unkn", "Ecow", "Ambt", "Tmpt" };

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -243,12 +243,14 @@ namespace CumulusMX
 									else
 									{
 										// There was no data returned.
+										cumulus.LastUpdateTime = endTime;
 										return false;
 									}
 								}
 								catch (Exception ex)
 								{
 									cumulus.LogMessage("API.GetHistoricData: Error decoding the response - " + ex.Message);
+									cumulus.LastUpdateTime = endTime;
 									return false;
 								}
 							}
@@ -258,10 +260,11 @@ namespace CumulusMX
 
 								// have we reached the retry limit?
 								if (--retries <= 0)
-									return false;
+									cumulus.LastUpdateTime = endTime;
+								return false;
 
-								cumulus.LogMessage("API.GetHistoricData: System Busy or Rate Limited, waiting before retry...");
-								System.Threading.Thread.Sleep(1500);
+								cumulus.LogMessage("API.GetHistoricData: System Busy or Rate Limited, waiting 5 secs before retry...");
+								System.Threading.Thread.Sleep(5000);
 							}
 							else
 							{
@@ -270,6 +273,7 @@ namespace CumulusMX
 						}
 						else
 						{
+							cumulus.LastUpdateTime = endTime;
 							return false;
 						}
 
@@ -1183,9 +1187,11 @@ namespace CumulusMX
 
 				// add in archive period worth of sunshine, if sunny
 				if (station.SolarRad > station.CurrentSolarMax * cumulus.SolarOptions.SunThreshold / 100 &&
-					station.SolarRad >= cumulus.SolarOptions.SolarMinimum)
+					station.SolarRad >= cumulus.SolarOptions.SolarMinimum &&
+					!cumulus.SolarOptions.UseBlakeLarsen)
+				{
 					station.SunshineHours += 5 / 60.0;
-
+				}
 
 
 				// add in 'following interval' minutes worth of wind speed to windrun
@@ -1739,6 +1745,7 @@ namespace CumulusMX
 		{
 			public EcowittHistoricDataTypeInt soilmoisture { get; set; }
 		}
+		
 		internal class EcowittHistoricDataTemp
 		{
 			public EcowittHistoricDataTypeDbl temperature { get; set; }

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -278,11 +278,11 @@ namespace CumulusMX
 						// 24hourrainin
 						// weeklyrainin
 						// monthlyrainin
-						// yearlyrainin
+						// yearlyrainin - missing on some stations, they supply totalrainin 
 						// eventrainin
-						// totalrainin ??? MISSING ???
+						// totalrainin - only some stations
 
-						var rain = data["yearlyrainin"];
+						var rain = data["yearlyrainin"] ?? data["totalrainin"];
 						//var rRate = data["hourlyrainin"]; // no rain rate, have to use the hourly rain
 
 						if (rain == null)

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -66,6 +66,16 @@ namespace CumulusMX
 					cumulus.LogMessage("Overriding the default outdoor temp/hum data with Extra temp/hum sensor #" + cumulus.Gw1000PrimaryTHSensor);
 				}
 
+				if (cumulus.Gw1000PrimaryRainSensor == 0)
+				{
+					// We are using the traditional rain tipper
+					cumulus.LogMessage("Using the default traditional rain sensor data");
+				}
+				else
+				{
+					cumulus.LogMessage("Using the piezo rain sensor data");
+				}
+
 				if (cumulus.EcowittSetCustomServer)
 				{
 					cumulus.LogMessage("Checking Ecowitt Gateway Custom Server configuration...");

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.16.0 - Build 3182 - BETA")]
+[assembly: AssemblyDescription("Version 3.16.1 - Build 3183")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.16.0.3182")]
-[assembly: AssemblyFileVersion("3.16.0.3182")]
+[assembly: AssemblyVersion("3.16.1.3183")]
+[assembly: AssemblyFileVersion("3.16.1.3183")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -991,87 +991,91 @@ namespace CumulusMX
 				// Ecowitt sensor mappings
 				try
 				{
-					cumulus.Gw1000PrimaryTHSensor = settings.ecowittmaps.primaryTHsensor;
-					cumulus.Gw1000PrimaryRainSensor = settings.ecowittmaps.primaryRainSensor;
-
-					if (cumulus.EcowittMapWN34[1] != settings.ecowittmaps.wn34chan1)
+					if (settings.ecowittmaps != null)
 					{
-						if (cumulus.EcowittMapWN34[1] == 0)
-							station.UserTemp[1] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[1]] = 0;
 
-						cumulus.EcowittMapWN34[1] = settings.ecowittmaps.wn34chan1;
-					}
+						cumulus.Gw1000PrimaryTHSensor = settings.ecowittmaps.primaryTHsensor;
+						cumulus.Gw1000PrimaryRainSensor = settings.ecowittmaps.primaryRainSensor;
 
-					if (cumulus.EcowittMapWN34[2] != settings.ecowittmaps.wn34chan2)
-					{
-						if (cumulus.EcowittMapWN34[2] == 0)
-							station.UserTemp[2] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[2]] = 0;
+						if (cumulus.EcowittMapWN34[1] != settings.ecowittmaps.wn34chan1)
+						{
+							if (cumulus.EcowittMapWN34[1] == 0)
+								station.UserTemp[1] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[1]] = 0;
 
-						cumulus.EcowittMapWN34[2] = settings.ecowittmaps.wn34chan2;
-					}
+							cumulus.EcowittMapWN34[1] = settings.ecowittmaps.wn34chan1;
+						}
 
-					if (cumulus.EcowittMapWN34[3] != settings.ecowittmaps.wn34chan3)
-					{
-						if (cumulus.EcowittMapWN34[3] == 0)
-							station.UserTemp[3] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[3]] = 0;
+						if (cumulus.EcowittMapWN34[2] != settings.ecowittmaps.wn34chan2)
+						{
+							if (cumulus.EcowittMapWN34[2] == 0)
+								station.UserTemp[2] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[2]] = 0;
 
-						cumulus.EcowittMapWN34[3] = settings.ecowittmaps.wn34chan3;
-					}
+							cumulus.EcowittMapWN34[2] = settings.ecowittmaps.wn34chan2;
+						}
 
-					if (cumulus.EcowittMapWN34[4] != settings.ecowittmaps.wn34chan4)
-					{
-						if (cumulus.EcowittMapWN34[4] == 0)
-							station.UserTemp[4] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[4]] = 0;
+						if (cumulus.EcowittMapWN34[3] != settings.ecowittmaps.wn34chan3)
+						{
+							if (cumulus.EcowittMapWN34[3] == 0)
+								station.UserTemp[3] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[3]] = 0;
 
-						cumulus.EcowittMapWN34[4] = settings.ecowittmaps.wn34chan4;
-					}
+							cumulus.EcowittMapWN34[3] = settings.ecowittmaps.wn34chan3;
+						}
 
-					if (cumulus.EcowittMapWN34[5] != settings.ecowittmaps.wn34chan5)
-					{
-						if (cumulus.EcowittMapWN34[5] == 0)
-							station.UserTemp[5] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[5]] = 0;
+						if (cumulus.EcowittMapWN34[4] != settings.ecowittmaps.wn34chan4)
+						{
+							if (cumulus.EcowittMapWN34[4] == 0)
+								station.UserTemp[4] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[4]] = 0;
 
-						cumulus.EcowittMapWN34[5] = settings.ecowittmaps.wn34chan5;
-					}
+							cumulus.EcowittMapWN34[4] = settings.ecowittmaps.wn34chan4;
+						}
 
-					if (cumulus.EcowittMapWN34[6] != settings.ecowittmaps.wn34chan6)
-					{
-						if (cumulus.EcowittMapWN34[6] == 0)
-							station.UserTemp[6] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[6]] = 0;
+						if (cumulus.EcowittMapWN34[5] != settings.ecowittmaps.wn34chan5)
+						{
+							if (cumulus.EcowittMapWN34[5] == 0)
+								station.UserTemp[5] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[5]] = 0;
 
-						cumulus.EcowittMapWN34[6] = settings.ecowittmaps.wn34chan6;
-					}
+							cumulus.EcowittMapWN34[5] = settings.ecowittmaps.wn34chan5;
+						}
 
-					if (cumulus.EcowittMapWN34[7] != settings.ecowittmaps.wn34chan7)
-					{
-						if (cumulus.EcowittMapWN34[7] == 0)
-							station.UserTemp[7] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[7]] = 0;
+						if (cumulus.EcowittMapWN34[6] != settings.ecowittmaps.wn34chan6)
+						{
+							if (cumulus.EcowittMapWN34[6] == 0)
+								station.UserTemp[6] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[6]] = 0;
 
-						cumulus.EcowittMapWN34[7] = settings.ecowittmaps.wn34chan7;
-					}
+							cumulus.EcowittMapWN34[6] = settings.ecowittmaps.wn34chan6;
+						}
 
-					if (cumulus.EcowittMapWN34[8] != settings.ecowittmaps.wn34chan8)
-					{
-						if (cumulus.EcowittMapWN34[8] == 0)
-							station.UserTemp[8] = 0;
-						else
-							station.SoilTemp[cumulus.EcowittMapWN34[8]] = 0;
+						if (cumulus.EcowittMapWN34[7] != settings.ecowittmaps.wn34chan7)
+						{
+							if (cumulus.EcowittMapWN34[7] == 0)
+								station.UserTemp[7] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[7]] = 0;
 
-						cumulus.EcowittMapWN34[8] = settings.ecowittmaps.wn34chan8;
+							cumulus.EcowittMapWN34[7] = settings.ecowittmaps.wn34chan7;
+						}
+
+						if (cumulus.EcowittMapWN34[8] != settings.ecowittmaps.wn34chan8)
+						{
+							if (cumulus.EcowittMapWN34[8] == 0)
+								station.UserTemp[8] = 0;
+							else
+								station.SoilTemp[cumulus.EcowittMapWN34[8]] = 0;
+
+							cumulus.EcowittMapWN34[8] = settings.ecowittmaps.wn34chan8;
+						}
 					}
 				}
 				catch (Exception ex)

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -541,6 +541,8 @@ namespace CumulusMX
 				rainthisyear += cumulus.YTDrain;
 				cumulus.LogMessage("Rainthisyear: " + rainthisyear);
 			}
+			RainMonth = rainthismonth;
+			RainYear = rainthisyear;
 		}
 
 		public void ReadTodayFile()

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,14 @@
+3.16.1 - b3183
+——————————————
+- Fix: Error message about Ecowitt sensor mapping when saving the station settings for non-Ecowitt stations
+- Fix: Some Ambient stations are not sending the yearly rainfall total - they send total rain instead
+- Fix: Ecowitt stations with a Blake-Larsen were erroneously adding CMX calculated sunshine during catch-up
+- Fix: Potential issue whereby Ecowitt historic data download could get stuck in a loop downloading the same block
+
+- Change: Ecowitt Local API stations with WS90 sensors now get the update rate set to 8 seconds (previously 4)
+
+
+
 3.16.0 - b3182
 ——————————————
 - Fix: Fix mislabelled July solar transmission factors to June
@@ -26,8 +37,7 @@
 		<#newrecord>
 		<#RainRecordSet>
 	- Note: It is not currently possible to edit these records via the built-in records editor
-
-- Change: You can now use comment lines within sections in .ini files that start with a # character
+- New: You can now use comment lines that start with a # character within sections in .ini files
 
 
 


### PR DESCRIPTION
- Fix: Error message about Ecowitt sensor mapping when saving the station settings for non-Ecowitt stations
- Fix: Some Ambient stations are not sending the yearly rainfall total - they send total rain instead
- Fix: Ecowitt stations with a Blake-Larsen were erroneously adding CMX calculated sunshine during catch-up
- Fix: Potential issue whereby Ecowitt historic data download could get stuck in a loop downloading the same block

- Change: Ecowitt Local API stations with WS90 sensors now get the update rate set to 8 seconds (previously 4)