### PR TITLE
v3.17.0

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -749,10 +749,11 @@ namespace CumulusMX
 			"HTTP WUnderground",			// 13
 			"HTTP Ecowitt",					// 14
 			"HTTP Ambient",					// 15
-			"WeatherFlow Tempest"			// 16
+			"WeatherFlow Tempest",			// 16
+			"Simulator"
 		};
 
-		public string[] APRSstationtype = { "DsVP", "DsVP", "WMR928", "WM918", "EW", "FO", "WS2300", "FOs", "WMR100", "WMR200", "IMET", "DsVP", "Ecow", "Unkn", "Ecow", "Ambt", "Tmpt" };
+		public string[] APRSstationtype = { "DsVP", "DsVP", "WMR928", "WM918", "EW", "FO", "WS2300", "FOs", "WMR100", "WMR200", "IMET", "DsVP", "Ecow", "Unkn", "Ecow", "Ambt", "Tmpt", "Simul" };
 
 		public string loggingfile;
 
@@ -1478,9 +1479,9 @@ namespace CumulusMX
 			}
 			Console.WriteLine();
 
-			LogDebugMessage("Lock: Cumulus waiting for the lock");
+			//LogDebugMessage("Lock: Cumulus waiting for the lock");
 			syncInit.Wait();
-			LogDebugMessage("Lock: Cumulus has lock");
+			//LogDebugMessage("Lock: Cumulus has lock");
 
 			LogMessage("Opening station");
 
@@ -1548,6 +1549,10 @@ namespace CumulusMX
 				case StationTypes.HttpAmbient:
 					Manufacturer = AMBIENT;
 					station = new HttpStationAmbient(this);
+					break;
+				case StationTypes.Simulator:
+					Manufacturer = SIMULATOR;
+					station = new Simulator(this);
 					break;
 				default:
 					LogConsoleMessage("Station type not set", ConsoleColor.Red);
@@ -1652,7 +1657,7 @@ namespace CumulusMX
 					StartTimersAndSensors();
 				}
 
-				if ((StationType == StationTypes.WMR100) || (StationType == StationTypes.EasyWeather) || (Manufacturer == OREGON))
+				if ((StationType == StationTypes.WMR100) || (StationType == StationTypes.EasyWeather) || (Manufacturer == OREGON) || StationType == StationTypes.Simulator)
 				{
 					station.StartLoop();
 				}
@@ -1662,7 +1667,7 @@ namespace CumulusMX
 				station.CreateEodGraphDataFiles();
 			}
 
-			LogDebugMessage("Lock: Cumulus releasing the lock");
+			//LogDebugMessage("Lock: Cumulus releasing the lock");
 			syncInit.Release();
 		}
 
@@ -6638,6 +6643,7 @@ namespace CumulusMX
 		public int HTTPSTATION = 7;
 		public int AMBIENT = 8;
 		public int WEATHERFLOW = 9;
+		public int SIMULATOR = 10;
 
 		//public bool startingup = true;
 		public string ReportPath;
@@ -10577,6 +10583,7 @@ namespace CumulusMX
 		public const int HttpEcowitt = 14;
 		public const int HttpAmbient = 15;
 		public const int Tempest = 16;
+		public const int Simulator = 17;
 	}
 
 	/*

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -10144,6 +10144,10 @@ namespace CumulusMX
 					updatingCustomHttpSeconds = false;
 				}
 			}
+			else
+			{
+				LogDebugMessage("CustomHttpSeconds: Query already in progress, skipping this attempt");
+			}
 		}
 
 		public async void CustomHttpMinutesUpdate()

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -492,8 +492,8 @@ namespace CumulusMX
 		private List<string> OWMList = new List<string>();
 
 		// Use thread safe queues for the MySQL command lists
-		private ConcurrentQueue<string> MySqlList = new ConcurrentQueue<string>();
-		private ConcurrentQueue<string> MySqlFailedList = new ConcurrentQueue<string>();
+		private readonly ConcurrentQueue<string> MySqlList = new ConcurrentQueue<string>();
+		private readonly ConcurrentQueue<string> MySqlFailedList = new ConcurrentQueue<string>();
 
 		// Calibration settings
 		/// <summary>
@@ -757,7 +757,7 @@ namespace CumulusMX
 
 		public string loggingfile;
 
-		private PingReply pingReply;
+		//private PingReply pingReply;
 
 		public Cumulus(int HTTPport, bool DebugEnabled, string startParms)
 		{
@@ -10512,7 +10512,7 @@ namespace CumulusMX
 				LogMessage("Ping reply: " + e.Reply.Status);
 			}
 
-			pingReply = e.Reply;
+			//pingReply = e.Reply;
 		}
 
 		private void CreateRequiredFolders()

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -237,6 +237,7 @@
     <Compile Include="ServiceCumulusInstaller.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Simulator.cs" />
     <Compile Include="SQLite.cs" />
     <Compile Include="ProgramSettings.cs" />
     <Compile Include="StationSettings.cs" />

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -266,7 +266,6 @@
     <None Include="App.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="CumulusMX_TemporaryKey.pfx" />
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />
   </ItemGroup>

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -12,7 +12,7 @@ namespace CumulusMX
 	internal class DataEditor
 	{
 		private WeatherStation station;
-		private Cumulus cumulus;
+		private readonly Cumulus cumulus;
 		private WebTags webtags;
 
 		private readonly List<LastHourRainLog> hourRainLog = new List<LastHourRainLog>();
@@ -1758,7 +1758,7 @@ namespace CumulusMX
 			var isDryNow = false;
 			var thisDateDry = DateTime.MinValue;
 			var thisDateWet = DateTime.MinValue;
-			var monthOffset = 0;
+			int monthOffset;
 			var firstEntry = true;
 
 			var json = new StringBuilder("{", 25500);

--- a/CumulusMX/DavisAirLink.cs
+++ b/CumulusMX/DavisAirLink.cs
@@ -312,9 +312,9 @@ namespace CumulusMX
 
 				var urlCurrent = $"http://{ip}/v1/current_conditions";
 
-				cumulus.LogDebugMessage($"GetAlCurrent: {locationStr} - Waiting for lock");
+				//cumulus.LogDebugMessage($"GetAlCurrent: {locationStr} - Waiting for lock");
 				WebReq.Wait();
-				cumulus.LogDebugMessage($"GetAlCurrent: {locationStr} - Has the lock");
+				//cumulus.LogDebugMessage($"GetAlCurrent: {locationStr} - Has the lock");
 
 				// The AL will error if already responding to a request from another device, so add a retry
 				do
@@ -356,7 +356,7 @@ namespace CumulusMX
 					}
 				} while (retry < 3);
 
-				cumulus.LogDebugMessage($"GetAlCurrent: {locationStr} - Releasing lock");
+				//cumulus.LogDebugMessage($"GetAlCurrent: {locationStr} - Releasing lock");
 				WebReq.Release();
 			}
 			else

--- a/CumulusMX/DavisAirLink.cs
+++ b/CumulusMX/DavisAirLink.cs
@@ -16,10 +16,10 @@ namespace CumulusMX
 {
 	internal class DavisAirLink
 	{
-		private Cumulus cumulus;
-		private WeatherStation station;
+		private readonly Cumulus cumulus;
+		private readonly WeatherStation station;
 
-		private string ipaddr;
+		private readonly string ipaddr;
 		private readonly System.Timers.Timer tmrCurrent;
 		private System.Timers.Timer tmrHealth;
 		private readonly object threadSafer = new object();
@@ -42,7 +42,7 @@ namespace CumulusMX
 		private readonly bool standaloneHistory; // Used to flag if we need to get history data on catch-up
 		private DateTime airLinkLastUpdateTime;
 
-		private DiscoveredDevices discovered = new DiscoveredDevices();
+		private readonly DiscoveredDevices discovered = new DiscoveredDevices();
 
 		public DavisAirLink(Cumulus cumulus, bool indoor, WeatherStation station)
 		{

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -772,24 +772,24 @@ namespace CumulusMX
 
 		private void bw_DoStart(object sender, DoWorkEventArgs e)
 		{
-			cumulus.LogDebugMessage("Lock: Station waiting for lock");
+			//cumulus.LogDebugMessage("Lock: Station waiting for lock");
 			Cumulus.syncInit.Wait();
-			cumulus.LogDebugMessage("Lock: Station has the lock");
+			//cumulus.LogDebugMessage("Lock: Station has the lock");
 
 			// Wait a short while for Cumulus initialisation to complete
 			Thread.Sleep(500);
 			StartLoop();
 
-			cumulus.LogDebugMessage("Lock: Station releasing lock");
+			//cumulus.LogDebugMessage("Lock: Station releasing lock");
 			Cumulus.syncInit.Release();
 		}
 
 		private void bw_DoWork(object sender, DoWorkEventArgs e)
 		{
 			int archiveRun = 0;
-			cumulus.LogDebugMessage("Lock: Station waiting for the lock");
+			//cumulus.LogDebugMessage("Lock: Station waiting for the lock");
 			Cumulus.syncInit.Wait();
-			cumulus.LogDebugMessage("Lock: Station has the lock");
+			//cumulus.LogDebugMessage("Lock: Station has the lock");
 			try
 			{
 				// set this temporarily, so speed is done from average and not peak gust from logger
@@ -805,7 +805,7 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage("Exception occurred reading archive data: "+ex.Message);
 			}
-			cumulus.LogDebugMessage("Lock: Station releasing the lock");
+			//cumulus.LogDebugMessage("Lock: Station releasing the lock");
 			Cumulus.syncInit.Release();
 		}
 

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -1636,6 +1636,7 @@ namespace CumulusMX
 				DoApparentTemp(now);
 				DoFeelsLike(now);
 				DoHumidex(now);
+				DoCloudBaseHeatIndex(now);
 
 				var forecastRule = loopData.ForecastRule < cumulus.DavisForecastLookup.Length ? loopData.ForecastRule : cumulus.DavisForecastLookup.Length - 1;
 
@@ -2507,6 +2508,7 @@ namespace CumulusMX
 							DoApparentTemp(timestamp);
 							DoFeelsLike(timestamp);
 							DoHumidex(timestamp);
+							DoCloudBaseHeatIndex(timestamp);
 
 							// add in 'archivePeriod' minutes worth of wind speed to windrun
 							WindRunToday += ((WindAverage * WindRunHourMult[cumulus.Units.Wind] * interval) / 60.0);

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -243,9 +243,9 @@ namespace CumulusMX
 			try
 			{
 				// Wait for the lock
-				cumulus.LogDebugMessage("Lock: Station waiting for lock");
+				//cumulus.LogDebugMessage("Lock: Station waiting for lock");
 				Cumulus.syncInit.Wait();
-				cumulus.LogDebugMessage("Lock: Station has the lock");
+				//cumulus.LogDebugMessage("Lock: Station has the lock");
 
 				// Create a realtime thread to periodically restart broadcasts
 				GetWllRealtime(null, null);
@@ -352,7 +352,7 @@ namespace CumulusMX
 			}
 			finally
 			{
-				cumulus.LogDebugMessage("Lock: Station releasing lock");
+				//cumulus.LogDebugMessage("Lock: Station releasing lock");
 				Cumulus.syncInit.Release();
 			}
 		}
@@ -402,9 +402,9 @@ namespace CumulusMX
 		{
 			var retry = 2;
 
-			cumulus.LogDebugMessage("GetWllRealtime: GetWllRealtime waiting for lock");
+			//cumulus.LogDebugMessage("GetWllRealtime: GetWllRealtime waiting for lock");
 			WebReq.Wait();
-			cumulus.LogDebugMessage("GetWllRealtime: GetWllRealtime has the lock");
+			//cumulus.LogDebugMessage("GetWllRealtime: GetWllRealtime has the lock");
 
 			// The WLL will error if already responding to a request from another device, so add a retry
 			do
@@ -465,7 +465,7 @@ namespace CumulusMX
 				}
 			} while (retry > 0);
 
-			cumulus.LogDebugMessage("GetWllRealtime: Releasing lock");
+			//cumulus.LogDebugMessage("GetWllRealtime: Releasing lock");
 			WebReq.Release();
 		}
 
@@ -486,9 +486,9 @@ namespace CumulusMX
 				// wait a random time of 0 to 5 seconds before making the request to try and avoid continued clashes with other software or instances of MX
 				await Task.Delay(random.Next(0, 5000));
 
-				cumulus.LogDebugMessage("GetWllCurrent: Waiting for lock");
+				//cumulus.LogDebugMessage("GetWllCurrent: Waiting for lock");
 				WebReq.Wait();
-				cumulus.LogDebugMessage("GetWllCurrent: Has the lock");
+				//cumulus.LogDebugMessage("GetWllCurrent: Has the lock");
 
 				// The WLL will error if already responding to a request from another device, so add a retry
 				do
@@ -524,7 +524,7 @@ namespace CumulusMX
 					}
 				} while (retry < 3);
 
-				cumulus.LogDebugMessage("GetWllCurrent: Releasing lock");
+				//cumulus.LogDebugMessage("GetWllCurrent: Releasing lock");
 				WebReq.Release();
 			}
 			else
@@ -814,12 +814,12 @@ namespace CumulusMX
 
 									// pesky null values from WLL when it is calm
 									int wdir = data1.wind_dir_last.HasValue ? data1.wind_dir_last.Value : 0;
-									double wind = data1.wind_speed_last.HasValue ? data1.wind_speed_last.Value : 0;
+									double wind = ConvertWindMPHToUser(data1.wind_speed_last ?? 0);
 									double wspdAvg10min = ConvertWindMPHToUser(data1.wind_speed_avg_last_10_min ?? 0);
 
-									DoWind(ConvertWindMPHToUser(wind), wdir, wspdAvg10min, dateTime);
+									DoWind(wind, wdir, wspdAvg10min, dateTime);
 
-									WindAverage = wspdAvg10min * cumulus.Calib.WindSpeed.Mult;
+									//WindAverage = wspdAvg10min * cumulus.Calib.WindSpeed.Mult;
 
 									// Wind data can be a bit out of date compared to the broadcasts (1 minute update), so only use gust broadcast data
 									/*
@@ -1245,11 +1245,6 @@ namespace CumulusMX
 							cumulus.LogDebugMessage($"WLL current: found an unknown transmitter type [{type}]!");
 							break;
 					}
-
-					DoForecast(string.Empty, false);
-
-					UpdateStatusPanel(DateTime.Now);
-					UpdateMQTT();
 				}
 
 				// Now we have the primary data, calculate the derived data
@@ -1270,6 +1265,11 @@ namespace CumulusMX
 				DoApparentTemp(dateTime);
 				DoFeelsLike(dateTime);
 				DoHumidex(dateTime);
+
+				DoForecast(string.Empty, false);
+
+				UpdateStatusPanel(DateTime.Now);
+				UpdateMQTT();
 
 				SensorContactLost = localSensorContactLost;
 
@@ -1442,15 +1442,15 @@ namespace CumulusMX
 		/*
 		private void bw_DoStart(object sender, DoWorkEventArgs e)
 		{
-			cumulus.LogDebugMessage("Lock: Station waiting for lock");
+			//cumulus.LogDebugMessage("Lock: Station waiting for lock");
 			Cumulus.syncInit.Wait();
-			cumulus.LogDebugMessage("Lock: Station has the lock");
+			//cumulus.LogDebugMessage("Lock: Station has the lock");
 
 			// Wait a short while for Cumulus initialisation to complete
 			Thread.Sleep(500);
 			StartLoop();
 
-			cumulus.LogDebugMessage("Lock: Station releasing lock");
+			//cumulus.LogDebugMessage("Lock: Station releasing lock");
 			Cumulus.syncInit.Release();
 		}
 		*/
@@ -1460,9 +1460,9 @@ namespace CumulusMX
 			BackgroundWorker worker = sender as BackgroundWorker;
 
 			int archiveRun = 0;
-			cumulus.LogDebugMessage("Lock: Station waiting for the lock");
+			//cumulus.LogDebugMessage("Lock: Station waiting for the lock");
 			Cumulus.syncInit.Wait();
-			cumulus.LogDebugMessage("Lock: Station has the lock");
+			//cumulus.LogDebugMessage("Lock: Station has the lock");
 
 			try
 			{
@@ -1495,7 +1495,8 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage("Exception occurred reading archive data: " + ex.Message);
 			}
-			cumulus.LogDebugMessage("Lock: Station releasing the lock");
+
+			//cumulus.LogDebugMessage("Lock: Station releasing the lock");
 			Cumulus.syncInit.Release();
 			bwDoneEvent.Set();
 		}

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -40,10 +40,10 @@ namespace CumulusMX
 		private bool broadcastReceived;
 		private int weatherLinkArchiveInterval = 16 * 60; // Used to get historic Health, 16 minutes in seconds only for initial fetch after load
 		private bool wllVoltageLow;
-		private CancellationTokenSource tokenSource = new CancellationTokenSource();
+		private readonly CancellationTokenSource tokenSource = new CancellationTokenSource();
 		private CancellationToken cancellationToken;
 		private Task broadcastTask;
-		private AutoResetEvent bwDoneEvent = new AutoResetEvent(false);
+		private readonly AutoResetEvent bwDoneEvent = new AutoResetEvent(false);
 		private readonly List<WlSensor> sensorList = new List<WlSensor>();
 		private readonly bool useWeatherLinkDotCom = true;
 
@@ -733,7 +733,7 @@ namespace CumulusMX
 										DoOutdoorTemp(ConvertTempFToUser(data1.temp.Value), dateTime);
 
 									if (data1.dew_point.HasValue)
-									DoOutdoorDewpoint(ConvertTempFToUser(data1.dew_point.Value), dateTime);
+										DoOutdoorDewpoint(ConvertTempFToUser(data1.dew_point.Value), dateTime);
 
 									if (!cumulus.StationOptions.CalculatedWC && data1.wind_chill.HasValue)
 									{
@@ -1265,6 +1265,7 @@ namespace CumulusMX
 				DoApparentTemp(dateTime);
 				DoFeelsLike(dateTime);
 				DoHumidex(dateTime);
+				DoCloudBaseHeatIndex(dateTime);
 
 				DoForecast(string.Empty, false);
 
@@ -1814,6 +1815,7 @@ namespace CumulusMX
 					DoApparentTemp(timestamp);
 					DoFeelsLike(timestamp);
 					DoHumidex(timestamp);
+					DoCloudBaseHeatIndex(timestamp);
 
 					// Log all the data
 					cumulus.DoLogFile(timestamp, false);

--- a/CumulusMX/EasyWeather.cs
+++ b/CumulusMX/EasyWeather.cs
@@ -161,6 +161,7 @@ namespace CumulusMX
 					DoApparentTemp(now);
 					DoFeelsLike(now);
 					DoHumidex(now);
+					DoCloudBaseHeatIndex(now);
 
 					DoForecast(string.Empty, false);
 

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -1249,6 +1249,9 @@ namespace CumulusMX
 		private void ApplyHistoricData(KeyValuePair<DateTime, EcowittApi.HistoricData> rec)
 		{
 			// === Wind ==
+			// WindGust = max for period
+			// WindSpd = avg for period
+			// WindDir = avg for period
 			try
 			{
 				if (rec.Value.WindGust.HasValue && rec.Value.WindSpd.HasValue && rec.Value.WindDir.HasValue)
@@ -1267,6 +1270,7 @@ namespace CumulusMX
 			}
 
 			// === Humidity ===
+			// = avg for period
 			try
 			{
 				if (rec.Value.IndoorHum.HasValue)
@@ -1285,6 +1289,7 @@ namespace CumulusMX
 			}
 
 			// === Pressure ===
+			// = avg for period
 			try
 			{
 				if (rec.Value.Pressure.HasValue)
@@ -1300,6 +1305,7 @@ namespace CumulusMX
 			}
 
 			// === Indoor temp ===
+			// = avg for period
 			try
 			{
 				if (rec.Value.IndoorTemp.HasValue)
@@ -1314,6 +1320,7 @@ namespace CumulusMX
 			}
 
 			// === Outdoor temp ===
+			// = avg for period
 			try
 			{
 				if (rec.Value.Temp.HasValue && cumulus.Gw1000PrimaryTHSensor == 0)
@@ -1356,6 +1363,7 @@ namespace CumulusMX
 			}
 
 			// === Solar ===
+			// = max for period
 			try
 			{
 				if (rec.Value.Solar.HasValue)
@@ -1369,6 +1377,7 @@ namespace CumulusMX
 			}
 
 			// === UVI ===
+			// = max for period
 			try
 			{
 				if (rec.Value.UVI.HasValue)

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -415,6 +415,7 @@ namespace CumulusMX
 							}
 						}
 					}
+					
 					// Dewpoint
 					if (data.outdoor.dew_point != null && data.outdoor.dew_point.list != null)
 					{
@@ -493,6 +494,7 @@ namespace CumulusMX
 							}
 						}
 					}
+					
 					// Direction
 					if (data.wind.wind_direction != null && data.wind.wind_direction.list != null)
 					{
@@ -688,6 +690,7 @@ namespace CumulusMX
 							}
 						}
 					}
+					
 					// uvi
 					if (data.solar_and_uvi.uvi != null && data.solar_and_uvi.uvi.list != null)
 					{
@@ -802,6 +805,7 @@ namespace CumulusMX
 								}
 							}
 						}
+						
 						// humidity
 						if (srcTH.humidity != null && srcTH.humidity.list != null)
 						{
@@ -949,6 +953,7 @@ namespace CumulusMX
 							}
 						}
 					}
+					
 					// 24 Avg
 					if (data.indoor_co2.average24h != null && data.indoor_co2.average24h.list != null)
 					{
@@ -1004,6 +1009,7 @@ namespace CumulusMX
 							}
 						}
 					}
+					
 					// 24 Avg
 					if (data.co2_aqi_combo.average24h != null && data.co2_aqi_combo.average24h.list != null)
 					{
@@ -1186,11 +1192,13 @@ namespace CumulusMX
 				ApplyHistoricData(rec);
 
 				// add in archive period worth of sunshine, if sunny
-				if (station.SolarRad > station.CurrentSolarMax * cumulus.SolarOptions.SunThreshold / 100 &&
+				if (station.CurrentSolarMax > 0 &&
+					station.SolarRad > station.CurrentSolarMax * cumulus.SolarOptions.SunThreshold / 100 &&
 					station.SolarRad >= cumulus.SolarOptions.SolarMinimum &&
 					!cumulus.SolarOptions.UseBlakeLarsen)
 				{
 					station.SunshineHours += 5 / 60.0;
+					cumulus.LogDebugMessage("Adding 5 minutes to Sunshine Hours");
 				}
 
 

--- a/CumulusMX/EmailSender.cs
+++ b/CumulusMX/EmailSender.cs
@@ -27,9 +27,9 @@ namespace CumulusMX
 		{
 			try
 			{
-				cumulus.LogDebugMessage($"SendEmail: Waiting for lock...");
+				//cumulus.LogDebugMessage($"SendEmail: Waiting for lock...");
 				await _writeLock.WaitAsync();
-				cumulus.LogDebugMessage($"SendEmail: Has the lock");
+				//cumulus.LogDebugMessage($"SendEmail: Has the lock");
 
 				var logMessage = ToLiteral(message);
 
@@ -80,7 +80,7 @@ namespace CumulusMX
 			}
 			finally
 			{
-				cumulus.LogDebugMessage($"SendEmail: Releasing lock...");
+				//cumulus.LogDebugMessage($"SendEmail: Releasing lock...");
 				_writeLock.Release();
 			}
 		}
@@ -91,9 +91,9 @@ namespace CumulusMX
 
 			try
 			{
-				cumulus.LogDebugMessage($"SendEmail: Waiting for lock...");
+				//cumulus.LogDebugMessage($"SendEmail: Waiting for lock...");
 				_writeLock.Wait();
-				cumulus.LogDebugMessage($"SendEmail: Has the lock");
+				//cumulus.LogDebugMessage($"SendEmail: Has the lock");
 
 				cumulus.LogDebugMessage($"SendEmail: Sending Test email, to [{string.Join("; ", to)}], subject [{subject}], body [{message}]...");
 
@@ -145,7 +145,7 @@ namespace CumulusMX
 			}
 			finally
 			{
-				cumulus.LogDebugMessage($"SendEmail: Releasing lock...");
+				//cumulus.LogDebugMessage($"SendEmail: Releasing lock...");
 				_writeLock.Release();
 			}
 

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -161,9 +161,9 @@ namespace CumulusMX
 		{
 			//var ci = new CultureInfo("en-GB");
 			//System.Threading.Thread.CurrentThread.CurrentCulture = ci;
-			cumulus.LogDebugMessage("Lock: Station waiting for the lock");
+			//cumulus.LogDebugMessage("Lock: Station waiting for the lock");
 			Cumulus.syncInit.Wait();
-			cumulus.LogDebugMessage("Lock: Station has the lock");
+			//cumulus.LogDebugMessage("Lock: Station has the lock");
 			try
 			{
 				getAndProcessHistoryData();
@@ -172,7 +172,7 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage("Exception occurred reading archive data: " + ex.Message);
 			}
-			cumulus.LogDebugMessage("Lock: Station releasing the lock");
+			//cumulus.LogDebugMessage("Lock: Station releasing the lock");
 			Cumulus.syncInit.Release();
 		}
 

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -526,6 +526,7 @@ namespace CumulusMX
 					DoApparentTemp(timestamp);
 					DoFeelsLike(timestamp);
 					DoHumidex(timestamp);
+					DoCloudBaseHeatIndex(timestamp);
 
 					if (hasSolar)
 					{
@@ -1007,10 +1008,8 @@ namespace CumulusMX
 						StationPressure = ConvertPressMBToUser(pressure);
 
 						UpdatePressureTrendString();
-						UpdateStatusPanel(now);
-						UpdateMQTT();
-						DoForecast(string.Empty, false);
 					}
+
 					var status = data[15];
 					if ((status & 0x40) != 0)
 					{
@@ -1098,6 +1097,7 @@ namespace CumulusMX
 							DoApparentTemp(now);
 							DoFeelsLike(now);
 							DoHumidex(now);
+							DoCloudBaseHeatIndex(now);
 						}
 
 						// Rain ============================================================
@@ -1163,6 +1163,10 @@ namespace CumulusMX
 								DoUV(UVreading, now);
 							}
 						}
+
+						UpdateStatusPanel(now);
+						UpdateMQTT();
+						DoForecast(string.Empty, false);
 					}
 					if (cumulus.SensorAlarm.Enabled)
 					{

--- a/CumulusMX/GW1000Api.cs
+++ b/CumulusMX/GW1000Api.cs
@@ -11,7 +11,7 @@ namespace CumulusMX
 {
 	internal class GW1000Api
 	{
-		private Cumulus cumulus;
+		private readonly Cumulus cumulus;
 		private NetworkStream stream;
 		private TcpClient socket;
 		private string ipAddress = null;
@@ -129,8 +129,6 @@ namespace CumulusMX
 			var buffer = new byte[2028];
 			var bytesRead = 0;
 			var cmdName = command.ToString();
-
-			var readBuffer = new byte[2028];
 
 			byte[] bytes;
 			if (data == null)

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -54,6 +54,10 @@ namespace CumulusMX
 			// GW1000 does not provide 10 min average wind speeds
 			cumulus.StationOptions.UseWind10MinAvg = true;
 
+			// GW1000 does not provide an interval gust value, it gives us a 30 second high
+			// so force using the wind speed for the average calculation
+			cumulus.StationOptions.UseSpeedForAvgCalc = true;
+
 			LightningTime = DateTime.MinValue;
 			LightningDistance = 999;
 
@@ -249,9 +253,9 @@ namespace CumulusMX
 
 		public override void getAndProcessHistoryData()
 		{
-			cumulus.LogDebugMessage("Lock: Station waiting for the lock");
+			//cumulus.LogDebugMessage("Lock: Station waiting for the lock");
 			Cumulus.syncInit.Wait();
-			cumulus.LogDebugMessage("Lock: Station has the lock");
+			//cumulus.LogDebugMessage("Lock: Station has the lock");
 
 			if (string.IsNullOrEmpty(cumulus.EcowittApplicationKey) || string.IsNullOrEmpty(cumulus.EcowittUserApiKey) || string.IsNullOrEmpty(cumulus.EcowittMacAddress))
 			{
@@ -279,7 +283,7 @@ namespace CumulusMX
 				}
 			}
 
-			cumulus.LogDebugMessage("Lock: Station releasing the lock");
+			//cumulus.LogDebugMessage("Lock: Station releasing the lock");
 			_ = Cumulus.syncInit.Release();
 
 			if (cancellationToken.IsCancellationRequested)
@@ -1173,8 +1177,9 @@ namespace CumulusMX
 
 					if (gustLast > -999 && windSpeedLast > -999 && windDirLast > -999)
 					{
-						//DoWind(gustLast, windDirLast, windSpeedLast, dateTime);
+						DoWind(gustLast, windDirLast, windSpeedLast, dateTime);
 
+						/*
 						// The protocol does not provide an average value
 						// so feed in current MX average
 						DoWind(windSpeedLast, windDirLast, WindAverage / cumulus.Calib.WindSpeed.Mult, dateTime);
@@ -1192,6 +1197,7 @@ namespace CumulusMX
 
 							RecentMaxGust = gustLastCal;
 						}
+						*/
 					}
 
 					if (rainLast > -999 && rainRateLast > -999)

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -41,6 +41,7 @@ namespace CumulusMX
 		//private readonly NumberFormatInfo invNum = CultureInfo.InvariantCulture.NumberFormat;
 
 		private readonly Version fwVersion;
+		private readonly string gatewayType;
 
 
 		public GW1000Station(Cumulus cumulus) : base(cumulus)
@@ -57,7 +58,7 @@ namespace CumulusMX
 			cumulus.StationOptions.UseSpeedForAvgCalc = true;
 
 			LightningTime = DateTime.MinValue;
-			LightningDistance = 999;
+			LightningDistance = -1.0;
 
 			tmrDataWatchdog = new System.Timers.Timer();
 
@@ -126,6 +127,7 @@ namespace CumulusMX
 						var fwString = GW1000FirmwareVersion.Split(new string[] { "_V" }, StringSplitOptions.None);
 						if (fwString.Length > 1)
 						{
+							gatewayType = fwString[0];
 							fwVersion = new Version(fwString[1]);
 						}
 						else
@@ -639,7 +641,7 @@ namespace CumulusMX
 						// if a WS90 is connected, it has a 8.8 second update rate, so reduce the MX update rate from the default 10 seconds
 						if (updateRate > 8000 && updateRate != 8000)
 						{
-							cumulus.LogMessage($"PrintSensorInfoNew: WS90 sensor detected, changing the update rate from {updateRate / 1000} seconds to 8 seconds");
+							cumulus.LogMessage($"PrintSensorInfoNew: WS90 sensor detected, changing the update rate from {(updateRate / 1000):D} seconds to 8 seconds");
 							updateRate = 8000;
 						}
 						battV = data[battPos] * 0.02;
@@ -669,7 +671,7 @@ namespace CumulusMX
 						// if a WS80 is connected, it has a 4.75 second update rate, so reduce the MX update rate from the default 10 seconds
 						if (updateRate > 4000 && updateRate != 4000)
 						{
-							cumulus.LogMessage($"PrintSensorInfoNew: WS80 sensor detected, changing the update rate from {updateRate/1000} seconds to 4 seconds");
+							cumulus.LogMessage($"PrintSensorInfoNew: WS80 sensor detected, changing the update rate from {(updateRate/1000):D} seconds to 4 seconds");
 							updateRate = 4000;
 						}
 						battV = data[battPos] * 0.02;

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -368,6 +368,7 @@ namespace CumulusMX
 					if (data["tempf"] != null && data["humidity"] != null)
 					{
 						DoHumidex(recDate);
+						DoCloudBaseHeatIndex(recDate);
 
 						// === Apparent === - requires temp, hum, and windspeed
 						if (data["windspeedmph"] != null)

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -692,22 +692,23 @@ namespace CumulusMX
 			}
 		}
 
+
+		/*
+		 * Not yet used
 		private void ProcessCo2(NameValueCollection data, WeatherStation station)
 		{
 			// co2 - [int, ppm]
 			// co2_in - [int, ppm]
 			// co2_in_24h - [float, ppm]
 
-			/*
-			if (data["co2_in"] != null)
-			{
-				station.CO2 = Convert.ToInt32(data["co2_in"], CultureInfo.InvariantCulture);
-			}
-			if (data["co2_in_24"] != null)
-			{
-				station.CO2_24h = Convert.ToInt32(data["co2_in_24"], CultureInfo.InvariantCulture);
-			}
-			*/
+			//if (data["co2_in"] != null)
+			//{
+			//	station.CO2 = Convert.ToInt32(data["co2_in"], CultureInfo.InvariantCulture);
+			//}
+			//if (data["co2_in_24"] != null)
+			//{
+			//	station.CO2_24h = Convert.ToInt32(data["co2_in_24"], CultureInfo.InvariantCulture);
+			//}
 
 			// From FOSKplugin
 			// co2lvl
@@ -738,6 +739,7 @@ namespace CumulusMX
 				station.CO2_pm10_24h = Convert.ToDouble(data["pm10_AQIlvl_24h_co2"], CultureInfo.InvariantCulture);
 			}
 		}
+		*/
 
 		private void ProcessLightning(NameValueCollection data, WeatherStation station)
 		{

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -289,8 +289,8 @@ namespace CumulusMX
 				if (recDate.Minute != lastMinute)
 				{
 
-					// at start-up or every 10 minutes trigger output of uptime
-					if ((recDate.Minute % 10) == 0 || lastMinute == -1 && data["runtime"] != null)
+					// at start-up or every 20 minutes trigger output of uptime
+					if ((recDate.Minute % 20) == 0 || lastMinute == -1 && data["runtime"] != null)
 					{
 						var runtime = Convert.ToInt32(data["runtime"]);
 						var uptime = TimeSpan.FromSeconds(runtime);
@@ -333,7 +333,7 @@ namespace CumulusMX
 
 						if (gust == null || dir == null || spd == null)
 						{
-							cumulus.LogMessage($"ProcessData: Error, missing wind data");
+							cumulus.LogDebugMessage($"ProcessData: Error, missing wind data");
 						}
 						else
 						{
@@ -374,7 +374,7 @@ namespace CumulusMX
 						{
 							if (thisHum == null)
 							{
-								cumulus.LogMessage("ProcessData: Error, missing outdoor humidity");
+								cumulus.LogDebugMessage("ProcessData: Error, missing outdoor humidity");
 							}
 							else
 							{
@@ -400,7 +400,7 @@ namespace CumulusMX
 
 						if (press == null)
 						{
-							cumulus.LogMessage($"ProcessData: Error, missing baro pressure");
+							cumulus.LogDebugMessage($"ProcessData: Error, missing baro pressure");
 						}
 						else
 						{
@@ -425,7 +425,7 @@ namespace CumulusMX
 
 						if (temp == null)
 						{
-							cumulus.LogMessage($"ProcessData: Error, missing indoor temp");
+							cumulus.LogDebugMessage($"ProcessData: Error, missing indoor temp");
 						}
 						else
 						{
@@ -448,7 +448,7 @@ namespace CumulusMX
 						{
 							if (thisTemp == null)
 							{
-								cumulus.LogMessage($"ProcessData: Error, missing outdoor temp");
+								cumulus.LogDebugMessage($"ProcessData: Error, missing outdoor temp");
 							}
 							else
 							{
@@ -514,7 +514,7 @@ namespace CumulusMX
 
 						if (rain == null)
 						{
-							cumulus.LogMessage($"ProcessData: Error, missing rainfall");
+							cumulus.LogDebugMessage($"ProcessData: Error, missing rainfall");
 						}
 						else
 						{

--- a/CumulusMX/HttpStationWund.cs
+++ b/CumulusMX/HttpStationWund.cs
@@ -317,6 +317,7 @@ namespace CumulusMX
 				if (data["tempf"] != null && data["humidity"] != null && data["tempf"] != "-9999" && data["humidity"] != "-9999")
 				{
 					DoHumidex(recDate);
+					DoCloudBaseHeatIndex(recDate);
 				}
 				else
 				{

--- a/CumulusMX/ImetStation.cs
+++ b/CumulusMX/ImetStation.cs
@@ -756,9 +756,11 @@ namespace CumulusMX
 							// Cause wind chill calc
 							DoWindChill(0, timestamp);
 
+							DoOutdoorDewpoint(0, timestamp);
 							DoApparentTemp(timestamp);
 							DoFeelsLike(timestamp);
 							DoHumidex(timestamp);
+							DoCloudBaseHeatIndex(timestamp);
 
 							// sunshine hours
 							if (sl[SUNPOS].Length > 0)
@@ -990,7 +992,10 @@ namespace CumulusMX
 
 				if (temp1 > -999 && humidity > -999)
 				{
+					DoOutdoorDewpoint(0, now);
 					DoHumidex(now);
+					DoCloudBaseHeatIndex(now);
+
 					if (windspeed > -999)
 					{
 						DoApparentTemp(now);

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.16.1 - Build 3183")]
+[assembly: AssemblyDescription("Version 3.17.0 - Build 3184")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.16.1.3183")]
-[assembly: AssemblyFileVersion("3.16.1.3183")]
+[assembly: AssemblyVersion("3.17.0.3184")]
+[assembly: AssemblyFileVersion("3.17.0.3184")]

--- a/CumulusMX/Simulator.cs
+++ b/CumulusMX/Simulator.cs
@@ -11,12 +11,12 @@ namespace CumulusMX
 	internal class Simulator : WeatherStation
 	{
 		private bool stop;
-		private CancellationTokenSource tokenSource = new CancellationTokenSource();
+		private readonly CancellationTokenSource tokenSource = new CancellationTokenSource();
 		private CancellationToken cancellationToken;
 
-		private DataSet currData;
+		private readonly DataSet currData;
 
-		private int dataUpdateRate = 5000; // 5 second data update rate
+		private readonly int dataUpdateRate = 5000; // 5 second data update rate
 
 		private new readonly Random random;
 		private bool solarIntialised;
@@ -133,6 +133,7 @@ namespace CumulusMX
 			DoHumidex(recDate);
 			DoApparentTemp(recDate);
 			DoFeelsLike(recDate);
+			DoCloudBaseHeatIndex(recDate);
 		}
 
 		private void doSolar(DateTime recDate)
@@ -181,14 +182,14 @@ namespace CumulusMX
 
 		private class DataSet 
 		{
-			private MeanRevertingRandomWalk temperature;
-			private MeanRevertingRandomWalk humidity;
-			private MeanRevertingRandomWalk windSpeed;
-			private MeanRevertingRandomWalk windDirection;
-			private MeanRevertingRandomWalk insideTemp;
-			private MeanRevertingRandomWalk insideHum;
-			private MeanRevertingRandomWalk pressure;
-			private MeanRevertingRandomWalk rainRate;
+			private readonly MeanRevertingRandomWalk temperature;
+			private readonly MeanRevertingRandomWalk humidity;
+			private readonly MeanRevertingRandomWalk windSpeed;
+			private readonly MeanRevertingRandomWalk windDirection;
+			private readonly MeanRevertingRandomWalk insideTemp;
+			private readonly MeanRevertingRandomWalk insideHum;
+			private readonly MeanRevertingRandomWalk pressure;
+			private readonly MeanRevertingRandomWalk rainRate;
 
 			public double tempVal { get; set; }
 			public int humVal { get; set; }

--- a/CumulusMX/Simulator.cs
+++ b/CumulusMX/Simulator.cs
@@ -1,0 +1,285 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CumulusMX
+{
+	internal class Simulator : WeatherStation
+	{
+		private bool stop;
+		private CancellationTokenSource tokenSource = new CancellationTokenSource();
+		private CancellationToken cancellationToken;
+
+		private DataSet currData;
+
+		private int dataUpdateRate = 5000; // 5 second data update rate
+
+		private new readonly Random random;
+		private bool solarIntialised;
+
+		public Simulator(Cumulus cumulus) : base(cumulus)
+		{
+
+			cumulus.LogMessage("Station type = Simulator");
+
+			cumulus.LogMessage("Last update time = " + cumulus.LastUpdateTime);
+
+			cancellationToken = tokenSource.Token;
+
+			random = new Random();
+
+			currData = new DataSet();
+
+			cumulus.StationOptions.CalculatedDP = true;
+			cumulus.StationOptions.CalculatedET = true;
+			cumulus.StationOptions.CalculatedWC = true;
+			cumulus.StationOptions.UseWind10MinAvg = true;
+			cumulus.StationOptions.UseCumulusPresstrendstr = true;
+			cumulus.StationOptions.UseSpeedForAvgCalc = false;
+
+			WindAverage = 0;
+
+			timerStartNeeded = true;
+			LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
+			DoDayResetIfNeeded();
+			DoTrendValues(DateTime.Now);
+
+		}
+
+
+		public override void Start()
+		{
+			while (!stop)
+			{
+				try
+				{
+					var now = DateTime.Now;
+
+					currData.SetNewData(now);
+
+					applyData(now);
+
+					DoForecast(string.Empty, false);
+
+					UpdateStatusPanel(now);
+					UpdateMQTT();
+
+					if (cancellationToken.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(dataUpdateRate)))
+					{
+						break;
+					}
+				}
+				catch (ThreadAbortException) // Catch the ThreadAbortException
+				{
+					cumulus.LogMessage("Simulator Start: ThreadAbortException");
+					// and exit
+					stop = true;
+				}
+				catch (Exception ex)
+				{
+					// any others, log them and carry on
+					cumulus.LogMessage("Simulator Start: Exception = " + ex.Message);
+				}
+			}
+
+			cumulus.LogMessage("Ending normal reading loop");
+		}
+
+		public override void Stop()
+		{
+			StopMinuteTimer();
+
+			cumulus.LogMessage("Stopping data generation task");
+			try
+			{
+				if (tokenSource != null)
+					tokenSource.Cancel();
+				cumulus.LogMessage("Waiting for data generation to complete");
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage("Error stopping the simulator" + ex.Message);
+			}
+		}
+
+
+		private void applyData(DateTime recDate)
+		{
+			cumulus.LogDataMessage($"Simulated data: temp={ConvertTempCToUser(currData.tempVal):f1}, hum={currData.humVal}, gust={ConvertWindMPHToUser(currData.windSpeedVal):f2}, dir={currData.windBearingVal}, press={ConvertPressMBToUser(currData.pressureVal):f2}, r.rate={ConvertRainMMToUser(currData.rainRateVal):f2}");
+
+			DoWind(ConvertWindMPHToUser(currData.windSpeedVal), currData.windBearingVal, WindAverage / cumulus.Calib.WindSpeed.Mult, recDate);
+
+			var rain = Raincounter + ConvertRainMMToUser(currData.rainRateVal * dataUpdateRate / 1000 / 3600);
+
+			DoRain(rain, ConvertRainMMToUser(currData.rainRateVal), recDate);
+
+			DoIndoorTemp(ConvertTempCToUser(currData.tempInVal));
+			DoIndoorHumidity(currData.humInVal);
+
+			DoOutdoorHumidity(currData.humVal, recDate);
+			DoOutdoorTemp(ConvertTempCToUser(currData.tempVal), recDate);
+
+			DoPressure(ConvertPressMBToUser(currData.pressureVal), recDate);
+			UpdatePressureTrendString();
+
+			doSolar(recDate);
+
+			DoOutdoorDewpoint(0, recDate);
+			DoWindChill(0, recDate);
+			DoHumidex(recDate);
+			DoApparentTemp(recDate);
+			DoFeelsLike(recDate);
+		}
+
+		private void doSolar(DateTime recDate)
+		{
+			// For the solar random walk we are chasing the theoretical solat max value
+			double solar = SolarRad;
+
+			// if we are starting up, set the intial solar rad value to 90% of theoretical
+			if (!solarIntialised)
+			{
+				CurrentSolarMax = AstroLib.SolarMax(recDate, cumulus.Longitude, cumulus.Latitude, AltitudeM(cumulus.Altitude), out SolarElevation, cumulus.SolarOptions);
+				solar = CurrentSolarMax * 0.9;
+				solarIntialised = true;
+			}
+			
+			// aim for 85% of theoretical in the morning, 75% after local noon
+			double factor;
+			if (recDate.IsDaylightSavingTime())
+			{
+				factor = recDate.Hour < 13 ? 0.85 : 0.75;
+			}
+			else
+			{
+				factor = recDate.Hour < 12 ? 0.85 : 0.75;
+			}
+
+			// If it's raining, make it dull!
+			if (RainRate > 0)
+			{
+				factor = 0.3;
+			}
+
+			var volatility = CurrentSolarMax * 0.05;
+			if (volatility < 2)
+				volatility = 2;
+			else if (volatility > 30)
+				volatility = 30;
+
+			solar -= (solar - CurrentSolarMax * factor) * 0.02;
+			solar += volatility * (2 * random.NextDouble() - 1);
+			if (solar < 0 || CurrentSolarMax == 0)
+				solar = 0;
+			DoSolarRad((int)solar, recDate);
+		}
+
+
+		private class DataSet 
+		{
+			private MeanRevertingRandomWalk temperature;
+			private MeanRevertingRandomWalk humidity;
+			private MeanRevertingRandomWalk windSpeed;
+			private MeanRevertingRandomWalk windDirection;
+			private MeanRevertingRandomWalk insideTemp;
+			private MeanRevertingRandomWalk insideHum;
+			private MeanRevertingRandomWalk pressure;
+			private MeanRevertingRandomWalk rainRate;
+
+			public double tempVal { get; set; }
+			public int humVal { get; set; }
+			public double windSpeedVal { get; set; }
+			public int windBearingVal { get; set; }
+			public double rainRateVal { get; set; }
+			public double pressureVal { get; set; }
+			public double tempInVal { get; set; }
+			public int humInVal { get; set; }
+
+
+			public DataSet()
+			{
+				// Temperature - both annual and daily variations, daily offset by 0.1 of a day
+				var tempMean = new Func<DateTime, double>((x) => 15 + 10 * Math.Cos(x.DayOfYear / 365.0 * 2 * Math.PI) - 10 * Math.Cos((x.TimeOfDay.TotalDays - 0.1) * 2 * Math.PI));
+				// Wind - daily variation, offset by 0.1 of a day
+				var windMean = new Func<DateTime, double>((x) => 10 - 9.5 *  Math.Cos((x.TimeOfDay.TotalDays - 0.1) * 2 * Math.PI));
+				var windVolatility = new Func<DateTime, double>((x) => 2 - 1.5 * Math.Cos((x.TimeOfDay.TotalDays - 0.1) * 2 * Math.PI));
+				// Humidity - daily variation, offset by 0.1 of a day
+				var humMean = new Func<DateTime, double>((x) => 60 + 30 * Math.Cos((x.TimeOfDay.TotalDays - 0.1) * 2 * Math.PI));
+				// Pressure - vary the range over a two day period
+				var pressMean = new Func<DateTime, double>((x) => 1010 + 25 * Math.Cos((x.DayOfYear + x.TimeOfDay.TotalDays + 0.2) % 4 / 4.0 * 2 * Math.PI) - 6 * Math.Cos((x.TimeOfDay.TotalDays + 0.65) * 2 * Math.PI));
+				// Inside Temp - assume heating between 07:00 and 23:00
+				var inTempMean = new Func<DateTime, double>((x) => (x.Hour < 7 || x.Hour > 22) ? 16 : 21);
+				// RainRate - lets try two blocks of rain per day, determined by day of the year, mean rate to be 3 mm/hr
+				var rainRateMean = new Func<DateTime, double>((x) => x.Hour == x.DayOfYear % 24 || x.Hour == (x.DayOfYear + 1) % 24 || x.Hour == (x.DayOfYear + 12) % 24 || x.Hour == (x.DayOfYear + 13) % 24 ? 3 : -100);
+
+				temperature = new MeanRevertingRandomWalk(tempMean, (x) => 0.1, 0.01, -10, 30);
+				humidity = new MeanRevertingRandomWalk(humMean, (x) => 1, 0.01, 10, 100);
+				windSpeed = new MeanRevertingRandomWalk(windMean, windVolatility, 0.02, 0, 50);
+				windDirection = new MeanRevertingRandomWalk((x) => 191, (x) => 10, 0.005, 0, 720);
+				pressure = new MeanRevertingRandomWalk(pressMean, (x) => .1, 0.05, 950, 1050);
+				rainRate = new MeanRevertingRandomWalk(rainRateMean, (x) => 5, 0.05, 0, 30);
+				insideTemp = new MeanRevertingRandomWalk(inTempMean, (x) => 0.1, 0.01, 15, 25);
+				insideHum = new MeanRevertingRandomWalk((x) => 50, (x) => 0.5, 0.005, 35, 75);
+			}
+
+			public void SetNewData(DateTime readTime)
+			{
+				tempVal = temperature.GetValue(readTime);
+				humVal = (int)humidity.GetValue(readTime);
+				windSpeedVal  = Math.Round(windSpeed.GetValue(readTime), 1);
+				if (windSpeedVal > 0)
+				{
+					windBearingVal = ((int)windDirection.GetValue(readTime) % 360) + 1;
+				}
+				rainRateVal = rainRate.GetValue(readTime);
+				pressureVal = pressure.GetValue(readTime);
+				tempInVal = insideTemp.GetValue(readTime);
+				humInVal = (int)insideHum.GetValue(readTime);
+			}
+		}
+
+		private class MeanRevertingRandomWalk
+		{
+			private readonly Func<DateTime, double> _meanCurve;
+			private readonly Func<DateTime, double> _volatility;
+			private readonly double _meanReversion;
+			private readonly double _cropMin;
+			private readonly double _cropMax;
+
+			private double _value;
+			private bool _initialised = false;
+			private readonly Random _random;
+
+			public MeanRevertingRandomWalk(Func<DateTime, double> meanCurve, Func<DateTime, double> volatility, double meanReversion, double cropMin, double cropMax)
+			{
+				_meanCurve = meanCurve;
+				_volatility = volatility;
+				_meanReversion = meanReversion;
+				_cropMin = cropMin;
+				_cropMax = cropMax;
+				_random = new Random();
+			}
+
+			public double GetValue(DateTime date)
+			{
+				if (!_initialised)
+				{
+					_value = _meanCurve(date);
+					_initialised = true;
+				}
+
+
+				_value -= (_value - _meanCurve(date)) * _meanReversion;
+				_value += _volatility(date) * (2 * _random.NextDouble() - 1);
+				if (_value < _cropMin) return _cropMin;
+				if (_value > _cropMax) return _cropMax;
+				return _value;
+			}
+		}
+
+	}
+}

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -28,6 +28,7 @@ namespace CumulusMX
 			// Build the settings data, convert to JSON, and return it
 			var optionsAdv = new JsonStationSettingsOptionsAdvanced()
 			{
+				usespeedforavg = cumulus.StationOptions.UseSpeedForAvgCalc,
 				avgbearingmins = cumulus.StationOptions.AvgBearingMinutes,
 				avgspeedmins = cumulus.StationOptions.AvgSpeedMinutes,
 				peakgustmins = cumulus.StationOptions.PeakGustMinutes,
@@ -41,7 +42,6 @@ namespace CumulusMX
 			{
 				usezerobearing = cumulus.StationOptions.UseZeroBearing,
 				calcwindaverage = cumulus.StationOptions.UseWind10MinAvg,
-				usespeedforavg = cumulus.StationOptions.UseSpeedForAvgCalc,
 				use100for98hum = cumulus.StationOptions.Humidity98Fix,
 				calculatedewpoint = cumulus.StationOptions.CalculatedDP,
 				calculatewindchill = cumulus.StationOptions.CalculatedWC,
@@ -743,7 +743,6 @@ namespace CumulusMX
 				{
 					cumulus.StationOptions.UseZeroBearing = settings.Options.usezerobearing;
 					cumulus.StationOptions.UseWind10MinAvg = settings.Options.calcwindaverage;
-					cumulus.StationOptions.UseSpeedForAvgCalc = settings.Options.usespeedforavg;
 					cumulus.StationOptions.Humidity98Fix = settings.Options.use100for98hum;
 					cumulus.StationOptions.CalculatedDP = settings.Options.calculatedewpoint;
 					cumulus.StationOptions.CalculatedWC = settings.Options.calculatewindchill;
@@ -754,6 +753,7 @@ namespace CumulusMX
 					cumulus.StationOptions.RoundWindSpeed = settings.Options.roundwindspeeds;
 					cumulus.StationOptions.NoSensorCheck = settings.Options.nosensorcheck;
 
+					cumulus.StationOptions.UseSpeedForAvgCalc = settings.Options.advanced.usespeedforavg;
 					cumulus.StationOptions.AvgBearingMinutes = settings.Options.advanced.avgbearingmins;
 					cumulus.StationOptions.AvgSpeedMinutes = settings.Options.advanced.avgspeedmins;
 					cumulus.StationOptions.PeakGustMinutes = settings.Options.advanced.peakgustmins;
@@ -1553,6 +1553,7 @@ namespace CumulusMX
 
 	internal class JsonStationSettingsOptionsAdvanced
 	{
+		public bool usespeedforavg { get; set; }
 		public int avgbearingmins { get; set; }
 		public int avgspeedmins { get; set; }
 		public int peakgustmins { get; set; }
@@ -1566,7 +1567,6 @@ namespace CumulusMX
 	{
 		public bool usezerobearing { get; set; }
 		public bool calcwindaverage { get; set; }
-		public bool usespeedforavg { get; set; }
 		public bool use100for98hum { get; set; }
 		public bool calculatedewpoint { get; set; }
 		public bool calculatewindchill { get; set; }

--- a/CumulusMX/TempestStation.cs
+++ b/CumulusMX/TempestStation.cs
@@ -165,7 +165,7 @@ namespace CumulusMX
 				DoApparentTemp(timestamp);
 				DoFeelsLike(timestamp);
 				DoHumidex(timestamp);
-
+				DoCloudBaseHeatIndex(timestamp);
 
 				DoUV((double) historydata.UV, timestamp);
 
@@ -309,6 +309,8 @@ namespace CumulusMX
 						DoFeelsLike(ts);
 						DoWindChill(userTemp,ts);
 						DoHumidex(ts);
+						DoCloudBaseHeatIndex(ts);
+
 						UpdateStatusPanel(ts);
 						UpdateMQTT();
 						DoForecast(string.Empty, false);
@@ -746,10 +748,7 @@ namespace CumulusMX.Tempest
 				if (!int.TryParse(packet.firmware_revision.ToString(), out var i)) i = -1;
 				FirmwareRevision = i;
 			}
-			catch (Exception e)
-			{
-				var ex = e.Message;
-			}
+			catch {}
 
 			RSSI = packet.rssi;
 			HubRSSI = packet.hub_rssi;
@@ -858,10 +857,7 @@ namespace CumulusMX.Tempest
 				if (!int.TryParse(packet.firmware_revision.ToString(), out i)) i = -1;
 				FirmwareRevision = i;
 			}
-			catch (Exception e)
-			{
-				var ex = e.Message;
-			}
+			catch {}
 
 			if (packet.obs[0].Length >= 18)
 			{

--- a/CumulusMX/TempestStation.cs
+++ b/CumulusMX/TempestStation.cs
@@ -36,9 +36,9 @@ namespace CumulusMX
 
 		public override void getAndProcessHistoryData()
 		{
-			cumulus.LogDebugMessage("Lock: Station waiting for the lock");
+			//cumulus.LogDebugMessage("Lock: Station waiting for the lock");
 			Cumulus.syncInit.Wait();
-			cumulus.LogDebugMessage("Lock: Station has the lock");
+			//cumulus.LogDebugMessage("Lock: Station has the lock");
 			try
 			{
 				var stTime = cumulus.LastUpdateTime;
@@ -61,7 +61,7 @@ namespace CumulusMX
 					te = te.InnerException;
 				}
 			}
-			cumulus.LogDebugMessage("Lock: Station releasing the lock");
+			//cumulus.LogDebugMessage("Lock: Station releasing the lock");
 			Cumulus.syncInit.Release();
 			StartLoop();
 		}

--- a/CumulusMX/WM918Station.cs
+++ b/CumulusMX/WM918Station.cs
@@ -377,6 +377,7 @@ namespace CumulusMX
 			DoApparentTemp(DateTime.Now);
 			DoFeelsLike(DateTime.Now);
 			DoHumidex(DateTime.Now);
+			DoCloudBaseHeatIndex(DateTime.Now);
 		}
 
 		private void WM918Rain(List<int> buff)

--- a/CumulusMX/WMR100Station.cs
+++ b/CumulusMX/WMR100Station.cs
@@ -463,6 +463,7 @@ namespace CumulusMX
 				DoApparentTemp(Now);
 				DoFeelsLike(Now);
 				DoHumidex(Now);
+				DoCloudBaseHeatIndex(Now);
 
 				// battery status
 				//if (PacketBuffer[0] & 0x40 == 0x40 )

--- a/CumulusMX/WMR200Station.cs
+++ b/CumulusMX/WMR200Station.cs
@@ -593,6 +593,7 @@ namespace CumulusMX
 				DoApparentTemp(now);
 				DoFeelsLike(now);
 				DoHumidex(now);
+				DoCloudBaseHeatIndex(now);
 			}
 			else if (sensor == 0)
 			{
@@ -1598,6 +1599,7 @@ namespace CumulusMX
 			DoApparentTemp(timestamp);
 			DoFeelsLike(timestamp);
 			DoHumidex(timestamp);
+			DoCloudBaseHeatIndex(timestamp);
 
 			cumulus.DoLogFile(timestamp,false);
 			cumulus.MySqlRealtimeFile(999, false, timestamp);

--- a/CumulusMX/WMR928Station.cs
+++ b/CumulusMX/WMR928Station.cs
@@ -316,6 +316,7 @@ namespace CumulusMX
 				DoApparentTemp(DateTime.Now);
 				DoFeelsLike(DateTime.Now);
 				DoHumidex(DateTime.Now);
+				DoCloudBaseHeatIndex(DateTime.Now);
 			}
 		}
 
@@ -475,6 +476,7 @@ namespace CumulusMX
 				DoApparentTemp(DateTime.Now);
 				DoFeelsLike(DateTime.Now);
 				DoHumidex(DateTime.Now);
+				DoCloudBaseHeatIndex(DateTime.Now);
 			}
 		}
 

--- a/CumulusMX/WS2300Station.cs
+++ b/CumulusMX/WS2300Station.cs
@@ -374,6 +374,7 @@ namespace CumulusMX
 				DoApparentTemp(timestamp);
 				DoFeelsLike(timestamp);
 				DoHumidex(timestamp);
+				DoCloudBaseHeatIndex(timestamp);
 
 				CalculateDominantWindBearing(Bearing, WindAverage, historydata.interval);
 
@@ -724,6 +725,8 @@ namespace CumulusMX
 				DoApparentTemp(now);
 				DoFeelsLike(now);
 				DoHumidex(now);
+				DoCloudBaseHeatIndex(now);
+
 				UpdateStatusPanel(now);
 				UpdateMQTT();
 			}

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1619,9 +1619,10 @@ namespace CumulusMX
 		{
 			CheckForDataStopped();
 
+			CurrentSolarMax = AstroLib.SolarMax(now, cumulus.Longitude, cumulus.Latitude, AltitudeM(cumulus.Altitude), out SolarElevation, cumulus.SolarOptions);
+			
 			if (!DataStopped)
 			{
-				CurrentSolarMax = AstroLib.SolarMax(now, cumulus.Longitude, cumulus.Latitude, AltitudeM(cumulus.Altitude), out SolarElevation, cumulus.SolarOptions);
 				if (((Pressure > 0) && TempReadyToPlot && WindReadyToPlot) || cumulus.StationOptions.NoSensorCheck)
 				{
 					// increment wind run by one minute's worth of average speed
@@ -1677,7 +1678,7 @@ namespace CumulusMX
 					AddRecentDataWithAq(now, WindAverage, RecentMaxGust, WindLatest, Bearing, AvgBearing, OutdoorTemperature, WindChill, OutdoorDewpoint, HeatIndex, OutdoorHumidity,
 						Pressure, RainToday, SolarRad, UV, Raincounter, FeelsLike, Humidex, ApparentTemperature, IndoorTemperature, IndoorHumidity, CurrentSolarMax, RainRate);
 					DoTrendValues(now);
-					DoPressTrend("Pressure trend");
+					DoPressTrend("Enable Cumulus pressure trend");
 
 					// calculate ET just before the hour so it is included in the correct day at roll over - only affects 9am met days really
 					if (cumulus.StationOptions.CalculatedET && now.Minute == 59)

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -43,7 +43,8 @@ namespace CumulusMX
 		public readonly Object yearIniThreadLock = new Object();
 		public readonly Object alltimeIniThreadLock = new Object();
 		public readonly Object monthlyalltimeIniThreadLock = new Object();
-		private readonly Object webSocketThreadLock = new Object();
+
+		private static readonly SemaphoreSlim webSocketSemaphore = new SemaphoreSlim(1, 1);
 
 		// holds all time highs and lows
 		public AllTimeRecords AllTime = new AllTimeRecords();
@@ -697,7 +698,7 @@ namespace CumulusMX
 			AlltimeRecordTimestamp = ini.GetValue("Records", "Alltime", DateTime.MinValue);
 
 			// Lightning (GW1000 for now)
-			LightningDistance = ini.GetValue("Lightning", "Distance", -1);
+			LightningDistance = ini.GetValue("Lightning", "Distance", -1.0);
 			LightningTime = ini.GetValue("Lightning", "LastStrike", DateTime.MinValue);
 		}
 
@@ -1443,64 +1444,67 @@ namespace CumulusMX
 			// send current data to web-socket
 			try
 			{
-				// wait for the ws lock object
-				lock (webSocketThreadLock)
+				// if we already have an update queued, don't add to the wait queue. Otherwise we get hundreds queued up during catch-up
+				if (webSocketSemaphore.CurrentCount == 0)
 				{
-					//cumulus.LogDebugMessage("WebSocket: Sending message");
-
-					StringBuilder windRoseData = new StringBuilder(80);
-
-					lock (windcounts)
-					{
-						windRoseData.Append((windcounts[0] * cumulus.Calib.WindGust.Mult).ToString(cumulus.WindFormat, CultureInfo.InvariantCulture));
-
-						for (var i = 1; i < cumulus.NumWindRosePoints; i++)
-						{
-							windRoseData.Append(",");
-							windRoseData.Append((windcounts[i] * cumulus.Calib.WindGust.Mult).ToString(cumulus.WindFormat, CultureInfo.InvariantCulture));
-						}
-					}
-
-					string stormRainStart = StartOfStorm == DateTime.MinValue ? "-----" : StartOfStorm.ToString("d");
-
-					var data = new DataStruct(cumulus, OutdoorTemperature, OutdoorHumidity, TempTotalToday / tempsamplestoday, IndoorTemperature, OutdoorDewpoint, WindChill, IndoorHumidity,
-						Pressure, WindLatest, WindAverage, RecentMaxGust, WindRunToday, Bearing, AvgBearing, RainToday, RainYesterday, RainMonth, RainYear, RainRate,
-						RainLastHour, HeatIndex, Humidex, ApparentTemperature, temptrendval, presstrendval, HiLoToday.HighGust, HiLoToday.HighGustTime.ToString("HH:mm"), HiLoToday.HighWind,
-						HiLoToday.HighGustBearing, cumulus.Units.WindText, BearingRangeFrom10, BearingRangeTo10, windRoseData.ToString(), HiLoToday.HighTemp, HiLoToday.LowTemp,
-						HiLoToday.HighTempTime.ToString("HH:mm"), HiLoToday.LowTempTime.ToString("HH:mm"), HiLoToday.HighPress, HiLoToday.LowPress, HiLoToday.HighPressTime.ToString("HH:mm"),
-						HiLoToday.LowPressTime.ToString("HH:mm"), HiLoToday.HighRainRate, HiLoToday.HighRainRateTime.ToString("HH:mm"), HiLoToday.HighHumidity, HiLoToday.LowHumidity,
-						HiLoToday.HighHumidityTime.ToString("HH:mm"), HiLoToday.LowHumidityTime.ToString("HH:mm"), cumulus.Units.PressText, cumulus.Units.TempText, cumulus.Units.RainText,
-						HiLoToday.HighDewPoint, HiLoToday.LowDewPoint, HiLoToday.HighDewPointTime.ToString("HH:mm"), HiLoToday.LowDewPointTime.ToString("HH:mm"), HiLoToday.LowWindChill,
-						HiLoToday.LowWindChillTime.ToString("HH:mm"), (int)SolarRad, (int)HiLoToday.HighSolar, HiLoToday.HighSolarTime.ToString("HH:mm"), UV, HiLoToday.HighUv,
-						HiLoToday.HighUvTime.ToString("HH:mm"), forecaststr, getTimeString(cumulus.SunRiseTime), getTimeString(cumulus.SunSetTime),
-						getTimeString(cumulus.MoonRiseTime), getTimeString(cumulus.MoonSetTime), HiLoToday.HighHeatIndex, HiLoToday.HighHeatIndexTime.ToString("HH:mm"), HiLoToday.HighAppTemp,
-						HiLoToday.LowAppTemp, HiLoToday.HighAppTempTime.ToString("HH:mm"), HiLoToday.LowAppTempTime.ToString("HH:mm"), (int)CurrentSolarMax,
-						AllTime.HighPress.Val, AllTime.LowPress.Val, SunshineHours, CompassPoint(DominantWindBearing), LastRainTip,
-						HiLoToday.HighHourlyRain, HiLoToday.HighHourlyRainTime.ToString("HH:mm"), "F" + cumulus.Beaufort(HiLoToday.HighWind), "F" + cumulus.Beaufort(WindAverage), cumulus.BeaufortDesc(WindAverage),
-						LastDataReadTimestamp.ToString("HH:mm:ss"), DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
-						cumulus.LowTempAlarm.Triggered, cumulus.HighTempAlarm.Triggered, cumulus.TempChangeAlarm.UpTriggered, cumulus.TempChangeAlarm.DownTriggered, cumulus.HighRainTodayAlarm.Triggered, cumulus.HighRainRateAlarm.Triggered,
-						cumulus.LowPressAlarm.Triggered, cumulus.HighPressAlarm.Triggered, cumulus.PressChangeAlarm.UpTriggered, cumulus.PressChangeAlarm.DownTriggered, cumulus.HighGustAlarm.Triggered, cumulus.HighWindAlarm.Triggered,
-						cumulus.SensorAlarm.Triggered, cumulus.BatteryLowAlarm.Triggered, cumulus.SpikeAlarm.Triggered, cumulus.UpgradeAlarm.Triggered,
-						cumulus.HttpUploadAlarm.Triggered, cumulus.MySqlUploadAlarm.Triggered,
-						FeelsLike, HiLoToday.HighFeelsLike, HiLoToday.HighFeelsLikeTime.ToString("HH:mm"), HiLoToday.LowFeelsLike, HiLoToday.LowFeelsLikeTime.ToString("HH:mm"),
-						HiLoToday.HighHumidex, HiLoToday.HighHumidexTime.ToString("HH:mm"));
-
-					//var json = jss.Serialize(data);
-
-					var ser = new DataContractJsonSerializer(typeof(DataStruct));
-
-					var stream = new MemoryStream();
-
-					ser.WriteObject(stream, data);
-
-					stream.Position = 0;
-
-					cumulus.LogDebugMessage("WebSocket: Send message");
-					WebSocket.SendMessage(new StreamReader(stream).ReadToEnd());
-
-					// We can't be sure when the broadcast completes because it is async internally, so the best we can do is wait a short time
-					Thread.Sleep(500);
+					cumulus.LogDebugMessage("sendWebSocketData: Update already queued, dropping this one");
+					return;
 				}
+
+				// wait for the ws lock object
+				webSocketSemaphore.Wait();
+
+				StringBuilder windRoseData = new StringBuilder(80);
+
+				lock (windcounts)
+				{
+					windRoseData.Append((windcounts[0] * cumulus.Calib.WindGust.Mult).ToString(cumulus.WindFormat, CultureInfo.InvariantCulture));
+
+					for (var i = 1; i < cumulus.NumWindRosePoints; i++)
+					{
+						windRoseData.Append(",");
+						windRoseData.Append((windcounts[i] * cumulus.Calib.WindGust.Mult).ToString(cumulus.WindFormat, CultureInfo.InvariantCulture));
+					}
+				}
+
+				string stormRainStart = StartOfStorm == DateTime.MinValue ? "-----" : StartOfStorm.ToString("d");
+
+				var data = new DataStruct(cumulus, OutdoorTemperature, OutdoorHumidity, TempTotalToday / tempsamplestoday, IndoorTemperature, OutdoorDewpoint, WindChill, IndoorHumidity,
+					Pressure, WindLatest, WindAverage, RecentMaxGust, WindRunToday, Bearing, AvgBearing, RainToday, RainYesterday, RainMonth, RainYear, RainRate,
+					RainLastHour, HeatIndex, Humidex, ApparentTemperature, temptrendval, presstrendval, HiLoToday.HighGust, HiLoToday.HighGustTime.ToString("HH:mm"), HiLoToday.HighWind,
+					HiLoToday.HighGustBearing, cumulus.Units.WindText, BearingRangeFrom10, BearingRangeTo10, windRoseData.ToString(), HiLoToday.HighTemp, HiLoToday.LowTemp,
+					HiLoToday.HighTempTime.ToString("HH:mm"), HiLoToday.LowTempTime.ToString("HH:mm"), HiLoToday.HighPress, HiLoToday.LowPress, HiLoToday.HighPressTime.ToString("HH:mm"),
+					HiLoToday.LowPressTime.ToString("HH:mm"), HiLoToday.HighRainRate, HiLoToday.HighRainRateTime.ToString("HH:mm"), HiLoToday.HighHumidity, HiLoToday.LowHumidity,
+					HiLoToday.HighHumidityTime.ToString("HH:mm"), HiLoToday.LowHumidityTime.ToString("HH:mm"), cumulus.Units.PressText, cumulus.Units.TempText, cumulus.Units.RainText,
+					HiLoToday.HighDewPoint, HiLoToday.LowDewPoint, HiLoToday.HighDewPointTime.ToString("HH:mm"), HiLoToday.LowDewPointTime.ToString("HH:mm"), HiLoToday.LowWindChill,
+					HiLoToday.LowWindChillTime.ToString("HH:mm"), (int)SolarRad, (int)HiLoToday.HighSolar, HiLoToday.HighSolarTime.ToString("HH:mm"), UV, HiLoToday.HighUv,
+					HiLoToday.HighUvTime.ToString("HH:mm"), forecaststr, getTimeString(cumulus.SunRiseTime), getTimeString(cumulus.SunSetTime),
+					getTimeString(cumulus.MoonRiseTime), getTimeString(cumulus.MoonSetTime), HiLoToday.HighHeatIndex, HiLoToday.HighHeatIndexTime.ToString("HH:mm"), HiLoToday.HighAppTemp,
+					HiLoToday.LowAppTemp, HiLoToday.HighAppTempTime.ToString("HH:mm"), HiLoToday.LowAppTempTime.ToString("HH:mm"), (int)CurrentSolarMax,
+					AllTime.HighPress.Val, AllTime.LowPress.Val, SunshineHours, CompassPoint(DominantWindBearing), LastRainTip,
+					HiLoToday.HighHourlyRain, HiLoToday.HighHourlyRainTime.ToString("HH:mm"), "F" + cumulus.Beaufort(HiLoToday.HighWind), "F" + cumulus.Beaufort(WindAverage), cumulus.BeaufortDesc(WindAverage),
+					LastDataReadTimestamp.ToString("HH:mm:ss"), DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
+					cumulus.LowTempAlarm.Triggered, cumulus.HighTempAlarm.Triggered, cumulus.TempChangeAlarm.UpTriggered, cumulus.TempChangeAlarm.DownTriggered, cumulus.HighRainTodayAlarm.Triggered, cumulus.HighRainRateAlarm.Triggered,
+					cumulus.LowPressAlarm.Triggered, cumulus.HighPressAlarm.Triggered, cumulus.PressChangeAlarm.UpTriggered, cumulus.PressChangeAlarm.DownTriggered, cumulus.HighGustAlarm.Triggered, cumulus.HighWindAlarm.Triggered,
+					cumulus.SensorAlarm.Triggered, cumulus.BatteryLowAlarm.Triggered, cumulus.SpikeAlarm.Triggered, cumulus.UpgradeAlarm.Triggered,
+					cumulus.HttpUploadAlarm.Triggered, cumulus.MySqlUploadAlarm.Triggered,
+					FeelsLike, HiLoToday.HighFeelsLike, HiLoToday.HighFeelsLikeTime.ToString("HH:mm"), HiLoToday.LowFeelsLike, HiLoToday.LowFeelsLikeTime.ToString("HH:mm"),
+					HiLoToday.HighHumidex, HiLoToday.HighHumidexTime.ToString("HH:mm"));
+
+				//var json = jss.Serialize(data);
+
+				var ser = new DataContractJsonSerializer(typeof(DataStruct));
+
+				var stream = new MemoryStream();
+
+				ser.WriteObject(stream, data);
+
+				stream.Position = 0;
+
+				WebSocket.SendMessage(new StreamReader(stream).ReadToEnd());
+
+				// We can't be sure when the broadcast completes because it is async internally, so the best we can do is wait a short time
+				Thread.Sleep(500);
 			}
 			catch (Exception ex)
 			{
@@ -1508,8 +1512,7 @@ namespace CumulusMX
 			}
 			finally
 			{
-				//cumulus.LogDebugMessage("WebSocket: End message");
-				//webSocketLocked = false;
+				webSocketSemaphore.Release();
 			}
 		}
 
@@ -9844,8 +9847,8 @@ namespace CumulusMX
 		{
 			var json = new StringBuilder("{\"data\":[", 256);
 
-			json.Append($"[\"Distance to last strike\",\"{LightningDistance.ToString(cumulus.WindRunFormat)}\",\"{cumulus.Units.WindRunText}\"],");
-			json.Append($"[\"Time of last strike\",\"{LightningTime}\",\"\"],");
+			json.Append($"[\"Distance to last strike\",\"{(LightningDistance == -1 ? "-" : LightningDistance.ToString(cumulus.WindRunFormat))}\",\"{cumulus.Units.WindRunText}\"],");
+			json.Append($"[\"Time of last strike\",\"{(DateTime.Equals(LightningTime, DateTime.MinValue) ? "-" : LightningTime.ToString("g"))}\",\"\"],");
 			json.Append($"[\"Number of strikes today\",\"{LightningStrikesToday}\",\"\"]");
 			json.Append("]}");
 			return json.ToString();

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -3890,12 +3890,12 @@ namespace CumulusMX
 
 		private string TagLightningDistance(Dictionary<string, string> tagParams)
 		{
-			return station.LightningDistance == 999 ? "--" : CheckRcDp(station.LightningDistance, tagParams, cumulus.WindRunDPlaces);
+			return station.LightningDistance == -1 ? "--" : CheckRcDp(station.LightningDistance, tagParams, cumulus.WindRunDPlaces);
 		}
 
 		private string TagLightningTime(Dictionary<string, string> tagParams)
 		{
-			return DateTime.Compare(station.LightningTime, new DateTime(1900, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)) == 0 ? "---" : GetFormattedDateTime(station.LightningTime, "t", tagParams);
+			return DateTime.Equals(station.LightningTime, DateTime.MinValue) ? "---" : GetFormattedDateTime(station.LightningTime, "t", tagParams);
 		}
 
 		private string TagLightningStrikesToday(Dictionary<string, string> tagParams)

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,10 +1,12 @@
 3.17.0 - b3184
 ——————————————
+- Fix: Cloud base being set to large value at start-up
 
 - New: Adds a PWS Simulator station type for testing or trial purposes
 
 - Change: The "live" dashboard screens now refresh whenever new data is received, or every five seconds
-
+- Change: The "Speed for average calc" station option has been moved from Common Options to Common Options | Advanced Options
+- Change: The Ecowitt stations now force the "Speed for average calc" option to be enabled at start-up
 
 
 3.16.1 - b3183

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,12 @@
+3.17.0 - b3184
+——————————————
+
+- New: Adds a PWS Simulator station type for testing or trial purposes
+
+- Change: The "live" dashboard screens now refresh whenever new data is received, or every five seconds
+
+
+
 3.16.1 - b3183
 ——————————————
 - Fix: Error message about Ecowitt sensor mapping when saving the station settings for non-Ecowitt stations

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,12 +2,14 @@
 ——————————————
 - Fix: Cloud base being set to large value at start-up
 - Fix: Reading lightning distance from today.ini
+- Fix: Potential crash obtaining the local IP address
 
 - New: Adds a PWS Simulator station type for testing or trial purposes
 
 - Change: The "live" dashboard screens now refresh whenever new data is received, or every five seconds
 - Change: The "Speed for average calc" station option has been moved from Common Options to Common Options | Advanced Options
 - Change: The Ecowitt stations now force the "Speed for average calc" option to be enabled at start-up
+- Change: Slightly improved solar position calculations
 
 
 3.16.1 - b3183

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,7 @@
 3.17.0 - b3184
 ——————————————
 - Fix: Cloud base being set to large value at start-up
+- Fix: Reading lightning distance from today.ini
 
 - New: Adds a PWS Simulator station type for testing or trial purposes
 


### PR DESCRIPTION
- Fix: Cloud base being set to large value at start-up
- Fix: Reading lightning distance from today.ini
- Fix: Potential crash obtaining the local IP address

- New: Adds a PWS Simulator station type for testing or trial purposes

- Change: The "live" dashboard screens now refresh whenever new data is received, or every five seconds
- Change: The "Speed for average calc" station option has been moved from Common Options to Common Options | Advanced Options
- Change: The Ecowitt stations now force the "Speed for average calc" option to be enabled at start-up
- Change: Slightly improved solar position calculations