### PR TITLE
v3.20.0

### DIFF
--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -164,7 +164,7 @@ namespace CumulusMX
 
 		public DateTime DownTriggeredTime { get; set; }
 
-		public void CheckAlarm(double value)
+		public new void CheckAlarm(double value)
 		{
 			if (value > Value)
 			{

--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CumulusMX
 {
@@ -21,7 +17,10 @@ namespace CumulusMX
 			get => triggered;
 			set
 			{
-				doTriggered(value);
+				if (Program.cumulus.NormalRunning)
+				{
+					doTriggered(value);
+				}
 			}
 		}
 
@@ -50,7 +49,10 @@ namespace CumulusMX
 
 		public void CheckAlarm(double value)
 		{
-			doTriggered((type == AlarmTypes.Above && value > Value) || (type == AlarmTypes.Below && value < Value));
+			if (Program.cumulus.NormalRunning)
+			{
+				doTriggered((type == AlarmTypes.Above && value > Value) || (type == AlarmTypes.Below && value < Value));
+			}
 		}
 
 		private void doTriggered(bool value)
@@ -145,7 +147,10 @@ namespace CumulusMX
 			get => upTriggered;
 			set
 			{
-				doUpTriggered(value);
+				if (Program.cumulus.NormalRunning)
+				{
+					doUpTriggered(value);
+				}
 			}
 		}
 		public DateTime UpTriggeredTime { get; set; }
@@ -157,7 +162,10 @@ namespace CumulusMX
 			get => downTriggered;
 			set
 			{
-				doDownTriggered(value);
+				if (Program.cumulus.NormalRunning)
+				{
+					doDownTriggered(value);
+				}
 			}
 		}
 
@@ -166,20 +174,24 @@ namespace CumulusMX
 
 		public new void CheckAlarm(double value)
 		{
-			if (value > Value)
+			if (Program.cumulus.NormalRunning)
 			{
-				doUpTriggered(true);
-				doDownTriggered(false);
-			}
-			else if (value < Value)
-			{
-				doUpTriggered(false);
-				doDownTriggered(true);
-			}
-			else
-			{
-				doUpTriggered(false);
-				doDownTriggered(false);
+
+				if (value > Value)
+				{
+					doUpTriggered(true);
+					doDownTriggered(false);
+				}
+				else if (value < -Value)
+				{
+					doUpTriggered(false);
+					doDownTriggered(true);
+				}
+				else
+				{
+					doUpTriggered(false);
+					doDownTriggered(false);
+				}
 			}
 		}
 

--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -11,6 +11,7 @@ namespace CumulusMX
 	{
 		public Cumulus cumulus { get; set; }
 
+		public string Name { get; }
 		public bool Enabled { get; set; }
 		public double Value { get; set; }
 		public bool Sound { get; set; }
@@ -20,75 +21,11 @@ namespace CumulusMX
 			get => triggered;
 			set
 			{
-				if (value)
-				{
-					triggerCount++;
-					TriggeredTime = DateTime.Now;
-
-					// do we have a threshold value
-					if (triggerCount >= TriggerThreshold)
-					{
-						// If we were not set before, so we need to send an email?
-						if (!triggered && Enabled)
-						{
-							if (Email && cumulus.SmtpOptions.Enabled)
-							{
-								// Construct the message - preamble, plus values
-								var msg = cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsg, Value, Units);
-								if (!string.IsNullOrEmpty(LastError))
-								{
-									msg += "\r\nLast error: " + LastError;
-								}
-								cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
-							}
-
-							if (!string.IsNullOrEmpty(Action))
-							{
-								try
-								{
-									// Prepare the process to run
-									ProcessStartInfo start = new ProcessStartInfo();
-									// Enter in the command line arguments
-									start.Arguments = ActionParams;
-									// Enter the executable to run, including the complete path
-									start.FileName = Action;
-									// Don"t show a console window
-									start.CreateNoWindow = true;
-									// Run the external process
-									Process.Start(start);
-								}
-								catch (Exception ex)
-								{
-									cumulus.LogMessage($"Alarm: Error executing external program '{Action}': {ex.Message}");
-								}
-							}
-						}
-						// If we get a new trigger, record the time
-						triggered = true;
-					}
-				}
-				else
-				{
-					// If the trigger is cleared, check if we should be latching the value
-					if (Latch)
-					{
-						if (DateTime.Now > TriggeredTime.AddHours(LatchHours))
-						{
-							// We are latching, but the latch period has expired, clear the trigger
-							triggered = false;
-							triggerCount = 0;
-						}
-					}
-					else
-					{
-						// No latch, just clear the trigger
-						triggered = false;
-						triggerCount = 0;
-					}
-				}
+				doTriggered(value);
 			}
 		}
-		public DateTime TriggeredTime { get; set; }
+
+		public DateTime TriggeredTime { get => triggeredTime; }
 		public bool Notify { get; set; }
 		public bool Email { get; set; }
 		public string Action { get; set; }
@@ -99,27 +36,48 @@ namespace CumulusMX
 		public string Units { get; set; }
 		public string LastError { get; set; }
 		public int TriggerThreshold { get; set; }
+
+		AlarmTypes type;
 		bool triggered;
 		int triggerCount = 0;
-}
+		DateTime triggeredTime;
 
-	public class AlarmChange : Alarm
-	{
-		bool upTriggered;
-		public bool UpTriggered
+		public Alarm(string AlarmName, AlarmTypes AlarmType)
 		{
-			get => upTriggered;
-			set
+			Name = AlarmName;
+			type = AlarmType;
+		}
+
+		public void CheckAlarm(double value)
+		{
+			doTriggered((type == AlarmTypes.Above && value > Value) || (type == AlarmTypes.Below && value < Value));
+		}
+
+		private void doTriggered(bool value)
+		{
+			if (value)
 			{
-				if (value)
+				triggerCount++;
+				triggeredTime = DateTime.Now;
+
+				// do we have a threshold value
+				if (triggerCount >= TriggerThreshold)
 				{
-					// If we were not set before, so we need to send an email etc?
-					if (!upTriggered && Enabled)
-					{ 
+					// If we were not set before, so we need to send an email?
+					if (!triggered && Enabled)
+					{
+						cumulus.LogMessage($"Alarm ({Name}): Triggered");
+
 						if (Email && cumulus.SmtpOptions.Enabled)
 						{
+							cumulus.LogMessage($"Alarm ({Name}): Sending email");
+
 							// Construct the message - preamble, plus values
-							var msg = Program.cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsgUp, Value, Units);
+							var msg = cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsg, Value, Units);
+							if (!string.IsNullOrEmpty(LastError))
+							{
+								msg += "\r\nLast error: " + LastError;
+							}
 							cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
 						}
 
@@ -127,6 +85,7 @@ namespace CumulusMX
 						{
 							try
 							{
+								cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {ActionParams}");
 								// Prepare the process to run
 								ProcessStartInfo start = new ProcessStartInfo();
 								// Enter in the command line arguments
@@ -140,32 +99,53 @@ namespace CumulusMX
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogMessage($"Alarm: Error executing external program '{Action}': {ex.Message}");
+								cumulus.LogMessage($"Alarm ({Name}): Error executing external program '{Action}': {ex.Message}");
 							}
 						}
 					}
 
-					// If we get a new trigger, record the time
-					upTriggered = true;
-					UpTriggeredTime = DateTime.Now;
+					// record the state
+					triggered = true;
+				}
+			}
+			else if (triggered)
+			{
+				// If the trigger is cleared, check if we should be latching the value
+				if (Latch)
+				{
+					if (DateTime.Now > TriggeredTime.AddHours(LatchHours))
+					{
+						// We are latching, but the latch period has expired, clear the trigger
+						triggered = false;
+						triggerCount = 0;
+						cumulus.LogMessage($"Alarm ({Name}): Trigger cleared");
+					}
 				}
 				else
 				{
-					// If the trigger is cleared, check if we should be latching the value
-					if (Latch)
-					{
-						if (DateTime.Now > UpTriggeredTime.AddHours(LatchHours))
-						{
-							// We are latching, but the latch period has expired, clear the trigger
-							upTriggered = false;
-						}
-					}
-					else
-					{
-						// No latch, just clear the trigger
-						upTriggered = false;
-					}
+					// No latch, just clear the trigger
+					triggered = false;
+					triggerCount = 0;
+					cumulus.LogMessage($"Alarm ({Name}): Trigger cleared");
 				}
+			}
+		}
+	}
+
+
+	public class AlarmChange : Alarm
+	{
+		public AlarmChange(string AlarmName) : base(AlarmName, AlarmTypes.Change)
+		{
+		}
+
+		bool upTriggered;
+		public bool UpTriggered
+		{
+			get => upTriggered;
+			set
+			{
+				doUpTriggered(value);
 			}
 		}
 		public DateTime UpTriggeredTime { get; set; }
@@ -177,67 +157,172 @@ namespace CumulusMX
 			get => downTriggered;
 			set
 			{
-				if (value)
-				{
-					// If we were not set before, so we need to send an email?
-					if (!downTriggered && Enabled)
-					{
-						if (Email && cumulus.SmtpOptions.Enabled)
-						{
-							// Construct the message - preamble, plus values
-							var msg = Program.cumulus.AlarmEmailPreamble + "\n" + string.Format(EmailMsgDn, Value, Units);
-							cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
-						}
+				doDownTriggered(value);
+			}
+		}
 
-						if (!string.IsNullOrEmpty(Action))
-						{
-							try
-							{
-								// Prepare the process to run
-								ProcessStartInfo start = new ProcessStartInfo();
-								// Enter in the command line arguments
-								start.Arguments = ActionParams;
-								// Enter the executable to run, including the complete path
-								start.FileName = Action;
-								// Don"t show a console window
-								start.CreateNoWindow = true;
-								// Run the external process
-								Process.Start(start);
-							}
-							catch (Exception ex)
-							{
-								cumulus.LogMessage($"Alarm: Error executing external program '{Action}': {ex.Message}");
-							}
-						}
+
+		public DateTime DownTriggeredTime { get; set; }
+
+		public void CheckAlarm(double value)
+		{
+			if (value > Value)
+			{
+				doUpTriggered(true);
+				doDownTriggered(false);
+			}
+			else if (value < Value)
+			{
+				doUpTriggered(false);
+				doDownTriggered(true);
+			}
+			else
+			{
+				doUpTriggered(false);
+				doDownTriggered(false);
+			}
+		}
+
+		private void doUpTriggered(bool value)
+		{
+			if (value)
+			{
+				// If we were not set before, so we need to send an email etc?
+				if (!upTriggered && Enabled)
+				{
+					cumulus.LogMessage($"Alarm ({Name}): Up triggered");
+
+					if (Email && cumulus.SmtpOptions.Enabled)
+					{
+						cumulus.LogMessage($"Alarm ({Name}): Sending email");
+
+						// Construct the message - preamble, plus values
+						var msg = Program.cumulus.AlarmEmailPreamble + "\r\n" + string.Format(EmailMsgUp, Value, Units);
+						cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
 					}
 
-					// If we get a new trigger, record the time
-					downTriggered = true;
-					DownTriggeredTime = DateTime.Now;
+					if (!string.IsNullOrEmpty(Action))
+					{
+						try
+						{
+							cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {ActionParams}");
+							// Prepare the process to run
+							ProcessStartInfo start = new ProcessStartInfo();
+							// Enter in the command line arguments
+							start.Arguments = ActionParams;
+							// Enter the executable to run, including the complete path
+							start.FileName = Action;
+							// Don"t show a console window
+							start.CreateNoWindow = true;
+							// Run the external process
+							Process.Start(start);
+						}
+						catch (Exception ex)
+						{
+							cumulus.LogMessage($"Alarm: Error executing external program '{Action}': {ex.Message}");
+						}
+					}
+				}
+
+				// If we get a new trigger, record the time
+				upTriggered = true;
+				UpTriggeredTime = DateTime.Now;
+			}
+			else if (upTriggered)
+			{
+				// If the trigger is cleared, check if we should be latching the value
+				if (Latch)
+				{
+					if (DateTime.Now > UpTriggeredTime.AddHours(LatchHours))
+					{
+						// We are latching, but the latch period has expired, clear the trigger
+						upTriggered = false;
+						cumulus.LogMessage($"Alarm ({Name}): Up trigger cleared");
+					}
 				}
 				else
 				{
-					// If the trigger is cleared, check if we should be latching the value
-					if (Latch)
-					{
-						if (DateTime.Now > DownTriggeredTime.AddHours(LatchHours))
-						{
-							// We are latching, but the latch period has expired, clear the trigger
-							downTriggered = false;
-						}
-					}
-					else
-					{
-						// No latch, just clear the trigger
-						downTriggered = false;
-					}
+					// No latch, just clear the trigger
+					upTriggered = false;
+					cumulus.LogMessage($"Alarm ({Name}): Up trigger cleared");
 				}
 			}
 		}
 
-		public DateTime DownTriggeredTime { get; set; }
+		private void doDownTriggered(bool value)
+		{
+			if (value)
+			{
+				// If we were not set before, so we need to send an email?
+				if (!downTriggered && Enabled)
+				{
+					cumulus.LogMessage($"Alarm ({Name}): Down triggered");
+
+					if (Email && cumulus.SmtpOptions.Enabled)
+					{
+						cumulus.LogMessage($"Alarm ({Name}): Sending email");
+						// Construct the message - preamble, plus values
+						var msg = Program.cumulus.AlarmEmailPreamble + "\n" + string.Format(EmailMsgDn, Value, Units);
+						cumulus.emailer.SendEmail(cumulus.AlarmDestEmail, cumulus.AlarmFromEmail, cumulus.AlarmEmailSubject, msg, cumulus.AlarmEmailHtml);
+					}
+
+					if (!string.IsNullOrEmpty(Action))
+					{
+						try
+						{
+							cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {ActionParams}");
+							// Prepare the process to run
+							ProcessStartInfo start = new ProcessStartInfo();
+							// Enter in the command line arguments
+							start.Arguments = ActionParams;
+							// Enter the executable to run, including the complete path
+							start.FileName = Action;
+							// Don"t show a console window
+							start.CreateNoWindow = true;
+							// Run the external process
+							Process.Start(start);
+						}
+						catch (Exception ex)
+						{
+							cumulus.LogMessage($"Alarm: Error executing external program '{Action}': {ex.Message}");
+						}
+					}
+				}
+
+				// If we get a new trigger, record the time
+				downTriggered = true;
+				DownTriggeredTime = DateTime.Now;
+			}
+			else if (downTriggered)
+			{
+				// If the trigger is cleared, check if we should be latching the value
+				if (Latch)
+				{
+					if (DateTime.Now > DownTriggeredTime.AddHours(LatchHours))
+					{
+						// We are latching, but the latch period has expired, clear the trigger
+						downTriggered = false;
+						cumulus.LogMessage($"Alarm ({Name}): Down trigger cleared");
+					}
+				}
+				else
+				{
+					// No latch, just clear the trigger
+					downTriggered = false;
+					cumulus.LogMessage($"Alarm ({Name}): Down trigger cleared");
+				}
+			}
+		}
 
 		public string EmailMsgUp { get; set; }
 		public string EmailMsgDn { get; set; }
+	}
+
+	public enum AlarmTypes
+	{
+		Above,
+		Below,
+		Change,
+		Trigger
 	}
 }

--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -94,7 +94,7 @@ namespace CumulusMX
 		public string Action { get; set; }
 		public string ActionParams { get; set; }
 		public bool Latch { get; set; }
-		public int LatchHours { get; set; }
+		public double LatchHours { get; set; }
 		public string EmailMsg { get; set; }
 		public string Units { get; set; }
 		public string LastError { get; set; }

--- a/CumulusMX/AlarmSettings.cs
+++ b/CumulusMX/AlarmSettings.cs
@@ -38,7 +38,9 @@ namespace CumulusMX
 					Notify = cumulus.LowTempAlarm.Notify,
 					Email = cumulus.LowTempAlarm.Email,
 					Latches = cumulus.LowTempAlarm.Latch,
-					LatchHrs = cumulus.LowTempAlarm.LatchHours
+					LatchHrs = cumulus.LowTempAlarm.LatchHours,
+					Action = cumulus.LowTempAlarm.Action,
+					ActionParams = cumulus.LowTempAlarm.ActionParams
 				},
 				tempAbove = new JsonAlarmValues()
 				{
@@ -49,7 +51,9 @@ namespace CumulusMX
 					Notify = cumulus.HighTempAlarm.Notify,
 					Email = cumulus.HighTempAlarm.Email,
 					Latches = cumulus.HighTempAlarm.Latch,
-					LatchHrs = cumulus.HighTempAlarm.LatchHours
+					LatchHrs = cumulus.HighTempAlarm.LatchHours,
+					Action = cumulus.HighTempAlarm.Action,
+					ActionParams = cumulus.HighTempAlarm.ActionParams
 				},
 				tempChange = new JsonAlarmValues()
 				{
@@ -60,7 +64,9 @@ namespace CumulusMX
 					Notify = cumulus.TempChangeAlarm.Notify,
 					Email = cumulus.TempChangeAlarm.Email,
 					Latches = cumulus.TempChangeAlarm.Latch,
-					LatchHrs = cumulus.TempChangeAlarm.LatchHours
+					LatchHrs = cumulus.TempChangeAlarm.LatchHours,
+					Action = cumulus.TempChangeAlarm.Action,
+					ActionParams = cumulus.TempChangeAlarm.ActionParams
 				},
 				pressBelow = new JsonAlarmValues()
 				{
@@ -71,7 +77,9 @@ namespace CumulusMX
 					Notify = cumulus.LowPressAlarm.Notify,
 					Email = cumulus.LowPressAlarm.Email,
 					Latches = cumulus.LowPressAlarm.Latch,
-					LatchHrs = cumulus.LowPressAlarm.LatchHours
+					LatchHrs = cumulus.LowPressAlarm.LatchHours,
+					Action = cumulus.LowPressAlarm.Action,
+					ActionParams = cumulus.LowPressAlarm.ActionParams
 				},
 				pressAbove = new JsonAlarmValues()
 				{
@@ -82,7 +90,9 @@ namespace CumulusMX
 					Notify = cumulus.HighPressAlarm.Notify,
 					Email = cumulus.HighPressAlarm.Email,
 					Latches = cumulus.HighPressAlarm.Latch,
-					LatchHrs = cumulus.HighPressAlarm.LatchHours
+					LatchHrs = cumulus.HighPressAlarm.LatchHours,
+					Action = cumulus.HighPressAlarm.Action,
+					ActionParams = cumulus.HighPressAlarm.ActionParams
 				},
 				pressChange = new JsonAlarmValues()
 				{
@@ -93,7 +103,9 @@ namespace CumulusMX
 					Notify = cumulus.PressChangeAlarm.Notify,
 					Email = cumulus.PressChangeAlarm.Email,
 					Latches = cumulus.PressChangeAlarm.Latch,
-					LatchHrs = cumulus.PressChangeAlarm.LatchHours
+					LatchHrs = cumulus.PressChangeAlarm.LatchHours,
+					Action = cumulus.PressChangeAlarm.Action,
+					ActionParams = cumulus.PressChangeAlarm.ActionParams
 				},
 				rainAbove = new JsonAlarmValues()
 				{
@@ -104,7 +116,9 @@ namespace CumulusMX
 					Notify = cumulus.HighRainTodayAlarm.Notify,
 					Email = cumulus.HighRainTodayAlarm.Email,
 					Latches = cumulus.HighRainTodayAlarm.Latch,
-					LatchHrs = cumulus.HighRainTodayAlarm.LatchHours
+					LatchHrs = cumulus.HighRainTodayAlarm.LatchHours,
+					Action = cumulus.HighRainTodayAlarm.Action,
+					ActionParams = cumulus.HighRainTodayAlarm.ActionParams
 				},
 				rainRateAbove = new JsonAlarmValues()
 				{
@@ -115,7 +129,9 @@ namespace CumulusMX
 					Notify = cumulus.HighRainRateAlarm.Notify,
 					Email = cumulus.HighRainRateAlarm.Email,
 					Latches = cumulus.HighRainRateAlarm.Latch,
-					LatchHrs = cumulus.HighRainRateAlarm.LatchHours
+					LatchHrs = cumulus.HighRainRateAlarm.LatchHours,
+					Action = cumulus.HighRainRateAlarm.Action,
+					ActionParams = cumulus.HighRainRateAlarm.ActionParams
 				},
 				isRaining = new JsonAlarmValues()
 				{
@@ -126,7 +142,9 @@ namespace CumulusMX
 					Email = cumulus.IsRainingAlarm.Email,
 					Latches = cumulus.IsRainingAlarm.Latch,
 					LatchHrs = cumulus.IsRainingAlarm.LatchHours,
-					Threshold = cumulus.IsRainingAlarm.TriggerThreshold
+					Threshold = cumulus.IsRainingAlarm.TriggerThreshold,
+					Action = cumulus.IsRainingAlarm.Action,
+					ActionParams = cumulus.IsRainingAlarm.ActionParams
 				},
 				gustAbove = new JsonAlarmValues()
 				{
@@ -137,7 +155,9 @@ namespace CumulusMX
 					Notify = cumulus.HighGustAlarm.Notify,
 					Email = cumulus.HighGustAlarm.Email,
 					Latches = cumulus.HighGustAlarm.Latch,
-					LatchHrs = cumulus.HighGustAlarm.LatchHours
+					LatchHrs = cumulus.HighGustAlarm.LatchHours,
+					Action = cumulus.HighGustAlarm.Action,
+					ActionParams = cumulus.HighGustAlarm.ActionParams
 				},
 				windAbove = new JsonAlarmValues()
 				{
@@ -148,7 +168,9 @@ namespace CumulusMX
 					Notify = cumulus.HighWindAlarm.Notify,
 					Email = cumulus.HighWindAlarm.Email,
 					Latches = cumulus.HighWindAlarm.Latch,
-					LatchHrs = cumulus.HighWindAlarm.LatchHours
+					LatchHrs = cumulus.HighWindAlarm.LatchHours,
+					Action = cumulus.HighWindAlarm.Action,
+					ActionParams = cumulus.HighWindAlarm.ActionParams
 				},
 				contactLost = new JsonAlarmValues()
 				{
@@ -159,7 +181,9 @@ namespace CumulusMX
 					Email = cumulus.SensorAlarm.Email,
 					Latches = cumulus.SensorAlarm.Latch,
 					LatchHrs = cumulus.SensorAlarm.LatchHours,
-					Threshold = cumulus.SensorAlarm.TriggerThreshold
+					Threshold = cumulus.SensorAlarm.TriggerThreshold,
+					Action = cumulus.SensorAlarm.Action,
+					ActionParams = cumulus.SensorAlarm.ActionParams
 				},
 				dataStopped = new JsonAlarmValues()
 				{
@@ -170,7 +194,9 @@ namespace CumulusMX
 					Email = cumulus.DataStoppedAlarm.Email,
 					Latches = cumulus.DataStoppedAlarm.Latch,
 					LatchHrs = cumulus.DataStoppedAlarm.LatchHours,
-					Threshold = cumulus.DataStoppedAlarm.TriggerThreshold
+					Threshold = cumulus.DataStoppedAlarm.TriggerThreshold,
+					Action = cumulus.DataStoppedAlarm.Action,
+					ActionParams = cumulus.DataStoppedAlarm.ActionParams
 				},
 				batteryLow = new JsonAlarmValues()
 				{
@@ -181,7 +207,9 @@ namespace CumulusMX
 					Email = cumulus.BatteryLowAlarm.Email,
 					Latches = cumulus.BatteryLowAlarm.Latch,
 					LatchHrs = cumulus.BatteryLowAlarm.LatchHours,
-					Threshold = cumulus.BatteryLowAlarm.TriggerThreshold
+					Threshold = cumulus.BatteryLowAlarm.TriggerThreshold,
+					Action = cumulus.BatteryLowAlarm.Action,
+					ActionParams = cumulus.BatteryLowAlarm.ActionParams
 				},
 				spike = new JsonAlarmValues()
 				{
@@ -192,7 +220,9 @@ namespace CumulusMX
 					Email = cumulus.SpikeAlarm.Email,
 					Latches = cumulus.SpikeAlarm.Latch,
 					LatchHrs = cumulus.SpikeAlarm.LatchHours,
-					Threshold = cumulus.SpikeAlarm.TriggerThreshold
+					Threshold = cumulus.SpikeAlarm.TriggerThreshold,
+					Action = cumulus.SpikeAlarm.Action,
+					ActionParams = cumulus.SpikeAlarm.ActionParams
 				},
 				upgrade = new JsonAlarmValues()
 				{
@@ -202,7 +232,9 @@ namespace CumulusMX
 					Notify = cumulus.UpgradeAlarm.Notify,
 					Email = cumulus.UpgradeAlarm.Email,
 					Latches = cumulus.UpgradeAlarm.Latch,
-					LatchHrs = cumulus.UpgradeAlarm.LatchHours
+					LatchHrs = cumulus.UpgradeAlarm.LatchHours,
+					Action = cumulus.UpgradeAlarm.Action,
+					ActionParams = cumulus.UpgradeAlarm.ActionParams
 				},
 				httpUpload = new JsonAlarmValues()
 				{
@@ -213,7 +245,9 @@ namespace CumulusMX
 					Email = cumulus.HttpUploadAlarm.Email,
 					Latches = cumulus.HttpUploadAlarm.Latch,
 					LatchHrs = cumulus.HttpUploadAlarm.LatchHours,
-					Threshold = cumulus.HttpUploadAlarm.TriggerThreshold
+					Threshold = cumulus.HttpUploadAlarm.TriggerThreshold,
+					Action = cumulus.HttpUploadAlarm.Action,
+					ActionParams = cumulus.HttpUploadAlarm.ActionParams
 				},
 				mySqlUpload = new JsonAlarmValues()
 				{
@@ -224,7 +258,9 @@ namespace CumulusMX
 					Email = cumulus.MySqlUploadAlarm.Email,
 					Latches = cumulus.MySqlUploadAlarm.Latch,
 					LatchHrs = cumulus.MySqlUploadAlarm.LatchHours,
-					Threshold = cumulus.MySqlUploadAlarm.TriggerThreshold
+					Threshold = cumulus.MySqlUploadAlarm.TriggerThreshold,
+					Action = cumulus.MySqlUploadAlarm.Action,
+					ActionParams = cumulus.MySqlUploadAlarm.ActionParams
 				}
 			};
 
@@ -290,6 +326,8 @@ namespace CumulusMX
 				cumulus.LowTempAlarm.Latch = settings.tempBelow.Latches;
 				cumulus.LowTempAlarm.LatchHours = settings.tempBelow.LatchHrs;
 				emailRequired = cumulus.LowTempAlarm.Email && cumulus.LowTempAlarm.Enabled;
+				cumulus.LowTempAlarm.Action = settings.tempBelow.Action;
+				cumulus.LowTempAlarm.ActionParams = settings.tempBelow.ActionParams;
 
 				cumulus.HighTempAlarm.Enabled = settings.tempAbove.Enabled;
 				cumulus.HighTempAlarm.Value = settings.tempAbove.Val;
@@ -300,6 +338,8 @@ namespace CumulusMX
 				cumulus.HighTempAlarm.Latch = settings.tempAbove.Latches;
 				cumulus.HighTempAlarm.LatchHours = settings.tempAbove.LatchHrs;
 				emailRequired = emailRequired || (cumulus.HighTempAlarm.Email && cumulus.HighTempAlarm.Enabled);
+				cumulus.HighTempAlarm.Action = settings.tempAbove.Action;
+				cumulus.HighTempAlarm.ActionParams = settings.tempAbove.ActionParams;
 
 				cumulus.TempChangeAlarm.Enabled = settings.tempChange.Enabled;
 				cumulus.TempChangeAlarm.Value = settings.tempChange.Val;
@@ -310,6 +350,8 @@ namespace CumulusMX
 				cumulus.TempChangeAlarm.Latch = settings.tempChange.Latches;
 				cumulus.TempChangeAlarm.LatchHours = settings.tempChange.LatchHrs;
 				emailRequired = emailRequired || (cumulus.TempChangeAlarm.Email && cumulus.TempChangeAlarm.Enabled);
+				cumulus.TempChangeAlarm.Action = settings.tempChange.Action;
+				cumulus.TempChangeAlarm.ActionParams = settings.tempChange.ActionParams;
 
 				cumulus.LowPressAlarm.Enabled = settings.pressBelow.Enabled;
 				cumulus.LowPressAlarm.Value = settings.pressBelow.Val;
@@ -320,6 +362,8 @@ namespace CumulusMX
 				cumulus.LowPressAlarm.Latch = settings.pressBelow.Latches;
 				cumulus.LowPressAlarm.LatchHours = settings.pressBelow.LatchHrs;
 				emailRequired = emailRequired || (cumulus.LowPressAlarm.Email && cumulus.LowPressAlarm.Enabled);
+				cumulus.LowPressAlarm.Action = settings.pressBelow.Action;
+				cumulus.LowPressAlarm.ActionParams = settings.pressBelow.ActionParams;
 
 				cumulus.HighPressAlarm.Enabled = settings.pressAbove.Enabled;
 				cumulus.HighPressAlarm.Value = settings.pressAbove.Val;
@@ -330,6 +374,8 @@ namespace CumulusMX
 				cumulus.HighPressAlarm.Latch = settings.pressAbove.Latches;
 				cumulus.HighPressAlarm.LatchHours = settings.pressAbove.LatchHrs;
 				emailRequired = emailRequired || (cumulus.HighPressAlarm.Email && cumulus.HighPressAlarm.Enabled);
+				cumulus.HighPressAlarm.Action = settings.pressAbove.Action;
+				cumulus.HighPressAlarm.ActionParams = settings.pressAbove.ActionParams;
 
 				cumulus.PressChangeAlarm.Enabled = settings.pressChange.Enabled;
 				cumulus.PressChangeAlarm.Value = settings.pressChange.Val;
@@ -340,6 +386,8 @@ namespace CumulusMX
 				cumulus.PressChangeAlarm.Latch = settings.pressChange.Latches;
 				cumulus.PressChangeAlarm.LatchHours = settings.pressChange.LatchHrs;
 				emailRequired = emailRequired || (cumulus.PressChangeAlarm.Email && cumulus.PressChangeAlarm.Enabled);
+				cumulus.PressChangeAlarm.Action = settings.pressChange.Action;
+				cumulus.PressChangeAlarm.ActionParams = settings.pressChange.ActionParams;
 
 				cumulus.HighRainTodayAlarm.Enabled = settings.rainAbove.Enabled;
 				cumulus.HighRainTodayAlarm.Value = settings.rainAbove.Val;
@@ -350,6 +398,8 @@ namespace CumulusMX
 				cumulus.HighRainTodayAlarm.Latch = settings.rainAbove.Latches;
 				cumulus.HighRainTodayAlarm.LatchHours = settings.rainAbove.LatchHrs;
 				emailRequired = emailRequired || (cumulus.HighRainTodayAlarm.Email && cumulus.HighRainTodayAlarm.Enabled);
+				cumulus.HighRainTodayAlarm.Action = settings.rainAbove.Action;
+				cumulus.HighRainTodayAlarm.ActionParams = settings.rainAbove.ActionParams;
 
 				cumulus.HighRainRateAlarm.Enabled = settings.rainRateAbove.Enabled;
 				cumulus.HighRainRateAlarm.Value = settings.rainRateAbove.Val;
@@ -360,6 +410,8 @@ namespace CumulusMX
 				cumulus.HighRainRateAlarm.Latch = settings.rainRateAbove.Latches;
 				cumulus.HighRainRateAlarm.LatchHours = settings.rainRateAbove.LatchHrs;
 				emailRequired = emailRequired || (cumulus.HighRainRateAlarm.Email && cumulus.HighRainRateAlarm.Enabled);
+				cumulus.HighRainRateAlarm.Action = settings.rainRateAbove.Action;
+				cumulus.HighRainRateAlarm.ActionParams = settings.rainRateAbove.ActionParams;
 
 				cumulus.IsRainingAlarm.Enabled = settings.isRaining.Enabled;
 				cumulus.IsRainingAlarm.Sound = settings.isRaining.SoundEnabled;
@@ -369,6 +421,8 @@ namespace CumulusMX
 				cumulus.IsRainingAlarm.Latch = settings.isRaining.Latches;
 				cumulus.IsRainingAlarm.LatchHours = settings.isRaining.LatchHrs;
 				emailRequired = emailRequired || (cumulus.IsRainingAlarm.Email && cumulus.IsRainingAlarm.Enabled);
+				cumulus.IsRainingAlarm.Action = settings.isRaining.Action;
+				cumulus.IsRainingAlarm.ActionParams = settings.isRaining.ActionParams;
 
 				cumulus.HighGustAlarm.Enabled = settings.gustAbove.Enabled;
 				cumulus.HighGustAlarm.Value = settings.gustAbove.Val;
@@ -379,6 +433,8 @@ namespace CumulusMX
 				cumulus.HighGustAlarm.Latch = settings.gustAbove.Latches;
 				cumulus.HighGustAlarm.LatchHours = settings.gustAbove.LatchHrs;
 				emailRequired = emailRequired || (cumulus.HighGustAlarm.Email && cumulus.HighGustAlarm.Enabled);
+				cumulus.HighGustAlarm.Action = settings.gustAbove.Action;
+				cumulus.HighGustAlarm.ActionParams = settings.gustAbove.ActionParams;
 
 				cumulus.HighWindAlarm.Enabled = settings.windAbove.Enabled;
 				cumulus.HighWindAlarm.Value = settings.windAbove.Val;
@@ -389,6 +445,8 @@ namespace CumulusMX
 				cumulus.HighWindAlarm.Latch = settings.windAbove.Latches;
 				cumulus.HighWindAlarm.LatchHours = settings.windAbove.LatchHrs;
 				emailRequired = emailRequired || (cumulus.HighWindAlarm.Email && cumulus.HighWindAlarm.Enabled);
+				cumulus.HighWindAlarm.Action = settings.windAbove.Action;
+				cumulus.HighWindAlarm.ActionParams = settings.windAbove.ActionParams;
 
 				cumulus.SensorAlarm.Enabled = settings.contactLost.Enabled;
 				cumulus.SensorAlarm.Sound = settings.contactLost.SoundEnabled;
@@ -399,6 +457,8 @@ namespace CumulusMX
 				cumulus.SensorAlarm.LatchHours = settings.contactLost.LatchHrs;
 				cumulus.SensorAlarm.TriggerThreshold = settings.contactLost.Threshold;
 				emailRequired = emailRequired || (cumulus.SensorAlarm.Email && cumulus.SensorAlarm.Enabled);
+				cumulus.SensorAlarm.Action = settings.contactLost.Action;
+				cumulus.SensorAlarm.ActionParams = settings.contactLost.ActionParams;
 
 				cumulus.DataStoppedAlarm.Enabled = settings.dataStopped.Enabled;
 				cumulus.DataStoppedAlarm.Sound = settings.dataStopped.SoundEnabled;
@@ -409,6 +469,8 @@ namespace CumulusMX
 				cumulus.DataStoppedAlarm.LatchHours = settings.dataStopped.LatchHrs;
 				cumulus.DataStoppedAlarm.TriggerThreshold = settings.dataStopped.Threshold;
 				emailRequired = emailRequired || (cumulus.DataStoppedAlarm.Email && cumulus.DataStoppedAlarm.Enabled);
+				cumulus.DataStoppedAlarm.Action = settings.dataStopped.Action;
+				cumulus.DataStoppedAlarm.ActionParams = settings.dataStopped.ActionParams;
 
 				cumulus.BatteryLowAlarm.Enabled = settings.batteryLow.Enabled;
 				cumulus.BatteryLowAlarm.Sound = settings.batteryLow.SoundEnabled;
@@ -419,6 +481,8 @@ namespace CumulusMX
 				cumulus.BatteryLowAlarm.LatchHours = settings.batteryLow.LatchHrs;
 				cumulus.BatteryLowAlarm.TriggerThreshold = settings.batteryLow.Threshold;
 				emailRequired = emailRequired || (cumulus.BatteryLowAlarm.Email && cumulus.BatteryLowAlarm.Enabled);
+				cumulus.BatteryLowAlarm.Action = settings.batteryLow.Action;
+				cumulus.BatteryLowAlarm.ActionParams = settings.batteryLow.ActionParams;
 
 				cumulus.SpikeAlarm.Enabled = settings.spike.Enabled;
 				cumulus.SpikeAlarm.Sound = settings.spike.SoundEnabled;
@@ -429,6 +493,8 @@ namespace CumulusMX
 				cumulus.SpikeAlarm.LatchHours = settings.spike.LatchHrs;
 				cumulus.SpikeAlarm.TriggerThreshold = settings.spike.Threshold;
 				emailRequired = emailRequired || (cumulus.SpikeAlarm.Email && cumulus.SpikeAlarm.Enabled);
+				cumulus.SpikeAlarm.Action = settings.spike.Action;
+				cumulus.SpikeAlarm.ActionParams = settings.spike.ActionParams;
 
 				cumulus.UpgradeAlarm.Enabled = settings.upgrade.Enabled;
 				cumulus.UpgradeAlarm.Sound = settings.upgrade.SoundEnabled;
@@ -438,6 +504,8 @@ namespace CumulusMX
 				cumulus.UpgradeAlarm.Latch = settings.upgrade.Latches;
 				cumulus.UpgradeAlarm.LatchHours = settings.upgrade.LatchHrs;
 				emailRequired = emailRequired || (cumulus.UpgradeAlarm.Email && cumulus.UpgradeAlarm.Enabled);
+				cumulus.UpgradeAlarm.Action = settings.upgrade.Action;
+				cumulus.UpgradeAlarm.ActionParams = settings.upgrade.ActionParams;
 
 				cumulus.HttpUploadAlarm.Enabled = settings.httpUpload.Enabled;
 				cumulus.HttpUploadAlarm.Sound = settings.httpUpload.SoundEnabled;
@@ -448,6 +516,8 @@ namespace CumulusMX
 				cumulus.HttpUploadAlarm.LatchHours = settings.httpUpload.LatchHrs;
 				cumulus.HttpUploadAlarm.TriggerThreshold = settings.httpUpload.Threshold;
 				emailRequired = emailRequired || (cumulus.HttpUploadAlarm.Email && cumulus.HttpUploadAlarm.Enabled);
+				cumulus.HttpUploadAlarm.Action = settings.httpUpload.Action;
+				cumulus.HttpUploadAlarm.ActionParams = settings.httpUpload.ActionParams;
 
 				cumulus.MySqlUploadAlarm.Enabled = settings.mySqlUpload.Enabled;
 				cumulus.MySqlUploadAlarm.Sound = settings.mySqlUpload.SoundEnabled;
@@ -458,6 +528,8 @@ namespace CumulusMX
 				cumulus.MySqlUploadAlarm.LatchHours = settings.mySqlUpload.LatchHrs;
 				cumulus.MySqlUploadAlarm.TriggerThreshold = settings.mySqlUpload.Threshold;
 				emailRequired = emailRequired || (cumulus.MySqlUploadAlarm.Email && cumulus.MySqlUploadAlarm.Enabled);
+				cumulus.MySqlUploadAlarm.Action = settings.mySqlUpload.Action;
+				cumulus.MySqlUploadAlarm.ActionParams = settings.mySqlUpload.ActionParams;
 
 				// validate the from email
 				if (emailRequired && !EmailSender.CheckEmailAddress(result.email.fromEmail.Trim()))
@@ -597,6 +669,8 @@ namespace CumulusMX
 		public bool Latches { get; set; }
 		public int LatchHrs { get; set; }
 		public int Threshold { get; set; }
+		public string Action { get; set; }
+		public string ActionParams { get; set; }
 	}
 
 	public class JsonAlarmEmail

--- a/CumulusMX/AlarmSettings.cs
+++ b/CumulusMX/AlarmSettings.cs
@@ -667,7 +667,7 @@ namespace CumulusMX
 		public bool Notify { get; set; }
 		public bool Email { get; set; }
 		public bool Latches { get; set; }
-		public int LatchHrs { get; set; }
+		public double LatchHrs { get; set; }
 		public int Threshold { get; set; }
 		public string Action { get; set; }
 		public string ActionParams { get; set; }

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -57,7 +57,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -65,7 +65,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{ 
 						switch (req)
 						{
@@ -132,7 +132,7 @@ namespace CumulusMX
 			{
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -140,7 +140,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						string res;
 						switch (req)
@@ -223,7 +223,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -240,7 +240,7 @@ namespace CumulusMX
 					int length = Convert.ToInt32(query["length"]);
 					string search = query["search[value]"];
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -287,7 +287,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -295,7 +295,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -326,13 +326,13 @@ namespace CumulusMX
 
 					if (Station == null)
 					{
-						using (var writer = HttpContext.OpenResponseText())
+						using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 							await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 						Response.StatusCode = 500;
 						return;
 					}
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -363,7 +363,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -371,7 +371,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -439,7 +439,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -447,7 +447,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -475,7 +475,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -483,7 +483,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -544,14 +544,14 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync("{}");
 					return;
 				}
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -590,7 +590,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -600,7 +600,7 @@ namespace CumulusMX
 				{
 					int month = Convert.ToInt32(mon);
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						if (month < 1 || month > 12)
 						{
@@ -645,7 +645,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -653,7 +653,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -692,14 +692,14 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync("{}");
 					return;
 				}
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -738,7 +738,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync("{}");
 					return;
 				}
@@ -750,7 +750,7 @@ namespace CumulusMX
 
 					var query = HttpUtility.ParseQueryString(Request.Url.Query);
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						if (query.AllKeys.Contains("startdate"))
 						{
@@ -843,7 +843,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -851,7 +851,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -897,7 +897,7 @@ namespace CumulusMX
 
 				if (Station == null)
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 						await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"500\",\"Description\":\"The station is not running\"}}");
 					Response.StatusCode = 500;
 					return;
@@ -905,7 +905,7 @@ namespace CumulusMX
 
 				try
 				{
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -1015,7 +1015,7 @@ namespace CumulusMX
 				{
 					Response.ContentType = "application/json";
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -1078,7 +1078,7 @@ namespace CumulusMX
 				{
 					Response.ContentType = "application/json";
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -1158,7 +1158,7 @@ namespace CumulusMX
 
 					Response.ContentType = "text/plain";
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 
 						if (!Int32.TryParse(query["year"], out year) || year < 2000 || year > 2050)
@@ -1205,7 +1205,7 @@ namespace CumulusMX
 					int month, year;
 					Response.ContentType = "text/plain";
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						if (!Int32.TryParse(query["year"], out year) || year < 2000 || year > 2050)
 						{
@@ -1236,7 +1236,7 @@ namespace CumulusMX
 				}
 				catch (Exception ex)
 				{
-					//using (var writer = HttpContext.OpenResponseText())
+					//using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					//	await writer.WriteAsync($"{{\"Title\":\"Unexpected Error\",\"ErrorCode\":\"{ex.GetType().Name}\",\"Description\":\"{ex.Message}\"}}");
 					Response.StatusCode = 500;
 					Program.cumulus.LogMessage($"api/genreports: Unexpected Error, ErrorCode: {ex.GetType().Name}, Description: \"{ex.Message}\"");
@@ -1254,7 +1254,7 @@ namespace CumulusMX
 				{
 					Response.ContentType = "application/json";
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 						switch (req)
 						{
@@ -1300,7 +1300,7 @@ namespace CumulusMX
 				{
 					Response.ContentType = "application/json";
 
-					using (var writer = HttpContext.OpenResponseText())
+					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
 
 						switch (req)

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -1425,7 +1425,6 @@ namespace CumulusMX
 				{
 					using (var writer = HttpContext.OpenResponseText(new UTF8Encoding(false)))
 					{
-						string res;
 						switch (req)
 						{
 							case "ftpnow.json":

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -1058,6 +1058,10 @@ namespace CumulusMX
 							case "wizard.json":
 								await writer.WriteAsync(wizard.GetAlpacaFormData());
 								break;
+							case "dateformat.txt":
+								Response.ContentType = "text/plain";
+								await writer.WriteAsync(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
+								break;
 							default:
 								Response.StatusCode = 404;
 								break;

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -142,6 +142,7 @@ namespace CumulusMX
 				{
 					using (var writer = HttpContext.OpenResponseText())
 					{
+						string res;
 						switch (req)
 						{
 							case "raintodayeditdata.json":
@@ -160,16 +161,36 @@ namespace CumulusMX
 								await writer.WriteAsync(dataEditor.EditCurrentCond(HttpContext));
 								break;
 							case "alltime":
-								await writer.WriteAsync(dataEditor.EditAllTimeRecs(HttpContext));
+								res = dataEditor.EditAllTimeRecs(HttpContext);
+								if (res != "Success")
+								{
+									Response.StatusCode = 500;
+								}
+								await writer.WriteAsync(res);
 								break;
 							case "monthly":
-								await writer.WriteAsync(dataEditor.EditMonthlyRecs(HttpContext));
+								res = dataEditor.EditMonthlyRecs(HttpContext);
+								if (res != "Success")
+								{
+									Response.StatusCode = 500;
+								}
+								await writer.WriteAsync(res);
 								break;
 							case "thismonth":
-								await writer.WriteAsync(dataEditor.EditThisMonthRecs(HttpContext));
+								res = dataEditor.EditThisMonthRecs(HttpContext);
+								if (res != "Success")
+								{
+									Response.StatusCode = 500;
+								}
+								await writer.WriteAsync(res);
 								break;
 							case "thisyear":
-								await writer.WriteAsync(dataEditor.EditThisYearRecs(HttpContext));
+								res = dataEditor.EditThisYearRecs(HttpContext);
+								if (res != "Success")
+								{
+									Response.StatusCode = 500;
+								}
+								await writer.WriteAsync(res);
 								break;
 							case "dayfile":
 								await writer.WriteAsync(dataEditor.EditDayFile(HttpContext));

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -245,7 +245,7 @@ namespace CumulusMX
 						switch (req)
 						{
 							case "dayfile":
-								await writer.WriteAsync(Station.GetDayfile(draw, start, length));
+								await writer.WriteAsync(Station.GetDayfile(draw, start, length, search));
 								break;
 							case "logfile":
 								//return await this.JsonResponseAsync(Station.GetLogfile(from, to, false));

--- a/CumulusMX/App.config
+++ b/CumulusMX/App.config
@@ -4,7 +4,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
   <runtime>
-	<GCConserveMemory enabled="6"/>
+	<GCConserveMemory enabled="6" />
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 		<dependentAssembly>
 			<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4632,6 +4632,8 @@ namespace CumulusMX
 			LowTempAlarm.Email = ini.GetValue("Alarms", "LowTempAlarmEmail", false);
 			LowTempAlarm.Latch = ini.GetValue("Alarms", "LowTempAlarmLatch", false);
 			LowTempAlarm.LatchHours = ini.GetValue("Alarms", "LowTempAlarmLatchHours", 24);
+			LowTempAlarm.Action = ini.GetValue("Alarms", "LowTempAlarmAction", "");
+			LowTempAlarm.ActionParams = ini.GetValue("Alarms", "LowTempAlarmActionParams", "");
 
 			HighTempAlarm.Value = ini.GetValue("Alarms", "alarmhightemp", 0.0);
 			HighTempAlarm.Enabled = ini.GetValue("Alarms", "HighTempAlarmSet", false);
@@ -4646,6 +4648,8 @@ namespace CumulusMX
 			HighTempAlarm.Email = ini.GetValue("Alarms", "HighTempAlarmEmail", false);
 			HighTempAlarm.Latch = ini.GetValue("Alarms", "HighTempAlarmLatch", false);
 			HighTempAlarm.LatchHours = ini.GetValue("Alarms", "HighTempAlarmLatchHours", 24);
+			HighTempAlarm.Action = ini.GetValue("Alarms", "HighTempAlarmAction", "");
+			HighTempAlarm.ActionParams = ini.GetValue("Alarms", "HighTempAlarmActionParams", "");
 
 			TempChangeAlarm.Value = ini.GetValue("Alarms", "alarmtempchange", 0.0);
 			TempChangeAlarm.Enabled = ini.GetValue("Alarms", "TempChangeAlarmSet", false);
@@ -4660,6 +4664,8 @@ namespace CumulusMX
 			TempChangeAlarm.Email = ini.GetValue("Alarms", "TempChangeAlarmEmail", false);
 			TempChangeAlarm.Latch = ini.GetValue("Alarms", "TempChangeAlarmLatch", false);
 			TempChangeAlarm.LatchHours = ini.GetValue("Alarms", "TempChangeAlarmLatchHours", 24);
+			TempChangeAlarm.Action = ini.GetValue("Alarms", "TempChangeAlarmAction", "");
+			TempChangeAlarm.ActionParams = ini.GetValue("Alarms", "TempChangeAlarmActionParams", "");
 
 			LowPressAlarm.Value = ini.GetValue("Alarms", "alarmlowpress", 0.0);
 			LowPressAlarm.Enabled = ini.GetValue("Alarms", "LowPressAlarmSet", false);
@@ -4674,6 +4680,8 @@ namespace CumulusMX
 			LowPressAlarm.Email = ini.GetValue("Alarms", "LowPressAlarmEmail", false);
 			LowPressAlarm.Latch = ini.GetValue("Alarms", "LowPressAlarmLatch", false);
 			LowPressAlarm.LatchHours = ini.GetValue("Alarms", "LowPressAlarmLatchHours", 24);
+			LowPressAlarm.Action = ini.GetValue("Alarms", "LowPressAlarmAction", "");
+			LowPressAlarm.ActionParams = ini.GetValue("Alarms", "LowPressAlarmActionParams", "");
 
 			HighPressAlarm.Value = ini.GetValue("Alarms", "alarmhighpress", 0.0);
 			HighPressAlarm.Enabled = ini.GetValue("Alarms", "HighPressAlarmSet", false);
@@ -4688,6 +4696,8 @@ namespace CumulusMX
 			HighPressAlarm.Email = ini.GetValue("Alarms", "HighPressAlarmEmail", false);
 			HighPressAlarm.Latch = ini.GetValue("Alarms", "HighPressAlarmLatch", false);
 			HighPressAlarm.LatchHours = ini.GetValue("Alarms", "HighPressAlarmLatchHours", 24);
+			HighPressAlarm.Action = ini.GetValue("Alarms", "HighPressAlarmAction", "");
+			HighPressAlarm.ActionParams = ini.GetValue("Alarms", "HighPressAlarmActionParams", "");
 
 			PressChangeAlarm.Value = ini.GetValue("Alarms", "alarmpresschange", 0.0);
 			PressChangeAlarm.Enabled = ini.GetValue("Alarms", "PressChangeAlarmSet", false);
@@ -4702,6 +4712,8 @@ namespace CumulusMX
 			PressChangeAlarm.Email = ini.GetValue("Alarms", "PressChangeAlarmEmail", false);
 			PressChangeAlarm.Latch = ini.GetValue("Alarms", "PressChangeAlarmLatch", false);
 			PressChangeAlarm.LatchHours = ini.GetValue("Alarms", "PressChangeAlarmLatchHours", 24);
+			PressChangeAlarm.Action = ini.GetValue("Alarms", "PressChangeAlarmAction", "");
+			PressChangeAlarm.ActionParams = ini.GetValue("Alarms", "PressChangeAlarmActionParams", "");
 
 			HighRainTodayAlarm.Value = ini.GetValue("Alarms", "alarmhighraintoday", 0.0);
 			HighRainTodayAlarm.Enabled = ini.GetValue("Alarms", "HighRainTodayAlarmSet", false);
@@ -4716,6 +4728,8 @@ namespace CumulusMX
 			HighRainTodayAlarm.Email = ini.GetValue("Alarms", "HighRainTodayAlarmEmail", false);
 			HighRainTodayAlarm.Latch = ini.GetValue("Alarms", "HighRainTodayAlarmLatch", false);
 			HighRainTodayAlarm.LatchHours = ini.GetValue("Alarms", "HighRainTodayAlarmLatchHours", 24);
+			HighRainTodayAlarm.Action = ini.GetValue("Alarms", "HighRainTodayAlarmAction", "");
+			HighRainTodayAlarm.ActionParams = ini.GetValue("Alarms", "HighRainTodayAlarmActionParams", "");
 
 			HighRainRateAlarm.Value = ini.GetValue("Alarms", "alarmhighrainrate", 0.0);
 			HighRainRateAlarm.Enabled = ini.GetValue("Alarms", "HighRainRateAlarmSet", false);
@@ -4730,6 +4744,8 @@ namespace CumulusMX
 			HighRainRateAlarm.Email = ini.GetValue("Alarms", "HighRainRateAlarmEmail", false);
 			HighRainRateAlarm.Latch = ini.GetValue("Alarms", "HighRainRateAlarmLatch", false);
 			HighRainRateAlarm.LatchHours = ini.GetValue("Alarms", "HighRainRateAlarmLatchHours", 24);
+			HighRainRateAlarm.Action = ini.GetValue("Alarms", "HighRainRateAlarmAction", "");
+			HighRainRateAlarm.ActionParams = ini.GetValue("Alarms", "HighRainRateAlarmActionParams", "");
 
 			IsRainingAlarm.Enabled = ini.GetValue("Alarms", "IsRainingAlarmSet", false);
 			IsRainingAlarm.Sound = ini.GetValue("Alarms", "IsRainingAlarmSound", false);
@@ -4738,6 +4754,8 @@ namespace CumulusMX
 			IsRainingAlarm.Email = ini.GetValue("Alarms", "IsRainingAlarmEmail", false);
 			IsRainingAlarm.Latch = ini.GetValue("Alarms", "IsRainingAlarmLatch", false);
 			IsRainingAlarm.LatchHours = ini.GetValue("Alarms", "IsRainingAlarmLatchHours", 1);
+			IsRainingAlarm.Action = ini.GetValue("Alarms", "IsRainingAlarmAction", "");
+			IsRainingAlarm.ActionParams = ini.GetValue("Alarms", "IsRainingAlarmActionParams", "");
 
 			HighGustAlarm.Value = ini.GetValue("Alarms", "alarmhighgust", 0.0);
 			HighGustAlarm.Enabled = ini.GetValue("Alarms", "HighGustAlarmSet", false);
@@ -4752,6 +4770,8 @@ namespace CumulusMX
 			HighGustAlarm.Email = ini.GetValue("Alarms", "HighGustAlarmEmail", false);
 			HighGustAlarm.Latch = ini.GetValue("Alarms", "HighGustAlarmLatch", false);
 			HighGustAlarm.LatchHours = ini.GetValue("Alarms", "HighGustAlarmLatchHours", 24);
+			HighGustAlarm.Action = ini.GetValue("Alarms", "HighGustAlarmAction", "");
+			HighGustAlarm.ActionParams = ini.GetValue("Alarms", "HighGustAlarmActionParams", "");
 
 			HighWindAlarm.Value = ini.GetValue("Alarms", "alarmhighwind", 0.0);
 			HighWindAlarm.Enabled = ini.GetValue("Alarms", "HighWindAlarmSet", false);
@@ -4766,6 +4786,8 @@ namespace CumulusMX
 			HighWindAlarm.Email = ini.GetValue("Alarms", "HighWindAlarmEmail", false);
 			HighWindAlarm.Latch = ini.GetValue("Alarms", "HighWindAlarmLatch", false);
 			HighWindAlarm.LatchHours = ini.GetValue("Alarms", "HighWindAlarmLatchHours", 24);
+			HighWindAlarm.Action = ini.GetValue("Alarms", "HighWindAlarmAction", "");
+			HighWindAlarm.ActionParams = ini.GetValue("Alarms", "HighWindAlarmActionParams", "");
 
 			SensorAlarm.Enabled = ini.GetValue("Alarms", "SensorAlarmSet", true);
 			SensorAlarm.Sound = ini.GetValue("Alarms", "SensorAlarmSound", false);
@@ -4780,6 +4802,8 @@ namespace CumulusMX
 			SensorAlarm.Latch = ini.GetValue("Alarms", "SensorAlarmLatch", true);
 			SensorAlarm.LatchHours = ini.GetValue("Alarms", "SensorAlarmLatchHours", 1);
 			SensorAlarm.TriggerThreshold = ini.GetValue("Alarms", "SensorAlarmTriggerCount", 2);
+			SensorAlarm.Action = ini.GetValue("Alarms", "SensorAlarmAction", "");
+			SensorAlarm.ActionParams = ini.GetValue("Alarms", "SensorAlarmActionParams", "");
 
 			DataStoppedAlarm.Enabled = ini.GetValue("Alarms", "DataStoppedAlarmSet", true);
 			DataStoppedAlarm.Sound = ini.GetValue("Alarms", "DataStoppedAlarmSound", false);
@@ -4794,6 +4818,8 @@ namespace CumulusMX
 			DataStoppedAlarm.Latch = ini.GetValue("Alarms", "DataStoppedAlarmLatch", true);
 			DataStoppedAlarm.LatchHours = ini.GetValue("Alarms", "DataStoppedAlarmLatchHours", 1);
 			DataStoppedAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataStoppedAlarmTriggerCount", 2);
+			DataStoppedAlarm.Action = ini.GetValue("Alarms", "DataStoppedAlarmAction", "");
+			DataStoppedAlarm.ActionParams = ini.GetValue("Alarms", "DataStoppedAlarmActionParams", "");
 
 			// Alarms below here were created after the change in default sound file, so no check required
 			BatteryLowAlarm.Enabled = ini.GetValue("Alarms", "BatteryLowAlarmSet", false);
@@ -4804,6 +4830,8 @@ namespace CumulusMX
 			BatteryLowAlarm.Latch = ini.GetValue("Alarms", "BatteryLowAlarmLatch", false);
 			BatteryLowAlarm.LatchHours = ini.GetValue("Alarms", "BatteryLowAlarmLatchHours", 24);
 			BatteryLowAlarm.TriggerThreshold = ini.GetValue("Alarms", "BatteryLowAlarmTriggerCount", 1);
+			BatteryLowAlarm.Action = ini.GetValue("Alarms", "BatteryLowAlarmAction", "");
+			BatteryLowAlarm.ActionParams = ini.GetValue("Alarms", "BatteryLowAlarmActionParams", "");
 
 			SpikeAlarm.Enabled = ini.GetValue("Alarms", "DataSpikeAlarmSet", false);
 			SpikeAlarm.Sound = ini.GetValue("Alarms", "DataSpikeAlarmSound", false);
@@ -4813,6 +4841,8 @@ namespace CumulusMX
 			SpikeAlarm.Latch = ini.GetValue("Alarms", "DataSpikeAlarmLatch", true);
 			SpikeAlarm.LatchHours = ini.GetValue("Alarms", "DataSpikeAlarmLatchHours", 24);
 			SpikeAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataSpikeAlarmTriggerCount", 1);
+			SpikeAlarm.Action = ini.GetValue("Alarms", "DataSpikeAlarmAction", "");
+			SpikeAlarm.ActionParams = ini.GetValue("Alarms", "DataSpikeAlarmActionParams", "");
 
 			UpgradeAlarm.Enabled = ini.GetValue("Alarms", "UpgradeAlarmSet", true);
 			UpgradeAlarm.Sound = ini.GetValue("Alarms", "UpgradeAlarmSound", false);
@@ -4821,6 +4851,8 @@ namespace CumulusMX
 			UpgradeAlarm.Email = ini.GetValue("Alarms", "UpgradeAlarmEmail", false);
 			UpgradeAlarm.Latch = ini.GetValue("Alarms", "UpgradeAlarmLatch", false);
 			UpgradeAlarm.LatchHours = ini.GetValue("Alarms", "UpgradeAlarmLatchHours", 24);
+			UpgradeAlarm.Action = ini.GetValue("Alarms", "UpgradeAlarmAction", "");
+			UpgradeAlarm.ActionParams = ini.GetValue("Alarms", "UpgradeAlarmActionParams", "");
 
 			HttpUploadAlarm.Enabled = ini.GetValue("Alarms", "HttpUploadAlarmSet", false);
 			HttpUploadAlarm.Sound = ini.GetValue("Alarms", "HttpUploadAlarmSound", false);
@@ -4830,6 +4862,8 @@ namespace CumulusMX
 			HttpUploadAlarm.Latch = ini.GetValue("Alarms", "HttpUploadAlarmLatch", false);
 			HttpUploadAlarm.LatchHours = ini.GetValue("Alarms", "HttpUploadAlarmLatchHours", 24);
 			HttpUploadAlarm.TriggerThreshold = ini.GetValue("Alarms", "HttpUploadAlarmTriggerCount", 1);
+			HttpUploadAlarm.Action = ini.GetValue("Alarms", "HttpUploadAlarmAction", "");
+			HttpUploadAlarm.ActionParams = ini.GetValue("Alarms", "HttpUploadAlarmActionParams", "");
 
 			MySqlUploadAlarm.Enabled = ini.GetValue("Alarms", "MySqlUploadAlarmSet", false);
 			MySqlUploadAlarm.Sound = ini.GetValue("Alarms", "MySqlUploadAlarmSound", false);
@@ -4839,6 +4873,8 @@ namespace CumulusMX
 			MySqlUploadAlarm.Latch = ini.GetValue("Alarms", "MySqlUploadAlarmLatch", false);
 			MySqlUploadAlarm.LatchHours = ini.GetValue("Alarms", "MySqlUploadAlarmLatchHours", 24);
 			MySqlUploadAlarm.TriggerThreshold = ini.GetValue("Alarms", "MySqlUploadAlarmTriggerCount", 1);
+			MySqlUploadAlarm.Action = ini.GetValue("Alarms", "MySqlUploadAlarmAction", "");
+			MySqlUploadAlarm.ActionParams = ini.GetValue("Alarms", "MySqlUploadAlarmActionParams", "");
 
 
 			AlarmFromEmail = ini.GetValue("Alarms", "FromEmail", "");
@@ -5625,6 +5661,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "LowTempAlarmEmail", LowTempAlarm.Email);
 			ini.SetValue("Alarms", "LowTempAlarmLatch", LowTempAlarm.Latch);
 			ini.SetValue("Alarms", "LowTempAlarmLatchHours", LowTempAlarm.LatchHours);
+			ini.SetValue("Alarms", "LowTempAlarmAction", LowTempAlarm.Action);
+			ini.SetValue("Alarms", "LowTempAlarmActionParams", LowTempAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmhightemp", HighTempAlarm.Value);
 			ini.SetValue("Alarms", "HighTempAlarmSet", HighTempAlarm.Enabled);
@@ -5634,6 +5672,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "HighTempAlarmEmail", HighTempAlarm.Email);
 			ini.SetValue("Alarms", "HighTempAlarmLatch", HighTempAlarm.Latch);
 			ini.SetValue("Alarms", "HighTempAlarmLatchHours", HighTempAlarm.LatchHours);
+			ini.SetValue("Alarms", "HighTempAlarmAction", HighTempAlarm.Action);
+			ini.SetValue("Alarms", "HighTempAlarmActionParams", HighTempAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmtempchange", TempChangeAlarm.Value);
 			ini.SetValue("Alarms", "TempChangeAlarmSet", TempChangeAlarm.Enabled);
@@ -5643,6 +5683,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "TempChangeAlarmEmail", TempChangeAlarm.Email);
 			ini.SetValue("Alarms", "TempChangeAlarmLatch", TempChangeAlarm.Latch);
 			ini.SetValue("Alarms", "TempChangeAlarmLatchHours", TempChangeAlarm.LatchHours);
+			ini.SetValue("Alarms", "TempChangeAlarmAction", TempChangeAlarm.Action);
+			ini.SetValue("Alarms", "TempChangeAlarmActionParams", TempChangeAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmlowpress", LowPressAlarm.Value);
 			ini.SetValue("Alarms", "LowPressAlarmSet", LowPressAlarm.Enabled);
@@ -5652,6 +5694,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "LowPressAlarmEmail", LowPressAlarm.Email);
 			ini.SetValue("Alarms", "LowPressAlarmLatch", LowPressAlarm.Latch);
 			ini.SetValue("Alarms", "LowPressAlarmLatchHours", LowPressAlarm.LatchHours);
+			ini.SetValue("Alarms", "LowPressAlarmAction", LowPressAlarm.Action);
+			ini.SetValue("Alarms", "LowPressAlarmActionParams", LowPressAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmhighpress", HighPressAlarm.Value);
 			ini.SetValue("Alarms", "HighPressAlarmSet", HighPressAlarm.Enabled);
@@ -5661,6 +5705,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "HighPressAlarmEmail", HighPressAlarm.Email);
 			ini.SetValue("Alarms", "HighPressAlarmLatch", HighPressAlarm.Latch);
 			ini.SetValue("Alarms", "HighPressAlarmLatchHours", HighPressAlarm.LatchHours);
+			ini.SetValue("Alarms", "HighPressAlarmAction", HighPressAlarm.Action);
+			ini.SetValue("Alarms", "HighPressAlarmActionParams", HighPressAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmpresschange", PressChangeAlarm.Value);
 			ini.SetValue("Alarms", "PressChangeAlarmSet", PressChangeAlarm.Enabled);
@@ -5670,6 +5716,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "PressChangeAlarmEmail", PressChangeAlarm.Email);
 			ini.SetValue("Alarms", "PressChangeAlarmLatch", PressChangeAlarm.Latch);
 			ini.SetValue("Alarms", "PressChangeAlarmLatchHours", PressChangeAlarm.LatchHours);
+			ini.SetValue("Alarms", "PressChangeAlarmAction", PressChangeAlarm.Action);
+			ini.SetValue("Alarms", "PressChangeAlarmActionParams", PressChangeAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmhighraintoday", HighRainTodayAlarm.Value);
 			ini.SetValue("Alarms", "HighRainTodayAlarmSet", HighRainTodayAlarm.Enabled);
@@ -5679,6 +5727,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "HighRainTodayAlarmEmail", HighRainTodayAlarm.Email);
 			ini.SetValue("Alarms", "HighRainTodayAlarmLatch", HighRainTodayAlarm.Latch);
 			ini.SetValue("Alarms", "HighRainTodayAlarmLatchHours", HighRainTodayAlarm.LatchHours);
+			ini.SetValue("Alarms", "HighRainTodayAlarmAction", HighRainTodayAlarm.Action);
+			ini.SetValue("Alarms", "HighRainTodayAlarmActionParams", HighRainTodayAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmhighrainrate", HighRainRateAlarm.Value);
 			ini.SetValue("Alarms", "HighRainRateAlarmSet", HighRainRateAlarm.Enabled);
@@ -5688,6 +5738,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "HighRainRateAlarmEmail", HighRainRateAlarm.Email);
 			ini.SetValue("Alarms", "HighRainRateAlarmLatch", HighRainRateAlarm.Latch);
 			ini.SetValue("Alarms", "HighRainRateAlarmLatchHours", HighRainRateAlarm.LatchHours);
+			ini.SetValue("Alarms", "HighRainRateAlarmAction", HighRainRateAlarm.Action);
+			ini.SetValue("Alarms", "HighRainRateAlarmActionParams", HighRainRateAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "IsRainingAlarmSet", IsRainingAlarm.Enabled);
 			ini.SetValue("Alarms", "IsRainingAlarmSound", IsRainingAlarm.Sound);
@@ -5697,6 +5749,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "IsRainingAlarmLatch", IsRainingAlarm.Latch);
 			ini.SetValue("Alarms", "IsRainingAlarmLatchHours", IsRainingAlarm.LatchHours);
 			ini.SetValue("Alarms", "IsRainingAlarmTriggerCount", IsRainingAlarm.TriggerThreshold);
+			ini.SetValue("Alarms", "IsRainingAlarmAction", IsRainingAlarm.Action);
+			ini.SetValue("Alarms", "IsRainingAlarmActionParams", IsRainingAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmhighgust", HighGustAlarm.Value);
 			ini.SetValue("Alarms", "HighGustAlarmSet", HighGustAlarm.Enabled);
@@ -5706,6 +5760,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "HighGustAlarmEmail", HighGustAlarm.Email);
 			ini.SetValue("Alarms", "HighGustAlarmLatch", HighGustAlarm.Latch);
 			ini.SetValue("Alarms", "HighGustAlarmLatchHours", HighGustAlarm.LatchHours);
+			ini.SetValue("Alarms", "HighGustAlarmAction", HighGustAlarm.Action);
+			ini.SetValue("Alarms", "HighGustAlarmActionParams", HighGustAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "alarmhighwind", HighWindAlarm.Value);
 			ini.SetValue("Alarms", "HighWindAlarmSet", HighWindAlarm.Enabled);
@@ -5715,6 +5771,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "HighWindAlarmEmail", HighWindAlarm.Email);
 			ini.SetValue("Alarms", "HighWindAlarmLatch", HighWindAlarm.Latch);
 			ini.SetValue("Alarms", "HighWindAlarmLatchHours", HighWindAlarm.LatchHours);
+			ini.SetValue("Alarms", "HighWindAlarmAction", HighWindAlarm.Action);
+			ini.SetValue("Alarms", "HighWindAlarmActionParams", HighWindAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "SensorAlarmSet", SensorAlarm.Enabled);
 			ini.SetValue("Alarms", "SensorAlarmSound", SensorAlarm.Sound);
@@ -5724,6 +5782,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "SensorAlarmLatch", SensorAlarm.Latch);
 			ini.SetValue("Alarms", "SensorAlarmLatchHours", SensorAlarm.LatchHours);
 			ini.SetValue("Alarms", "SensorAlarmTriggerCount", SensorAlarm.TriggerThreshold);
+			ini.SetValue("Alarms", "SensorAlarmAction", SensorAlarm.Action);
+			ini.SetValue("Alarms", "SensorAlarmActionParams", SensorAlarm.ActionParams);
 
 
 			ini.SetValue("Alarms", "DataStoppedAlarmSet", DataStoppedAlarm.Enabled);
@@ -5734,6 +5794,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "DataStoppedAlarmLatch", DataStoppedAlarm.Latch);
 			ini.SetValue("Alarms", "DataStoppedAlarmLatchHours", DataStoppedAlarm.LatchHours);
 			ini.SetValue("Alarms", "DataStoppedAlarmTriggerCount", DataStoppedAlarm.TriggerThreshold);
+			ini.SetValue("Alarms", "DataStoppedAlarmAction", DataStoppedAlarm.Action);
+			ini.SetValue("Alarms", "DataStoppedAlarmActionParams", DataStoppedAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "BatteryLowAlarmSet", BatteryLowAlarm.Enabled);
 			ini.SetValue("Alarms", "BatteryLowAlarmSound", BatteryLowAlarm.Sound);
@@ -5743,6 +5805,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "BatteryLowAlarmLatch", BatteryLowAlarm.Latch);
 			ini.SetValue("Alarms", "BatteryLowAlarmLatchHours", BatteryLowAlarm.LatchHours);
 			ini.SetValue("Alarms", "BatteryLowAlarmTriggerCount", BatteryLowAlarm.TriggerThreshold);
+			ini.SetValue("Alarms", "BatteryLowAlarmAction", BatteryLowAlarm.Action);
+			ini.SetValue("Alarms", "BatteryLowAlarmActionParams", BatteryLowAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "DataSpikeAlarmSet", SpikeAlarm.Enabled);
 			ini.SetValue("Alarms", "DataSpikeAlarmSound", SpikeAlarm.Sound);
@@ -5752,6 +5816,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "DataSpikeAlarmLatch", SpikeAlarm.Latch);
 			ini.SetValue("Alarms", "DataSpikeAlarmLatchHours", SpikeAlarm.LatchHours);
 			ini.SetValue("Alarms", "DataSpikeAlarmTriggerCount", SpikeAlarm.TriggerThreshold);
+			ini.SetValue("Alarms", "DataSpikeAlarmAction", SpikeAlarm.Action);
+			ini.SetValue("Alarms", "DataSpikeAlarmActionParams", SpikeAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "UpgradeAlarmSet", UpgradeAlarm.Enabled);
 			ini.SetValue("Alarms", "UpgradeAlarmSound", UpgradeAlarm.Sound);
@@ -5760,6 +5826,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "UpgradeAlarmEmail", UpgradeAlarm.Email);
 			ini.SetValue("Alarms", "UpgradeAlarmLatch", UpgradeAlarm.Latch);
 			ini.SetValue("Alarms", "UpgradeAlarmLatchHours", UpgradeAlarm.LatchHours);
+			ini.SetValue("Alarms", "UpgradeAlarmAction", UpgradeAlarm.Action);
+			ini.SetValue("Alarms", "UpgradeAlarmActionParams", UpgradeAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "HttpUploadAlarmSet", HttpUploadAlarm.Enabled);
 			ini.SetValue("Alarms", "HttpUploadAlarmSound", HttpUploadAlarm.Sound);
@@ -5769,6 +5837,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "HttpUploadAlarmLatch", HttpUploadAlarm.Latch);
 			ini.SetValue("Alarms", "HttpUploadAlarmLatchHours", HttpUploadAlarm.LatchHours);
 			ini.SetValue("Alarms", "HttpUploadAlarmTriggerCount", HttpUploadAlarm.TriggerThreshold);
+			ini.SetValue("Alarms", "HttpUploadAlarmAction", HttpUploadAlarm.Action);
+			ini.SetValue("Alarms", "HttpUploadAlarmActionParams", HttpUploadAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "MySqlUploadAlarmSet", MySqlUploadAlarm.Enabled);
 			ini.SetValue("Alarms", "MySqlUploadAlarmSound", MySqlUploadAlarm.Sound);
@@ -5778,6 +5848,8 @@ namespace CumulusMX
 			ini.SetValue("Alarms", "MySqlUploadAlarmLatch", MySqlUploadAlarm.Latch);
 			ini.SetValue("Alarms", "MySqlUploadAlarmLatchHours", MySqlUploadAlarm.LatchHours);
 			ini.SetValue("Alarms", "MySqlUploadAlarmTriggerCount", MySqlUploadAlarm.TriggerThreshold);
+			ini.SetValue("Alarms", "MySqlUploadAlarmAction", MySqlUploadAlarm.Action);
+			ini.SetValue("Alarms", "MySqlUploadAlarmActionParams", MySqlUploadAlarm.ActionParams);
 
 			ini.SetValue("Alarms", "FromEmail", AlarmFromEmail);
 			ini.SetValue("Alarms", "DestEmail", AlarmDestEmail.Join(";"));

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -9532,7 +9532,7 @@ namespace CumulusMX
 					}
 					catch (Exception ex)
 					{
-						LogMessage("CustomSqlSecs: Error - " + ex.Message);
+						LogMessage($"CustomSqlSecs[{i}]: Error - " + ex.Message);
 					}
 				}
 				customMySqlSecondsUpdateInProgress = false;
@@ -9556,12 +9556,15 @@ namespace CumulusMX
 				{
 					try
 					{
-						customMysqlMinutesTokenParser.InputText = MySqlSettings.CustomMins.Commands[i];
-						await CheckMySQLFailedUploads("CustomSqlMins", customMysqlMinutesTokenParser.ToStringFromString());
+						if (!string.IsNullOrEmpty(MySqlSettings.CustomMins.Commands[i]))
+						{
+							customMysqlMinutesTokenParser.InputText = MySqlSettings.CustomMins.Commands[i];
+							await CheckMySQLFailedUploads($"CustomSqlMins[{i}]", customMysqlMinutesTokenParser.ToStringFromString());
+						}
 					}
 					catch (Exception ex)
 					{
-						LogMessage("CustomSqlMins: Error - " + ex.Message);
+						LogMessage($"CustomSqlMins[{i}]: Error - " + ex.Message);
 					}
 				}
 				customMySqlMinutesUpdateInProgress = false;
@@ -9584,12 +9587,15 @@ namespace CumulusMX
 				{
 					try
 					{
-						customMysqlRolloverTokenParser.InputText = MySqlSettings.CustomRollover.Commands[i];
-						await CheckMySQLFailedUploads("CustomSqlRollover", customMysqlRolloverTokenParser.ToStringFromString());
+						if (!string.IsNullOrEmpty(MySqlSettings.CustomRollover.Commands[i]))
+						{
+							customMysqlRolloverTokenParser.InputText = MySqlSettings.CustomRollover.Commands[i];
+							await CheckMySQLFailedUploads($"CustomSqlRollover[{i}]", customMysqlRolloverTokenParser.ToStringFromString());
+						}
 					}
 					catch (Exception ex)
 					{
-						LogMessage("CustomSqlRollover: Error - " + ex.Message);
+						LogMessage($"CustomSqlRollover[{i}]: Error - " + ex.Message);
 					}
 				}
 				customMySqlRolloverUpdateInProgress = false;

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3809,6 +3809,8 @@ namespace CumulusMX
 			ProgramOptions.StartupPingEscapeTime = ini.GetValue("Program", "StartupPingEscapeTime", 999);
 			ProgramOptions.StartupDelaySecs = ini.GetValue("Program", "StartupDelaySecs", 0);
 			ProgramOptions.StartupDelayMaxUptime = ini.GetValue("Program", "StartupDelayMaxUptime", 300);
+			ProgramOptions.DataStoppedExit = ini.GetValue("Program", "DataStoppedExit", false);
+			ProgramOptions.DataStoppedMins = ini.GetValue("Program", "DataStoppedMins", 10);
 			ProgramOptions.Culture.RemoveSpaceFromDateSeparator = ini.GetValue("Culture", "RemoveSpaceFromDateSeparator", false);
 			// if the culture names match, then we apply the new date separator if change is enabled and it contains a space
 			if (ProgramOptions.Culture.RemoveSpaceFromDateSeparator && CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator.Contains(" "))
@@ -5195,6 +5197,9 @@ namespace CumulusMX
 
 			ini.SetValue("Program", "StartupDelaySecs", ProgramOptions.StartupDelaySecs);
 			ini.SetValue("Program", "StartupDelayMaxUptime", ProgramOptions.StartupDelayMaxUptime);
+
+			ini.SetValue("Program", "DataStoppedExit", ProgramOptions.DataStoppedExit);
+			ini.SetValue("Program", "DataStoppedMins", ProgramOptions.DataStoppedMins);
 
 			ini.SetValue("Culture", "RemoveSpaceFromDateSeparator", ProgramOptions.Culture.RemoveSpaceFromDateSeparator);
 
@@ -10730,6 +10735,8 @@ namespace CumulusMX
 		public bool WarnMultiple { get; set; }
 		public bool ListWebTags { get; set; }
 		public CultureConfig Culture { get; set; }
+		public bool DataStoppedExit { get; set; }
+		public int DataStoppedMins { get; set; }
 	}
 
 	public class CultureConfig

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -9481,7 +9481,10 @@ namespace CumulusMX
 						}
 						else
 						{
-							MySqlFailedList = (ConcurrentQueue<string>)MySqlFailedList.Concat<string>(cmds);
+							for (var i = 0; i < cmds.Count; i++)
+							{
+								MySqlFailedList.Enqueue(cmds[i]);
+							}
 						}
 					}
 					else
@@ -10147,6 +10150,7 @@ namespace CumulusMX
 					Cmds.TryDequeue(out var cmd);
 					if (!cmd.StartsWith("DELETE IGNORE FROM"))
 					{
+						LogDebugMessage($"{CallingFunction}: Buffering command to failed list");
 						MySqlFailedList.Enqueue(cmd);
 					}
 				}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -194,7 +194,7 @@ namespace CumulusMX
 		public const double DefaultHiVal = -9999;
 		public const double DefaultLoVal = 9999;
 
-		public const int DayfileFields = 53;
+		public const int DayfileFields = 55;
 
 		public const int LogFileRetries = 3;
 
@@ -605,24 +605,24 @@ namespace CumulusMX
 		public double CPUtemp = -999;
 
 		// Alarms
-		public Alarm DataStoppedAlarm = new Alarm();
-		public Alarm BatteryLowAlarm = new Alarm();
-		public Alarm SensorAlarm = new Alarm();
-		public Alarm SpikeAlarm = new Alarm();
-		public Alarm HighWindAlarm = new Alarm();
-		public Alarm HighGustAlarm = new Alarm();
-		public Alarm HighRainRateAlarm = new Alarm();
-		public Alarm HighRainTodayAlarm = new Alarm();
-		public AlarmChange PressChangeAlarm = new AlarmChange();
-		public Alarm HighPressAlarm = new Alarm();
-		public Alarm LowPressAlarm = new Alarm();
-		public AlarmChange TempChangeAlarm = new AlarmChange();
-		public Alarm HighTempAlarm = new Alarm();
-		public Alarm LowTempAlarm = new Alarm();
-		public Alarm UpgradeAlarm = new Alarm();
-		public Alarm HttpUploadAlarm = new Alarm();
-		public Alarm MySqlUploadAlarm = new Alarm();
-		public Alarm IsRainingAlarm = new Alarm();
+		public Alarm DataStoppedAlarm = new Alarm("Data Stopped", AlarmTypes.Trigger);
+		public Alarm BatteryLowAlarm = new Alarm("Battery Low", AlarmTypes.Trigger);
+		public Alarm SensorAlarm = new Alarm("Sensor Data Stopped", AlarmTypes.Trigger);
+		public Alarm SpikeAlarm = new Alarm("Data Spike",AlarmTypes.Trigger);
+		public Alarm HighWindAlarm = new Alarm("High Wind", AlarmTypes.Above);
+		public Alarm HighGustAlarm = new Alarm("High Gust", AlarmTypes.Above);
+		public Alarm HighRainRateAlarm = new Alarm("High Rainfall Rate", AlarmTypes.Above);
+		public Alarm HighRainTodayAlarm = new Alarm("Total Rainfall Today", AlarmTypes.Above);
+		public AlarmChange PressChangeAlarm = new AlarmChange("Pressure Change");
+		public Alarm HighPressAlarm = new Alarm("High Pressure", AlarmTypes.Above);
+		public Alarm LowPressAlarm = new Alarm("Low Pressure", AlarmTypes.Below);
+		public AlarmChange TempChangeAlarm = new AlarmChange("Temperature Change");
+		public Alarm HighTempAlarm = new Alarm("High Temperature", AlarmTypes.Above);
+		public Alarm LowTempAlarm = new Alarm("Low Temperature", AlarmTypes.Below);
+		public Alarm UpgradeAlarm = new Alarm("Upgrade Available", AlarmTypes.Trigger);
+		public Alarm HttpUploadAlarm = new Alarm("HTTP Uploads", AlarmTypes.Trigger);
+		public Alarm MySqlUploadAlarm = new Alarm("MySQL Uploads", AlarmTypes.Trigger);
+		public Alarm IsRainingAlarm = new Alarm("IsRaining", AlarmTypes.Trigger);
 
 
 		private const double DEFAULTFCLOWPRESS = 950.0;

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -8609,6 +8609,11 @@ namespace CumulusMX
 					{
 						LogFtpMessage("FTP[Int]: Error connecting ftp - " + ex.Message);
 
+						if (null != ex.InnerException)
+						{
+							LogMessage($"FTP[Int]: Error connecting ftp - {ex.GetBaseException().Message}");
+						}
+
 						if ((uint)ex.HResult == 0x80004005) // Could not resolve host
 						{
 							// Disable the DNS cache for the next query
@@ -8809,7 +8814,7 @@ namespace CumulusMX
 						LogFtpMessage($"FTP[{cycleStr}]: Error deleting {remotefile} : {ex.Message}");
 						if (ex.InnerException != null)
 						{
-							LogFtpMessage($"FTP[{cycleStr}]: Inner Exception: {ex.InnerException.Message}");
+							LogFtpMessage($"FTP[{cycleStr}]: Inner Exception: {ex.GetBaseException().Message}");
 						}
 						return conn.IsConnected;
 					}
@@ -8838,7 +8843,7 @@ namespace CumulusMX
 						LogFtpMessage($"FTP[{cycleStr}]: Error renaming {remotefilename} to {remotefile} : {ex.Message}");
 						if (ex.InnerException != null)
 						{
-							LogFtpMessage($"FTP[{cycleStr}]: Inner Exception: {ex.InnerException.Message}");
+							LogFtpMessage($"FTP[{cycleStr}]: Inner Exception: {ex.GetBaseException().Message}");
 						}
 						return conn.IsConnected;
 					}
@@ -8849,7 +8854,7 @@ namespace CumulusMX
 				LogFtpMessage($"FTP[{cycleStr}]: Error uploading {localfile} to {remotefile} : {ex.Message}");
 				if (ex.InnerException != null)
 				{
-					LogFtpMessage($"FTP[{cycleStr}]: Inner Exception: {ex.InnerException.Message}");
+					LogFtpMessage($"FTP[{cycleStr}]: Inner Exception: {ex.GetBaseException().Message}");
 				}
 			}
 
@@ -9813,6 +9818,10 @@ namespace CumulusMX
 				catch (Exception ex)
 				{
 					LogMessage($"RealtimeFTPLogin: Error connecting ftp - {ex.Message}");
+					if (null != ex.InnerException)
+					{
+						LogMessage($"RealtimeFTPLogin: Inner Error - {ex.GetBaseException().Message}");
+					}
 					RealtimeFTP.Disconnect();
 				}
 			}
@@ -10673,7 +10682,7 @@ namespace CumulusMX
 			// If an error occurred, display the exception to the user.
 			if (e.Error != null)
 			{
-				LogMessage("Ping failed: " + e.Error.Message + " > " + e.Error.InnerException.Message);
+				LogMessage("Ping failed: " + e.Error.Message + " > " + e.Error.GetBaseException().Message);
 			}
 			else
 			{
@@ -10686,7 +10695,7 @@ namespace CumulusMX
 		private void CreateRequiredFolders()
 		{
 			// The required folders are: /backup, backup/daily, /data, /Reports
-			var folders = new string[4] { "backup", "backup/daily", "data", "Reports"};
+			var folders = new string[4] { "backup", "backup/daily", "data", "Reports" };
 
 			LogMessage("Checking required folders");
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -221,7 +221,7 @@ namespace CumulusMX
 		private readonly TokenParser customMysqlMinutesTokenParser = new TokenParser();
 		private readonly TokenParser customMysqlRolloverTokenParser = new TokenParser();
 
-		public string CurrentActivity = "Stopped";
+		public bool NormalRunning = false;
 
 		private static readonly TraceListener FtpTraceListener = new TextWriterTraceListener("ftplog.txt", "ftplog");
 
@@ -9492,6 +9492,7 @@ namespace CumulusMX
 
 			EnableOpenWeatherMap();
 
+			NormalRunning = true;
 			LogMessage("Normal running");
 			LogConsoleMessage("Normal running", ConsoleColor.Green);
 		}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -10151,6 +10151,7 @@ namespace CumulusMX
 			await Task.Run(() =>
 			{
 				ConcurrentQueue<string> queue = UseFailedList ? ref MySqlFailedList : ref Cmds;
+				var cmdStr = "";
 
 				try
 				{
@@ -10163,7 +10164,7 @@ namespace CumulusMX
 							do
 							{
 								// Do not remove the item from the stack until we know the command worked
-								if (queue.TryPeek(out var cmdStr))
+								if (queue.TryPeek(out cmdStr))
 								{
 									using (MySqlCommand cmd = new MySqlCommand(cmdStr, mySqlConn))
 									{
@@ -10201,6 +10202,12 @@ namespace CumulusMX
 				catch (Exception ex)
 				{
 					LogMessage($"{CallingFunction}: Error encountered during MySQL operation = {ex.Message}");
+					// if debug logging is disable, then log the failing statement anyway
+					if (!DebuggingEnabled)
+					{
+						LogMessage($"{CallingFunction}: SQL = {cmdStr}");
+					}
+
 
 					MySqlUploadAlarm.LastError = ex.Message;
 					MySqlUploadAlarm.Triggered = true;
@@ -10227,10 +10234,10 @@ namespace CumulusMX
 		public void MySqlCommandSync(ConcurrentQueue<string> Cmds, string CallingFunction, bool UseFailedList)
 		{
 			ConcurrentQueue<string> queue = UseFailedList ? ref MySqlFailedList : ref Cmds;
+			var cmdStr = "";
 
 			try
 			{
-
 				using (var mySqlConn = new MySqlConnection(MySqlConnSettings.ToString()))
 				{
 					mySqlConn.Open();
@@ -10240,7 +10247,7 @@ namespace CumulusMX
 						do
 						{
 							// Do not remove the item from the stack until we know the command worked
-							if (queue.TryPeek(out var cmdStr))
+							if (queue.TryPeek(out cmdStr))
 							{
 
 								using (MySqlCommand cmd = new MySqlCommand(cmdStr, mySqlConn))
@@ -10278,8 +10285,13 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				LogMessage($"{CallingFunction}: Error encountered during MySQL operation.");
-				LogMessage(ex.Message);
+				LogMessage($"{CallingFunction}: Error encountered during MySQL operation = {ex.Message}");
+				// if debug logging is disable, then log the failing statement anyway
+				if (!DebuggingEnabled)
+				{
+					LogMessage($"{CallingFunction}: SQL = {cmdStr}");
+				}
+
 				MySqlUploadAlarm.LastError = ex.Message;
 				MySqlUploadAlarm.Triggered = true;
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1831,7 +1831,8 @@ namespace CumulusMX
 				"HighHourRain,THighHourRain,LowWindChill,TLowWindChill,HighDewPoint,THighDewPoint," +
 				"LowDewPoint,TLowDewPoint,DomWindDir,HeatDegDays,CoolDegDays,HighSolarRad," +
 				"THighSolarRad,HighUV,THighUV,HWindGBearSym,DomWindDirSym," +
-				"MaxFeelsLike,TMaxFeelsLike,MinFeelsLike,TMinFeelsLike,MaxHumidex,TMaxHumidex)";
+				"MaxFeelsLike,TMaxFeelsLike,MinFeelsLike,TMinFeelsLike,MaxHumidex,TMaxHumidex," +
+				"ChillHours,HighRain24h,THighRain24h)";
 		}
 
 		internal void SetStartOfMonthlyInsertSQL()
@@ -6780,27 +6781,7 @@ namespace CumulusMX
 			// First determine the date for the log file.
 			// If we're using 9am roll-over, the date should be 9 hours (10 in summer)
 			// before 'Now'
-			DateTime logfiledate;
-
-			if (RolloverHour == 0)
-			{
-				logfiledate = thedate;
-			}
-			else
-			{
-				TimeZone tz = TimeZone.CurrentTimeZone;
-
-				if (Use10amInSummer && tz.IsDaylightSavingTime(thedate))
-				{
-					// Locale is currently on Daylight (summer) time
-					logfiledate = thedate.AddHours(-10);
-				}
-				else
-				{
-					// Locale is currently on Standard time or unknown
-					logfiledate = thedate.AddHours(-9);
-				}
-			}
+			DateTime logfiledate = thedate.AddHours(GetHourInc(thedate));
 
 			var datestring = logfiledate.ToString("MMMyy").Replace(".", "");
 
@@ -6812,27 +6793,7 @@ namespace CumulusMX
 			// First determine the date for the log file.
 			// If we're using 9am roll-over, the date should be 9 hours (10 in summer)
 			// before 'Now'
-			DateTime logfiledate;
-
-			if (RolloverHour == 0)
-			{
-				logfiledate = thedate;
-			}
-			else
-			{
-				TimeZone tz = TimeZone.CurrentTimeZone;
-
-				if (Use10amInSummer && tz.IsDaylightSavingTime(thedate))
-				{
-					// Locale is currently on Daylight (summer) time
-					logfiledate = thedate.AddHours(-10);
-				}
-				else
-				{
-					// Locale is currently on Standard time or unknown
-					logfiledate = thedate.AddHours(-9);
-				}
-			}
+			DateTime logfiledate = thedate.AddHours(GetHourInc(thedate));
 
 			var datestring = logfiledate.ToString("yyyyMM");
 			datestring = datestring.Replace(".", "");
@@ -6845,27 +6806,7 @@ namespace CumulusMX
 			// First determine the date for the log file.
 			// If we're using 9am roll-over, the date should be 9 hours (10 in summer)
 			// before 'Now'
-			DateTime logfiledate;
-
-			if (RolloverHour == 0)
-			{
-				logfiledate = thedate;
-			}
-			else
-			{
-				TimeZone tz = TimeZone.CurrentTimeZone;
-
-				if (Use10amInSummer && tz.IsDaylightSavingTime(thedate))
-				{
-					// Locale is currently on Daylight (summer) time
-					logfiledate = thedate.AddHours(-10);
-				}
-				else
-				{
-					// Locale is currently on Standard time or unknown
-					logfiledate = thedate.AddHours(-9);
-				}
-			}
+			DateTime logfiledate = thedate.AddHours(GetHourInc(thedate));
 
 			var datestring = logfiledate.ToString("yyyyMM");
 			datestring = datestring.Replace(".", "");
@@ -10562,8 +10503,9 @@ namespace CumulusMX
 			strb.Append("TMinFeelsLike varchar(5),");
 			strb.Append("MaxHumidex decimal(5," + TempDPlaces + "),");
 			strb.Append("TMaxHumidex varchar(5),");
-			//strb.Append("MinHumidex decimal(5," + TempDPlaces + "),");
-			//strb.Append("TMinHumidex varchar(5),");
+			strb.Append("ChillHours decimal(7," + TempDPlaces + "),");
+			strb.Append("HighRain24h decimal(6," + RainDPlaces + "),");
+			strb.Append("THighRain24h varchar(5),");
 			strb.Append("PRIMARY KEY(LogDate)) COMMENT = \"Dayfile from Cumulus\"");
 			CreateDayfileSQL = strb.ToString();
 		}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -675,7 +675,7 @@ namespace CumulusMX
 		private readonly TokenParser customHttpSecondsTokenParser = new TokenParser();
 		internal Timer CustomHttpSecondsTimer;
 		internal bool CustomHttpSecondsEnabled;
-		internal string CustomHttpSecondsString;
+		internal string[] CustomHttpSecondsStrings = new string[10];
 		internal int CustomHttpSecondsInterval;
 
 		// Custom HTTP - minutes
@@ -684,7 +684,7 @@ namespace CumulusMX
 		private bool updatingCustomHttpMinutes;
 		private readonly TokenParser customHttpMinutesTokenParser = new TokenParser();
 		internal bool CustomHttpMinutesEnabled;
-		internal string CustomHttpMinutesString;
+		internal string[] CustomHttpMinutesStrings = new string[10];
 		internal int CustomHttpMinutesInterval;
 		internal int CustomHttpMinutesIntervalIndex;
 
@@ -694,7 +694,7 @@ namespace CumulusMX
 		private bool updatingCustomHttpRollover;
 		private readonly TokenParser customHttpRolloverTokenParser = new TokenParser();
 		internal bool CustomHttpRolloverEnabled;
-		internal string CustomHttpRolloverString;
+		internal string[] CustomHttpRolloverStrings = new string[10];
 
 		public Thread ftpThread;
 		public Thread MySqlCatchupThread;
@@ -5128,12 +5128,25 @@ namespace CumulusMX
 			MySqlSettings.CustomRollover.Enabled = ini.GetValue("MySQL", "CustomMySqlRolloverEnabled", false);
 
 			// Custom HTTP - seconds
-			CustomHttpSecondsString = ini.GetValue("HTTP", "CustomHttpSecondsString", "");
+			CustomHttpSecondsStrings[0] = ini.GetValue("HTTP", "CustomHttpSecondsString", "");
+			for (var i = 1; i < 10; i++)
+			{
+				if (ini.ValueExists("HTTP", "CustomHttpSecondsString" + i))
+					CustomHttpSecondsStrings[i] = ini.GetValue("HTTP", "CustomHttpSecondsString" + i, "");
+			}
+
 			CustomHttpSecondsEnabled = ini.GetValue("HTTP", "CustomHttpSecondsEnabled", false);
 			CustomHttpSecondsInterval = ini.GetValue("HTTP", "CustomHttpSecondsInterval", 10);
 			if (CustomHttpSecondsInterval < 1) { CustomHttpSecondsInterval = 1; }
+			
 			// Custom HTTP - minutes
-			CustomHttpMinutesString = ini.GetValue("HTTP", "CustomHttpMinutesString", "");
+			CustomHttpMinutesStrings[0] = ini.GetValue("HTTP", "CustomHttpMinutesString", "");
+			for (var i = 1; i < 10; i++)
+			{
+				if (ini.ValueExists("HTTP", "CustomHttpMinutesString" + i))
+					CustomHttpMinutesStrings[i] = ini.GetValue("HTTP", "CustomHttpMinutesString" + i, "");
+			}
+
 			CustomHttpMinutesEnabled = ini.GetValue("HTTP", "CustomHttpMinutesEnabled", false);
 			CustomHttpMinutesIntervalIndex = ini.GetValue("HTTP", "CustomHttpMinutesIntervalIndex", -1);
 			if (CustomHttpMinutesIntervalIndex >= 0 && CustomHttpMinutesIntervalIndex < FactorsOf60.Length)
@@ -5146,9 +5159,16 @@ namespace CumulusMX
 				CustomHttpMinutesIntervalIndex = 6;
 				rewriteRequired = true;
 			}
+
 			// Http - custom roll-over
-			CustomHttpRolloverString = ini.GetValue("HTTP", "CustomHttpRolloverString", "");
 			CustomHttpRolloverEnabled = ini.GetValue("HTTP", "CustomHttpRolloverEnabled", false);
+			CustomHttpRolloverStrings[0] = ini.GetValue("HTTP", "CustomHttpRolloverString", "");
+			for (var i = 1; i < 10; i++)
+			{
+				if (ini.ValueExists("HTTP", "CustomHttpRolloverString" + i))
+					CustomHttpRolloverStrings[i] = ini.GetValue("HTTP", "CustomHttpRolloverString" + i, "");
+			}
+
 
 			// Select-a-Chart settings
 			for (int i = 0; i < SelectaChartOptions.series.Length; i++)
@@ -5543,14 +5563,29 @@ namespace CumulusMX
 
 			for (int i = 0; i < numextrafiles; i++)
 			{
-				ini.SetValue("FTP site", "ExtraLocal" + i, ExtraFiles[i].local);
-				ini.SetValue("FTP site", "ExtraRemote" + i, ExtraFiles[i].remote);
-				ini.SetValue("FTP site", "ExtraProcess" + i, ExtraFiles[i].process);
-				ini.SetValue("FTP site", "ExtraBinary" + i, ExtraFiles[i].binary);
-				ini.SetValue("FTP site", "ExtraRealtime" + i, ExtraFiles[i].realtime);
-				ini.SetValue("FTP site", "ExtraFTP" + i, ExtraFiles[i].FTP);
-				ini.SetValue("FTP site", "ExtraUTF" + i, ExtraFiles[i].UTF8);
-				ini.SetValue("FTP site", "ExtraEOD" + i, ExtraFiles[i].endofday);
+				if (string.IsNullOrEmpty(ExtraFiles[i].local) && string.IsNullOrEmpty(ExtraFiles[i].remote))
+				{
+					ini.DeleteValue("FTP site", "ExtraLocal" + i);
+					ini.DeleteValue("FTP site", "ExtraRemote" + i);
+					ini.DeleteValue("FTP site", "ExtraProcess" + i);
+					ini.DeleteValue("FTP site", "ExtraBinary" + i);
+					ini.DeleteValue("FTP site", "ExtraRealtime" + i);
+					ini.DeleteValue("FTP site", "ExtraFTP" + i);
+					ini.DeleteValue("FTP site", "ExtraUTF" + i);
+					ini.DeleteValue("FTP site", "ExtraEOD" + i);
+
+				}
+				else
+				{
+					ini.SetValue("FTP site", "ExtraLocal" + i, ExtraFiles[i].local);
+					ini.SetValue("FTP site", "ExtraRemote" + i, ExtraFiles[i].remote);
+					ini.SetValue("FTP site", "ExtraProcess" + i, ExtraFiles[i].process);
+					ini.SetValue("FTP site", "ExtraBinary" + i, ExtraFiles[i].binary);
+					ini.SetValue("FTP site", "ExtraRealtime" + i, ExtraFiles[i].realtime);
+					ini.SetValue("FTP site", "ExtraFTP" + i, ExtraFiles[i].FTP);
+					ini.SetValue("FTP site", "ExtraUTF" + i, ExtraFiles[i].UTF8);
+					ini.SetValue("FTP site", "ExtraEOD" + i, ExtraFiles[i].endofday);
+				}
 			}
 
 			ini.SetValue("FTP site", "ExternalProgram", ExternalProgram);
@@ -6034,9 +6069,27 @@ namespace CumulusMX
 			ini.SetValue("MySQL", "CustomMySqlSecondsInterval", MySqlSettings.CustomSecs.Interval);
 			ini.SetValue("MySQL", "CustomMySqlMinutesIntervalIndex", CustomMySqlMinutesIntervalIndex);
 
-			ini.SetValue("HTTP", "CustomHttpSecondsString", CustomHttpSecondsString);
-			ini.SetValue("HTTP", "CustomHttpMinutesString", CustomHttpMinutesString);
-			ini.SetValue("HTTP", "CustomHttpRolloverString", CustomHttpRolloverString);
+			ini.SetValue("HTTP", "CustomHttpSecondsString", CustomHttpSecondsStrings[0]);
+			ini.SetValue("HTTP", "CustomHttpMinutesString", CustomHttpMinutesStrings[0]);
+			ini.SetValue("HTTP", "CustomHttpRolloverString", CustomHttpRolloverStrings[0]);
+
+			for (var i = 1; i < 10; i++)
+			{
+				if (string.IsNullOrEmpty(CustomHttpSecondsStrings[i]))
+					ini.DeleteValue("HTTP", "CustomHttpSecondsString" + i);
+				else
+					ini.SetValue("HTTP", "CustomHttpSecondsString" + i, CustomHttpSecondsStrings[i]);
+
+				if (string.IsNullOrEmpty(CustomHttpMinutesStrings[i]))
+					ini.DeleteValue("HTTP", "CustomHttpMinutesString" + i);
+				else
+					ini.SetValue("HTTP", "CustomHttpMinutesString" + i, CustomHttpMinutesStrings[i]);
+
+				if (string.IsNullOrEmpty(CustomHttpRolloverStrings[i]))
+					ini.DeleteValue("HTTP", "CustomHttpRolloverString" + i);
+				else
+					ini.SetValue("HTTP", "CustomHttpRolloverString" + i, CustomHttpRolloverStrings[i]);
+			}
 
 			ini.SetValue("HTTP", "CustomHttpSecondsEnabled", CustomHttpSecondsEnabled);
 			ini.SetValue("HTTP", "CustomHttpMinutesEnabled", CustomHttpMinutesEnabled);
@@ -10209,25 +10262,29 @@ namespace CumulusMX
 			{
 				updatingCustomHttpSeconds = true;
 
-				try
+				for (var i = 0; i < 10; i++)
 				{
-					customHttpSecondsTokenParser.InputText = CustomHttpSecondsString;
-					var processedString = customHttpSecondsTokenParser.ToStringFromString();
-					LogDebugMessage("CustomHttpSeconds: Querying - " + processedString);
-					var response = await customHttpSecondsClient.GetAsync(processedString);
-					response.EnsureSuccessStatusCode();
-					var responseBodyAsText = await response.Content.ReadAsStringAsync();
-					LogDebugMessage("CustomHttpSeconds: Response - " + response.StatusCode);
-					LogDataMessage("CustomHttpSeconds: Response Text - " + responseBodyAsText);
+					try
+					{
+						if (!string.IsNullOrEmpty(CustomHttpSecondsStrings[i]))
+						{
+							customHttpSecondsTokenParser.InputText = CustomHttpSecondsStrings[i];
+							var processedString = customHttpSecondsTokenParser.ToStringFromString();
+							LogDebugMessage($"CustomHttpSeconds[{i}]: Querying - {processedString}");
+							var response = await customHttpSecondsClient.GetAsync(processedString);
+							response.EnsureSuccessStatusCode();
+							var responseBodyAsText = await response.Content.ReadAsStringAsync();
+							LogDebugMessage($"CustomHttpSeconds[{i}]: Response - {response.StatusCode}");
+							LogDataMessage($"CustomHttpSeconds[{i}]: Response Text - {responseBodyAsText}");
+						}
+					}
+					catch (Exception ex)
+					{
+						LogDebugMessage("CustomHttpSeconds: " + ex.Message);
+					}
 				}
-				catch (Exception ex)
-				{
-					LogDebugMessage("CustomHttpSeconds: " + ex.Message);
-				}
-				finally
-				{
-					updatingCustomHttpSeconds = false;
-				}
+
+				updatingCustomHttpSeconds = false;
 			}
 			else
 			{
@@ -10241,24 +10298,25 @@ namespace CumulusMX
 			{
 				updatingCustomHttpMinutes = true;
 
-				try
+				for (var i = 0; i < 10; i++)
 				{
-					customHttpMinutesTokenParser.InputText = CustomHttpMinutesString;
-					var processedString = customHttpMinutesTokenParser.ToStringFromString();
-					LogDebugMessage("CustomHttpMinutes: Querying - " + processedString);
-					var response = await customHttpMinutesClient.GetAsync(processedString);
-					var responseBodyAsText = await response.Content.ReadAsStringAsync();
-					LogDebugMessage("CustomHttpMinutes: Response code - " + response.StatusCode);
-					LogDataMessage("CustomHttpMinutes: Response text - " + responseBodyAsText);
+					try
+					{
+						customHttpMinutesTokenParser.InputText = CustomHttpMinutesStrings[i];
+						var processedString = customHttpMinutesTokenParser.ToStringFromString();
+						LogDebugMessage($"CustomHttpMinutes[{i}]: Querying - {processedString}");
+						var response = await customHttpMinutesClient.GetAsync(processedString);
+						var responseBodyAsText = await response.Content.ReadAsStringAsync();
+						LogDebugMessage($"CustomHttpMinutes[{i}]: Response code - {response.StatusCode}");
+						LogDataMessage($"CustomHttpMinutes[{i}]: Response text - {responseBodyAsText}");
+					}
+					catch (Exception ex)
+					{
+						LogDebugMessage("CustomHttpMinutes: " + ex.Message);
+					}
 				}
-				catch (Exception ex)
-				{
-					LogDebugMessage("CustomHttpMinutes: " + ex.Message);
-				}
-				finally
-				{
-					updatingCustomHttpMinutes = false;
-				}
+
+				updatingCustomHttpMinutes = false;
 			}
 		}
 
@@ -10268,24 +10326,25 @@ namespace CumulusMX
 			{
 				updatingCustomHttpRollover = true;
 
-				try
+				for (var i = 0; i < 10; i++)
 				{
-					customHttpRolloverTokenParser.InputText = CustomHttpRolloverString;
-					var processedString = customHttpRolloverTokenParser.ToStringFromString();
-					LogDebugMessage("CustomHttpRollover: Querying - " + processedString);
-					var response = await customHttpRolloverClient.GetAsync(processedString);
-					var responseBodyAsText = await response.Content.ReadAsStringAsync();
-					LogDebugMessage("CustomHttpRollover: Response code - " + response.StatusCode);
-					LogDataMessage("CustomHttpRollover: Response text - " + responseBodyAsText);
+					try
+					{
+						customHttpRolloverTokenParser.InputText = CustomHttpRolloverStrings[i];
+						var processedString = customHttpRolloverTokenParser.ToStringFromString();
+						LogDebugMessage($"CustomHttpRollover[{i}]: Querying - {processedString}");
+						var response = await customHttpRolloverClient.GetAsync(processedString);
+						var responseBodyAsText = await response.Content.ReadAsStringAsync();
+						LogDebugMessage($"CustomHttpRollover[{i}]: Response code - {response.StatusCode}");
+						LogDataMessage($"CustomHttpRollover[{i}]: Response text - {responseBodyAsText}");
+					}
+					catch (Exception ex)
+					{
+						LogDebugMessage("CustomHttpRollover: " + ex.Message);
+					}
 				}
-				catch (Exception ex)
-				{
-					LogDebugMessage("CustomHttpRollover: " + ex.Message);
-				}
-				finally
-				{
-					updatingCustomHttpRollover = false;
-				}
+				
+				updatingCustomHttpRollover = false;
 			}
 		}
 

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -120,7 +120,7 @@
       <HintPath>..\packages\SSH.NET.2020.0.2\lib\net40\Renci.SshNet.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.6.1.0\lib\net472\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.6.2.0\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="Swan.Lite, Version=3.0.0.0, Culture=neutral, PublicKeyToken=30c707c872729fff, processorArchitecture=MSIL">
       <HintPath>..\packages\Unosquare.Swan.Lite.3.0.0\lib\net461\Swan.Lite.dll</HintPath>

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -110,11 +110,11 @@
     <Reference Include="MimeKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
       <HintPath>..\packages\MimeKit.3.3.0\lib\net48\MimeKit.dll</HintPath>
     </Reference>
-    <Reference Include="MQTTnet, Version=4.0.1.184, Culture=neutral, PublicKeyToken=fdb7629f2e364a63, processorArchitecture=MSIL">
-      <HintPath>..\packages\MQTTnet.4.0.1.184\lib\net461\MQTTnet.dll</HintPath>
+    <Reference Include="MQTTnet, Version=4.0.2.221, Culture=neutral, PublicKeyToken=fdb7629f2e364a63, processorArchitecture=MSIL">
+      <HintPath>..\packages\MQTTnet.4.0.2.221\lib\net461\MQTTnet.dll</HintPath>
     </Reference>
     <Reference Include="MySqlConnector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d33d3e53aa5f8c92, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySqlConnector.2.1.10\lib\net471\MySqlConnector.dll</HintPath>
+      <HintPath>..\packages\MySqlConnector.2.1.11\lib\net471\MySqlConnector.dll</HintPath>
     </Reference>
     <Reference Include="Renci.SshNet, Version=2020.0.2.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106, processorArchitecture=MSIL">
       <HintPath>..\packages\SSH.NET.2020.0.2\lib\net40\Renci.SshNet.dll</HintPath>

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -219,6 +219,7 @@
     <Compile Include="MoonriseMoonset.cs" />
     <Compile Include="MqttPublisher.cs" />
     <Compile Include="MysqlSettings.cs" />
+    <Compile Include="MySQLTable.cs" />
     <Compile Include="NOAA.cs" />
     <Compile Include="NOAAReports.cs" />
     <Compile Include="AlarmSettings.cs" />

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -1233,7 +1233,6 @@ namespace CumulusMX
 			var value = newData[1].Split('=')[1];
 			try
 			{
-				string[] dt;
 				switch (field)
 				{
 					case "highTempVal":
@@ -1413,7 +1412,6 @@ namespace CumulusMX
 						break;
 					default:
 						return "Data index not recognised";
-						break;
 				}
 			}
 			catch (Exception ex)
@@ -1622,7 +1620,6 @@ namespace CumulusMX
 							break;
 						default:
 							return "Data index not recognised";
-							break;
 					}
 				}
 			}
@@ -2788,7 +2785,6 @@ namespace CumulusMX
 			var value = newData[1].Split('=')[1];
 			try
 			{
-				string[] dt;
 				switch (field)
 				{
 					case "highTempVal":
@@ -2961,7 +2957,6 @@ namespace CumulusMX
 						break;
 					default:
 						return "Data index not recognised";
-						break;
 				}
 				station.WriteMonthIniFile();
 			}
@@ -3063,7 +3058,6 @@ namespace CumulusMX
 			var value = newData[1].Split('=')[1];
 			try
 			{
-				string[] dt;
 				switch (field)
 				{
 					case "highTempVal":
@@ -3243,7 +3237,6 @@ namespace CumulusMX
 						break;
 					default:
 						return "Data index not recognised";
-						break;
 				}
 				station.WriteYearIniFile();
 			}

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -238,7 +238,7 @@ namespace CumulusMX
 			return json.ToString();
 		}
 
-		internal string GetRecordsDayFile(string recordType)
+		internal string GetRecordsDayFile(string recordType, DateTime? start = null, DateTime? end = null)
 		{
 			const string timeStampFormat = "dd/MM/yyyy HH:mm";
 			const string dateStampFormat = "dd/MM/yyyy";
@@ -274,6 +274,7 @@ namespace CumulusMX
 
 			var thisDate = DateTime.MinValue;
 			DateTime startDate;
+			DateTime endDate = DateTime.Now;
 
 			switch (recordType)
 			{
@@ -287,6 +288,10 @@ namespace CumulusMX
 				case "thismonth":
 					now = DateTime.Now;
 					startDate = new DateTime(now.Year, now.Month, 1);
+					break;
+				case "thisperiod":
+					startDate = start.Value;
+					endDate = end.Value;
 					break;
 				default:
 					startDate = DateTime.MinValue;
@@ -324,7 +329,7 @@ namespace CumulusMX
 			// Read the dayfile list extract the records from there
 			if (station.DayFile.Count() > 0)
 			{
-				var data = station.DayFile.Where(r => r.Date >= startDate).ToList();
+				var data = station.DayFile.Where(r => r.Date >= startDate && r.Date <= endDate).ToList();
 				foreach (var rec in data)
 				{
 					if (firstRec)

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -15,6 +15,7 @@ namespace CumulusMX
 		private readonly Cumulus cumulus;
 		private WebTags webtags;
 
+
 		internal DataEditor(Cumulus cumulus)
 		{
 			this.cumulus = cumulus;
@@ -162,8 +163,10 @@ namespace CumulusMX
 
 		internal string GetAllTimeRecData()
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			const string timeStampFormat = "g";
+			const string dateStampFormat = "d";
+			const string monthFormat = "MMM yyyy";
+
 			// Records - Temperature values
 			var json = new StringBuilder("{", 1700);
 			json.Append($"\"highTempVal\":\"{station.AllTime.HighTemp.GetValString(cumulus.TempFormat)}\",");
@@ -230,7 +233,7 @@ namespace CumulusMX
 			json.Append($"\"highHourlyRainTime\":\"{station.AllTime.HourlyRain.GetTsString(timeStampFormat)}\",");
 			json.Append($"\"highDailyRainTime\":\"{station.AllTime.DailyRain.GetTsString(dateStampFormat)}\",");
 			json.Append($"\"highRain24hTime\":\"{station.AllTime.HighRain24Hours.GetTsString(timeStampFormat)}\",");
-			json.Append($"\"highMonthlyRainTime\":\"{station.AllTime.MonthlyRain.GetTsString("MM/yyyy")}\",");
+			json.Append($"\"highMonthlyRainTime\":\"{station.AllTime.MonthlyRain.GetTsString(monthFormat)}\",");
 			json.Append($"\"longestDryPeriodTime\":\"{station.AllTime.LongestDryPeriod.GetTsString(dateStampFormat)}\",");
 			json.Append($"\"longestWetPeriodTime\":\"{station.AllTime.LongestWetPeriod.GetTsString(dateStampFormat)}\"");
 			json.Append('}');
@@ -240,8 +243,9 @@ namespace CumulusMX
 
 		internal string GetRecordsDayFile(string recordType, DateTime? start = null, DateTime? end = null)
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			var timeStampFormat = "g";
+			var dateStampFormat = "d";
+			var monthFormat = "MMM yyyy";
 
 			var highTemp = new LocalRec(true);
 			var lowTemp = new LocalRec(false);
@@ -293,6 +297,8 @@ namespace CumulusMX
 				case "thisperiod":
 					startDate = start.Value;
 					endDate = end.Value;
+					timeStampFormat = "f";
+					dateStampFormat = "D";
 					break;
 				default:
 					startDate = DateTime.MinValue;
@@ -631,7 +637,7 @@ namespace CumulusMX
 			if (recordType != "thismonth")
 			{
 				json.Append($"\"highMonthlyRainValDayfile\":\"{highRainMonth.GetValString(cumulus.RainFormat)}\",");
-				json.Append($"\"highMonthlyRainTimeDayfile\":\"{highRainMonth.GetTsString("MM/yyyy")}\",");
+				json.Append($"\"highMonthlyRainTimeDayfile\":\"{highRainMonth.GetTsString(monthFormat)}\",");
 			}
 			json.Append($"\"highRain24hValDayfile\":\"{highRain24h.GetValString(cumulus.RainFormat)}\",");
 			json.Append($"\"highRain24hTimeDayfile\":\"{highRain24h.GetTsString(timeStampFormat)}\",");
@@ -646,8 +652,9 @@ namespace CumulusMX
 
 		internal string GetRecordsLogFile(string recordType)
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			const string timeStampFormat = "g";
+			const string dateStampFormat = "d";
+			const string monthFormat = "MMM yyyy";
 
 			var json = new StringBuilder("{", 2048);
 			DateTime datefrom;
@@ -1168,7 +1175,7 @@ namespace CumulusMX
 			json.Append($"\"highRain24hValLogfile\":\"{highRain24h.GetValString(cumulus.RainFormat)}\",");
 			json.Append($"\"highRain24hTimeLogfile\":\"{highRain24h.GetTsString(timeStampFormat)}\",");
 			json.Append($"\"highMonthlyRainValLogfile\":\"{highRainMonth.GetValString(cumulus.RainFormat)}\",");
-			json.Append($"\"highMonthlyRainTimeLogfile\":\"{highRainMonth.GetTsString("MM/yyyy")}\",");
+			json.Append($"\"highMonthlyRainTimeLogfile\":\"{highRainMonth.GetTsString(monthFormat)}\",");
 			if (recordType == "alltime")
 			{
 				json.Append($"\"longestDryPeriodValLogfile\":\"{dryPeriod.GetValString()}\",");
@@ -1213,7 +1220,6 @@ namespace CumulusMX
 			var newData = text.Split('&');
 			var field = newData[0].Split('=')[1];
 			var value = newData[1].Split('=')[1];
-			var result = 1;
 			try
 			{
 				string[] dt;
@@ -1223,209 +1229,187 @@ namespace CumulusMX
 						station.SetAlltime(station.AllTime.HighTemp, double.Parse(value), station.AllTime.HighTemp.Ts);
 						break;
 					case "highTempTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighTemp, station.AllTime.HighTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighTemp, station.AllTime.HighTemp.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowTempVal":
 						station.SetAlltime(station.AllTime.LowTemp, double.Parse(value), station.AllTime.LowTemp.Ts);
 						break;
 					case "lowTempTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowTemp, station.AllTime.LowTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowTemp, station.AllTime.LowTemp.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highDewPointVal":
 						station.SetAlltime(station.AllTime.HighDewPoint, double.Parse(value), station.AllTime.HighDewPoint.Ts);
 						break;
 					case "highDewPointTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighDewPoint, station.AllTime.HighDewPoint.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighDewPoint, station.AllTime.HighDewPoint.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowDewPointVal":
 						station.SetAlltime(station.AllTime.LowDewPoint, double.Parse(value), station.AllTime.LowDewPoint.Ts);
 						break;
 					case "lowDewPointTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowDewPoint, station.AllTime.LowDewPoint.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowDewPoint, station.AllTime.LowDewPoint.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highApparentTempVal":
 						station.SetAlltime(station.AllTime.HighAppTemp, double.Parse(value), station.AllTime.HighAppTemp.Ts);
 						break;
 					case "highApparentTempTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighAppTemp, station.AllTime.HighAppTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighAppTemp, station.AllTime.HighAppTemp.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowApparentTempVal":
 						station.SetAlltime(station.AllTime.LowAppTemp, double.Parse(value), station.AllTime.LowAppTemp.Ts);
 						break;
 					case "lowApparentTempTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowAppTemp, station.AllTime.LowAppTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowAppTemp, station.AllTime.LowAppTemp.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highFeelsLikeVal":
 						station.SetAlltime(station.AllTime.HighFeelsLike, double.Parse(value), station.AllTime.HighFeelsLike.Ts);
 						break;
 					case "highFeelsLikeTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighFeelsLike, station.AllTime.HighFeelsLike.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighFeelsLike, station.AllTime.HighFeelsLike.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowFeelsLikeVal":
 						station.SetAlltime(station.AllTime.LowFeelsLike, double.Parse(value), station.AllTime.LowFeelsLike.Ts);
 						break;
 					case "lowFeelsLikeTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowFeelsLike, station.AllTime.LowFeelsLike.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowFeelsLike, station.AllTime.LowFeelsLike.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highHumidexVal":
 						station.SetAlltime(station.AllTime.HighHumidex, double.Parse(value), station.AllTime.HighHumidex.Ts);
 						break;
 					case "highHumidexTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighHumidex, station.AllTime.HighHumidex.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighHumidex, station.AllTime.HighHumidex.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowWindChillVal":
 						station.SetAlltime(station.AllTime.LowChill, double.Parse(value), station.AllTime.LowChill.Ts);
 						break;
 					case "lowWindChillTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowChill, station.AllTime.LowChill.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowChill, station.AllTime.LowChill.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highHeatIndexVal":
 						station.SetAlltime(station.AllTime.HighHeatIndex, double.Parse(value), station.AllTime.HighHeatIndex.Ts);
 						break;
 					case "highHeatIndexTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighHeatIndex, station.AllTime.HighHeatIndex.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighHeatIndex, station.AllTime.HighHeatIndex.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highMinTempVal":
 						station.SetAlltime(station.AllTime.HighMinTemp, double.Parse(value), station.AllTime.HighMinTemp.Ts);
 						break;
 					case "highMinTempTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighMinTemp, station.AllTime.HighMinTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighMinTemp, station.AllTime.HighMinTemp.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowMaxTempVal":
 						station.SetAlltime(station.AllTime.LowMaxTemp, double.Parse(value), station.AllTime.LowMaxTemp.Ts);
 						break;
 					case "lowMaxTempTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowMaxTemp, station.AllTime.LowMaxTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowMaxTemp, station.AllTime.LowMaxTemp.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highDailyTempRangeVal":
 						station.SetAlltime(station.AllTime.HighDailyTempRange, double.Parse(value), station.AllTime.HighDailyTempRange.Ts);
 						break;
 					case "highDailyTempRangeTime":
-						station.SetAlltime(station.AllTime.HighDailyTempRange, station.AllTime.HighDailyTempRange.Val, Utils.ddmmyyStrToDate(value));
+						station.SetAlltime(station.AllTime.HighDailyTempRange, station.AllTime.HighDailyTempRange.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowDailyTempRangeVal":
 						station.SetAlltime(station.AllTime.LowDailyTempRange, double.Parse(value), station.AllTime.LowDailyTempRange.Ts);
 						break;
 					case "lowDailyTempRangeTime":
-						station.SetAlltime(station.AllTime.LowDailyTempRange, station.AllTime.LowDailyTempRange.Val, Utils.ddmmyyStrToDate(value));
+						station.SetAlltime(station.AllTime.LowDailyTempRange, station.AllTime.LowDailyTempRange.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highHumidityVal":
 						station.SetAlltime(station.AllTime.HighHumidity, double.Parse(value), station.AllTime.HighHumidity.Ts);
 						break;
 					case "highHumidityTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighHumidity, station.AllTime.HighHumidity.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighHumidity, station.AllTime.HighHumidity.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowHumidityVal":
 						station.SetAlltime(station.AllTime.LowHumidity, double.Parse(value), station.AllTime.LowHumidity.Ts);
 						break;
 					case "lowHumidityTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowHumidity, station.AllTime.LowHumidity.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowHumidity, station.AllTime.LowHumidity.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highBarometerVal":
 						station.SetAlltime(station.AllTime.HighPress, double.Parse(value), station.AllTime.HighPress.Ts);
 						break;
 					case "highBarometerTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighPress, station.AllTime.HighPress.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighPress, station.AllTime.HighPress.Val, localeDateTimeStrToDate(value));
 						break;
 					case "lowBarometerVal":
 						station.SetAlltime(station.AllTime.LowPress, double.Parse(value), station.AllTime.LowPress.Ts);
 						break;
 					case "lowBarometerTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.LowPress, station.AllTime.LowPress.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.LowPress, station.AllTime.LowPress.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highGustVal":
 						station.SetAlltime(station.AllTime.HighGust, double.Parse(value), station.AllTime.HighGust.Ts);
 						break;
 					case "highGustTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighGust, station.AllTime.HighGust.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighGust, station.AllTime.HighGust.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highWindVal":
 						station.SetAlltime(station.AllTime.HighWind, double.Parse(value), station.AllTime.HighWind.Ts);
 						break;
 					case "highWindTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighWind, station.AllTime.HighWind.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighWind, station.AllTime.HighWind.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highWindRunVal":
 						station.SetAlltime(station.AllTime.HighWindRun, double.Parse(value), station.AllTime.HighWindRun.Ts);
 						break;
 					case "highWindRunTime":
-						station.SetAlltime(station.AllTime.HighWindRun, station.AllTime.HighWindRun.Val, Utils.ddmmyyStrToDate(value));
+						station.SetAlltime(station.AllTime.HighWindRun, station.AllTime.HighWindRun.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highRainRateVal":
 						station.SetAlltime(station.AllTime.HighRainRate, double.Parse(value), station.AllTime.HighRainRate.Ts);
 						break;
 					case "highRainRateTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighRainRate, station.AllTime.HighRainRate.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighRainRate, station.AllTime.HighRainRate.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highHourlyRainVal":
 						station.SetAlltime(station.AllTime.HourlyRain, double.Parse(value), station.AllTime.HourlyRain.Ts);
 						break;
 					case "highHourlyRainTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HourlyRain, station.AllTime.HourlyRain.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HourlyRain, station.AllTime.HourlyRain.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highDailyRainVal":
 						station.SetAlltime(station.AllTime.DailyRain, double.Parse(value), station.AllTime.DailyRain.Ts);
 						break;
 					case "highDailyRainTime":
-						station.SetAlltime(station.AllTime.DailyRain, station.AllTime.DailyRain.Val, Utils.ddmmyyStrToDate(value));
+						station.SetAlltime(station.AllTime.DailyRain, station.AllTime.DailyRain.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highRain24hVal":
 						station.SetAlltime(station.AllTime.HighRain24Hours, double.Parse(value), station.AllTime.HighRain24Hours.Ts);
 						break;
 					case "highRain24hTime":
-						dt = value.Split('+');
-						station.SetAlltime(station.AllTime.HighRain24Hours, station.AllTime.HighRain24Hours.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+						station.SetAlltime(station.AllTime.HighRain24Hours, station.AllTime.HighRain24Hours.Val, localeDateTimeStrToDate(value));
 						break;
 					case "highMonthlyRainVal":
 						station.SetAlltime(station.AllTime.MonthlyRain, double.Parse(value), station.AllTime.MonthlyRain.Ts);
 						break;
 					case "highMonthlyRainTime":
 						// MM/yyyy
-						station.SetAlltime(station.AllTime.MonthlyRain, station.AllTime.MonthlyRain.Val, Utils.ddmmyyStrToDate("01/" + value));
+						station.SetAlltime(station.AllTime.MonthlyRain, station.AllTime.MonthlyRain.Val, localeMonthYearStrToDate(value));
 						break;
 					case "longestDryPeriodVal":
 						station.SetAlltime(station.AllTime.LongestDryPeriod, double.Parse(value), station.AllTime.LongestDryPeriod.Ts);
 						break;
 					case "longestDryPeriodTime":
-						station.SetAlltime(station.AllTime.LongestDryPeriod, station.AllTime.LongestDryPeriod.Val, Utils.ddmmyyStrToDate(value));
+						station.SetAlltime(station.AllTime.LongestDryPeriod, station.AllTime.LongestDryPeriod.Val, localeDateTimeStrToDate(value));
 						break;
 					case "longestWetPeriodVal":
 						station.SetAlltime(station.AllTime.LongestWetPeriod, double.Parse(value), station.AllTime.LongestWetPeriod.Ts);
 						break;
 					case "longestWetPeriodTime":
-						station.SetAlltime(station.AllTime.LongestWetPeriod, station.AllTime.LongestWetPeriod.Val, Utils.ddmmyyStrToDate(value));
+						station.SetAlltime(station.AllTime.LongestWetPeriod, station.AllTime.LongestWetPeriod.Val, localeDateTimeStrToDate(value));
 						break;
 					default:
-						result = 0;
+						return "Data index not recognised";
 						break;
 				}
 			}
-			catch
+			catch (Exception ex)
 			{
-				result = 0;
+				return ex.Message;
 			}
-			return "{\"result\":\"" + ((result == 1) ? "Success" : "Failed") + "\"}";
+			return "Success";
 		}
 
 		internal string EditMonthlyRecs(IHttpContext context)
@@ -1443,7 +1427,6 @@ namespace CumulusMX
 			var month = int.Parse(monthField[0]);
 			var field = monthField[1];
 			var value = newData[1].Split('=')[1];
-			var result = 1;
 			try
 			{
 				lock (station.monthlyalltimeIniThreadLock)
@@ -1455,216 +1438,195 @@ namespace CumulusMX
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighTemp, double.Parse(value), station.MonthlyRecs[month].HighTemp.Ts);
 							break;
 						case "highTempTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighTemp, station.MonthlyRecs[month].HighTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighTemp, station.MonthlyRecs[month].HighTemp.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowTempVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowTemp, double.Parse(value), station.MonthlyRecs[month].LowTemp.Ts);
 							break;
 						case "lowTempTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowTemp, station.MonthlyRecs[month].LowTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowTemp, station.MonthlyRecs[month].LowTemp.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highDewPointVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighDewPoint, double.Parse(value), station.MonthlyRecs[month].HighDewPoint.Ts);
 							break;
 						case "highDewPointTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighDewPoint, station.MonthlyRecs[month].HighDewPoint.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighDewPoint, station.MonthlyRecs[month].HighDewPoint.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowDewPointVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowDewPoint, double.Parse(value), station.MonthlyRecs[month].LowDewPoint.Ts);
 							break;
 						case "lowDewPointTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowDewPoint, station.MonthlyRecs[month].LowDewPoint.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowDewPoint, station.MonthlyRecs[month].LowDewPoint.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highApparentTempVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighAppTemp, double.Parse(value), station.MonthlyRecs[month].HighAppTemp.Ts);
 							break;
 						case "highApparentTempTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighAppTemp, station.MonthlyRecs[month].HighAppTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighAppTemp, station.MonthlyRecs[month].HighAppTemp.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowApparentTempVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowAppTemp, double.Parse(value), station.MonthlyRecs[month].LowAppTemp.Ts);
 							break;
 						case "lowApparentTempTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowAppTemp, station.MonthlyRecs[month].LowAppTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowAppTemp, station.MonthlyRecs[month].LowAppTemp.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highFeelsLikeVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighFeelsLike, double.Parse(value), station.MonthlyRecs[month].HighFeelsLike.Ts);
 							break;
 						case "highFeelsLikeTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighFeelsLike, station.MonthlyRecs[month].HighFeelsLike.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighFeelsLike, station.MonthlyRecs[month].HighFeelsLike.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowFeelsLikeVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowFeelsLike, double.Parse(value), station.MonthlyRecs[month].LowFeelsLike.Ts);
 							break;
 						case "lowFeelsLikeTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowFeelsLike, station.MonthlyRecs[month].LowFeelsLike.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowFeelsLike, station.MonthlyRecs[month].LowFeelsLike.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highHumidexVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHumidex, double.Parse(value), station.MonthlyRecs[month].HighHumidex.Ts);
 							break;
 						case "highHumidexTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHumidex, station.MonthlyRecs[month].HighHumidex.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHumidex, station.MonthlyRecs[month].HighHumidex.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowWindChillVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowChill, double.Parse(value), station.MonthlyRecs[month].LowChill.Ts);
 							break;
 						case "lowWindChillTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowChill, station.MonthlyRecs[month].LowChill.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowChill, station.MonthlyRecs[month].LowChill.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highHeatIndexVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHeatIndex, double.Parse(value), station.MonthlyRecs[month].HighHeatIndex.Ts);
 							break;
 						case "highHeatIndexTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHeatIndex, station.MonthlyRecs[month].HighHeatIndex.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHeatIndex, station.MonthlyRecs[month].HighHeatIndex.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highMinTempVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighMinTemp, double.Parse(value), station.MonthlyRecs[month].HighMinTemp.Ts);
 							break;
 						case "highMinTempTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighMinTemp, station.MonthlyRecs[month].HighMinTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighMinTemp, station.MonthlyRecs[month].HighMinTemp.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowMaxTempVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowMaxTemp, double.Parse(value), station.MonthlyRecs[month].LowMaxTemp.Ts);
 							break;
 						case "lowMaxTempTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowMaxTemp, station.MonthlyRecs[month].LowMaxTemp.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowMaxTemp, station.MonthlyRecs[month].LowMaxTemp.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highDailyTempRangeVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighDailyTempRange, double.Parse(value), station.MonthlyRecs[month].HighDailyTempRange.Ts);
 							break;
 						case "highDailyTempRangeTime":
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighDailyTempRange, station.MonthlyRecs[month].HighDailyTempRange.Val, Utils.ddmmyyStrToDate(value));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighDailyTempRange, station.MonthlyRecs[month].HighDailyTempRange.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowDailyTempRangeVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowDailyTempRange, double.Parse(value), station.MonthlyRecs[month].LowDailyTempRange.Ts);
 							break;
 						case "lowDailyTempRangeTime":
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowDailyTempRange, station.MonthlyRecs[month].LowDailyTempRange.Val, Utils.ddmmyyStrToDate(value));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowDailyTempRange, station.MonthlyRecs[month].LowDailyTempRange.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highHumidityVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHumidity, double.Parse(value), station.MonthlyRecs[month].HighHumidity.Ts);
 							break;
 						case "highHumidityTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHumidity, station.MonthlyRecs[month].HighHumidity.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighHumidity, station.MonthlyRecs[month].HighHumidity.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowHumidityVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowHumidity, double.Parse(value), station.MonthlyRecs[month].LowHumidity.Ts);
 							break;
 						case "lowHumidityTime":
 							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowHumidity, station.MonthlyRecs[month].LowHumidity.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowHumidity, station.MonthlyRecs[month].LowHumidity.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highBarometerVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighPress, double.Parse(value), station.MonthlyRecs[month].HighPress.Ts);
 							break;
 						case "highBarometerTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighPress, station.MonthlyRecs[month].HighPress.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighPress, station.MonthlyRecs[month].HighPress.Val, localeDateTimeStrToDate(value));
 							break;
 						case "lowBarometerVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowPress, double.Parse(value), station.MonthlyRecs[month].LowPress.Ts);
 							break;
 						case "lowBarometerTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowPress, station.MonthlyRecs[month].LowPress.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LowPress, station.MonthlyRecs[month].LowPress.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highGustVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighGust, double.Parse(value), station.MonthlyRecs[month].HighGust.Ts);
 							break;
 						case "highGustTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighGust, station.MonthlyRecs[month].HighGust.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighGust, station.MonthlyRecs[month].HighGust.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highWindVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighWind, double.Parse(value), station.MonthlyRecs[month].HighWind.Ts);
 							break;
 						case "highWindTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighWind, station.MonthlyRecs[month].HighWind.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighWind, station.MonthlyRecs[month].HighWind.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highWindRunVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighWindRun, double.Parse(value), station.MonthlyRecs[month].HighWindRun.Ts);
 							break;
 						case "highWindRunTime":
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighWindRun, station.MonthlyRecs[month].HighWindRun.Val, Utils.ddmmyyStrToDate(value));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighWindRun, station.MonthlyRecs[month].HighWindRun.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highRainRateVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighRainRate, double.Parse(value), station.MonthlyRecs[month].HighRainRate.Ts);
 							break;
 						case "highRainRateTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighRainRate, station.MonthlyRecs[month].HighRainRate.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighRainRate, station.MonthlyRecs[month].HighRainRate.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highHourlyRainVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HourlyRain, double.Parse(value), station.MonthlyRecs[month].HourlyRain.Ts);
 							break;
 						case "highHourlyRainTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HourlyRain, station.MonthlyRecs[month].HourlyRain.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HourlyRain, station.MonthlyRecs[month].HourlyRain.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highDailyRainVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].DailyRain, double.Parse(value), station.MonthlyRecs[month].DailyRain.Ts);
 							break;
 						case "highDailyRainTime":
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].DailyRain, station.MonthlyRecs[month].DailyRain.Val, Utils.ddmmyyStrToDate(value));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].DailyRain, station.MonthlyRecs[month].DailyRain.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highRain24hVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighRain24Hours, double.Parse(value), station.MonthlyRecs[month].HighRain24Hours.Ts);
 							break;
 						case "highRain24hTime":
-							dt = value.Split('+');
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighRain24Hours, station.MonthlyRecs[month].HighRain24Hours.Val, Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].HighRain24Hours, station.MonthlyRecs[month].HighRain24Hours.Val, localeDateTimeStrToDate(value));
 							break;
 						case "highMonthlyRainVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].MonthlyRain, double.Parse(value), station.MonthlyRecs[month].MonthlyRain.Ts);
 							break;
 						case "highMonthlyRainTime":
-							var datstr = "01/" + value;  // MM/yyyy
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].MonthlyRain, station.MonthlyRecs[month].MonthlyRain.Val, Utils.ddmmyyStrToDate(datstr));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].MonthlyRain, station.MonthlyRecs[month].MonthlyRain.Val, localeMonthYearStrToDate(value));
 							break;
 						case "longestDryPeriodVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LongestDryPeriod, double.Parse(value), station.MonthlyRecs[month].LongestDryPeriod.Ts);
 							break;
 						case "longestDryPeriodTime":
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LongestDryPeriod, station.MonthlyRecs[month].LongestDryPeriod.Val, Utils.ddmmyyStrToDate(value));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LongestDryPeriod, station.MonthlyRecs[month].LongestDryPeriod.Val, localeDateTimeStrToDate(value));
 							break;
 						case "longestWetPeriodVal":
 							station.SetMonthlyAlltime(station.MonthlyRecs[month].LongestWetPeriod, double.Parse(value), station.MonthlyRecs[month].LongestWetPeriod.Ts);
 							break;
 						case "longestWetPeriodTime":
-							station.SetMonthlyAlltime(station.MonthlyRecs[month].LongestWetPeriod, station.MonthlyRecs[month].LongestWetPeriod.Val, Utils.ddmmyyStrToDate(value));
+							station.SetMonthlyAlltime(station.MonthlyRecs[month].LongestWetPeriod, station.MonthlyRecs[month].LongestWetPeriod.Val, localeDateTimeStrToDate(value));
 							break;
 						default:
-							result = 0;
+							return "Data index not recognised";
 							break;
 					}
 				}
 			}
-			catch
+			catch (Exception ex)
 			{
-				result = 0;
+				return ex.Message;
 			}
-			return "{\"result\":\"" + ((result == 1) ? "Success" : "Failed") + "\"}";
+			return "Success";
 		}
 
 		internal string GetMonthlyRecData()
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			const string timeStampFormat = "g";
+			const string dateStampFormat = "d";
+			const string monthFormat = "MMM yyyy";
 
 			var json = new StringBuilder("{", 21000);
 			for (var m = 1; m <= 12; m++)
@@ -1734,7 +1696,7 @@ namespace CumulusMX
 				json.Append($"\"{m}-highHourlyRainTime\":\"{station.MonthlyRecs[m].HourlyRain.GetTsString(timeStampFormat)}\",");
 				json.Append($"\"{m}-highDailyRainTime\":\"{station.MonthlyRecs[m].DailyRain.GetTsString(dateStampFormat)}\",");
 				json.Append($"\"{m}-highRain24hTime\":\"{station.MonthlyRecs[m].HighRain24Hours.GetTsString(timeStampFormat)}\",");
-				json.Append($"\"{m}-highMonthlyRainTime\":\"{station.MonthlyRecs[m].MonthlyRain.GetTsString("MM/yyyy")}\",");
+				json.Append($"\"{m}-highMonthlyRainTime\":\"{station.MonthlyRecs[m].MonthlyRain.GetTsString(monthFormat)}\",");
 				json.Append($"\"{m}-longestDryPeriodTime\":\"{station.MonthlyRecs[m].LongestDryPeriod.GetTsString(dateStampFormat)}\",");
 				json.Append($"\"{m}-longestWetPeriodTime\":\"{station.MonthlyRecs[m].LongestWetPeriod.GetTsString(dateStampFormat)}\",");
 			}
@@ -1746,8 +1708,9 @@ namespace CumulusMX
 
 		internal string GetMonthlyRecDayFile()
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			const string timeStampFormat = "g";
+			const string dateStampFormat = "d";
+			const string monthFormat = "MMM yyyy";
 
 			var highTemp = new LocalRec[12];
 			var lowTemp = new LocalRec[12];
@@ -2166,7 +2129,7 @@ namespace CumulusMX
 				json.Append($"\"{m}-highRain24hValDayfile\":\"{highRain24h[i].GetValString(cumulus.RainFormat)}\",");
 				json.Append($"\"{m}-highRain24hTimeDayfile\":\"{highRain24h[i].GetTsString(timeStampFormat)}\",");
 				json.Append($"\"{m}-highMonthlyRainValDayfile\":\"{highRainMonth[i].GetValString(cumulus.RainFormat)}\",");
-				json.Append($"\"{m}-highMonthlyRainTimeDayfile\":\"{highRainMonth[i].GetTsString("MM/yyyy")}\",");
+				json.Append($"\"{m}-highMonthlyRainTimeDayfile\":\"{highRainMonth[i].GetTsString(monthFormat)}\",");
 				json.Append($"\"{m}-longestDryPeriodValDayfile\":\"{dryPeriod[i].GetValString()}\",");
 				json.Append($"\"{m}-longestDryPeriodTimeDayfile\":\"{dryPeriod[i].GetTsString(dateStampFormat)}\",");
 				json.Append($"\"{m}-longestWetPeriodValDayfile\":\"{wetPeriod[i].GetValString()}\",");
@@ -2180,8 +2143,9 @@ namespace CumulusMX
 
 		internal string GetMonthlyRecLogFile()
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			const string timeStampFormat = "g";
+			const string dateStampFormat = "d";
+			const string monthFormat = "MMM yyyy";
 
 			var json = new StringBuilder("{", 25500);
 			var datefrom = DateTime.Parse(cumulus.RecordsBeganDate);
@@ -2708,7 +2672,7 @@ namespace CumulusMX
 				json.Append($"\"{m}-highRain24hValLogfile\":\"{highRain24h[i].GetValString(cumulus.RainFormat)}\",");
 				json.Append($"\"{m}-highRain24hTimeLogfile\":\"{highRain24h[i].GetTsString(timeStampFormat)}\",");
 				json.Append($"\"{m}-highMonthlyRainValLogfile\":\"{highRainMonth[i].GetValString(cumulus.RainFormat)}\",");
-				json.Append($"\"{m}-highMonthlyRainTimeLogfile\":\"{highRainMonth[i].GetTsString("MM/yyyy")}\",");
+				json.Append($"\"{m}-highMonthlyRainTimeLogfile\":\"{highRainMonth[i].GetTsString(monthFormat)}\",");
 				json.Append($"\"{m}-longestDryPeriodValLogfile\":\"{dryPeriod[i].GetValString()}\",");
 				json.Append($"\"{m}-longestDryPeriodTimeLogfile\":\"{dryPeriod[i].GetTsString(dateStampFormat)}\",");
 				json.Append($"\"{m}-longestWetPeriodValLogfile\":\"{wetPeriod[i].GetValString()}\",");
@@ -2727,8 +2691,8 @@ namespace CumulusMX
 
 		internal string GetThisMonthRecData()
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			const string timeStampFormat = "g";
+			const string dateStampFormat = "d";
 
 			var json = new StringBuilder("{", 1700);
 			// Records - Temperature
@@ -2811,7 +2775,6 @@ namespace CumulusMX
 			var newData = text.Split('&');
 			var field = newData[0].Split('=')[1];
 			var value = newData[1].Split('=')[1];
-			var result = 1;
 			try
 			{
 				string[] dt;
@@ -2821,209 +2784,188 @@ namespace CumulusMX
 						station.ThisMonth.HighTemp.Val = double.Parse(value);
 						break;
 					case "highTempTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowTempVal":
 						station.ThisMonth.LowTemp.Val = double.Parse(value);
 						break;
 					case "lowTempTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highDewPointVal":
 						station.ThisMonth.HighDewPoint.Val = double.Parse(value);
 						break;
 					case "highDewPointTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighDewPoint.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighDewPoint.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowDewPointVal":
 						station.ThisMonth.LowDewPoint.Val = double.Parse(value);
 						break;
 					case "lowDewPointTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowDewPoint.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowDewPoint.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highApparentTempVal":
 						station.ThisMonth.HighAppTemp.Val = double.Parse(value);
 						break;
 					case "highApparentTempTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighAppTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighAppTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowApparentTempVal":
 						station.ThisMonth.LowAppTemp.Val = double.Parse(value);
 						break;
 					case "lowApparentTempTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowAppTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowAppTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highFeelsLikeVal":
 						station.ThisMonth.HighFeelsLike.Val = double.Parse(value);
 						break;
 					case "highFeelsLikeTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighFeelsLike.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighFeelsLike.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowFeelsLikeVal":
 						station.ThisMonth.LowFeelsLike.Val = double.Parse(value);
 						break;
 					case "lowFeelsLikeTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowFeelsLike.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowFeelsLike.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHumidexVal":
 						station.ThisMonth.HighHumidex.Val = double.Parse(value);
 						break;
 					case "highHumidexTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighHumidex.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighHumidex.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowWindChillVal":
 						station.ThisMonth.LowChill.Val = double.Parse(value);
 						break;
 					case "lowWindChillTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowChill.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowChill.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHeatIndexVal":
 						station.ThisMonth.HighHeatIndex.Val = double.Parse(value);
 						break;
 					case "highHeatIndexTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighHeatIndex.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighHeatIndex.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highMinTempVal":
 						station.ThisMonth.HighMinTemp.Val = double.Parse(value);
 						break;
 					case "highMinTempTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighMinTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighMinTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowMaxTempVal":
 						station.ThisMonth.LowMaxTemp.Val = double.Parse(value);
 						break;
 					case "lowMaxTempTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowMaxTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowMaxTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highDailyTempRangeVal":
 						station.ThisMonth.HighDailyTempRange.Val = double.Parse(value);
 						break;
 					case "highDailyTempRangeTime":
-						station.ThisMonth.HighDailyTempRange.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisMonth.HighDailyTempRange.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowDailyTempRangeVal":
 						station.ThisMonth.LowDailyTempRange.Val = double.Parse(value);
 						break;
 					case "lowDailyTempRangeTime":
-						station.ThisMonth.LowDailyTempRange.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisMonth.LowDailyTempRange.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHumidityVal":
 						station.ThisMonth.HighHumidity.Val = int.Parse(value);
 						break;
 					case "highHumidityTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighHumidity.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighHumidity.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowHumidityVal":
 						station.ThisMonth.LowHumidity.Val = int.Parse(value);
 						break;
 					case "lowHumidityTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowHumidity.Ts =  Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowHumidity.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highBarometerVal":
 						station.ThisMonth.HighPress.Val = double.Parse(value);
 						break;
 					case "highBarometerTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighPress.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighPress.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowBarometerVal":
 						station.ThisMonth.LowPress.Val = double.Parse(value);
 						break;
 					case "lowBarometerTime":
-						dt = value.Split('+');
-						station.ThisMonth.LowPress.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.LowPress.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highGustVal":
 						station.ThisMonth.HighGust.Val = double.Parse(value);
 						break;
 					case "highGustTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighGust.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighGust.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highWindVal":
 						station.ThisMonth.HighWind.Val = double.Parse(value);
 						break;
 					case "highWindTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighWind.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighWind.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highWindRunVal":
 						station.ThisMonth.HighWindRun.Val = double.Parse(value);
 						break;
 					case "highWindRunTime":
-						station.ThisMonth.HighWindRun.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisMonth.HighWindRun.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highRainRateVal":
 						station.ThisMonth.HighRainRate.Val = double.Parse(value);
 						break;
 					case "highRainRateTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighRainRate.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighRainRate.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHourlyRainVal":
 						station.ThisMonth.HourlyRain.Val = double.Parse(value);
 						break;
 					case "highHourlyRainTime":
-						dt = value.Split('+');
-						station.ThisMonth.HourlyRain.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HourlyRain.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highDailyRainVal":
 						station.ThisMonth.DailyRain.Val = double.Parse(value);
 						break;
 					case "highDailyRainTime":
-						station.ThisMonth.DailyRain.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisMonth.DailyRain.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highRain24hVal":
 						station.ThisMonth.HighRain24Hours.Val = double.Parse(value);
 						break;
 					case "highRain24hTime":
-						dt = value.Split('+');
-						station.ThisMonth.HighRain24Hours.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisMonth.HighRain24Hours.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "longestDryPeriodVal":
 						station.ThisMonth.LongestDryPeriod.Val = int.Parse(value);
 						break;
 					case "longestDryPeriodTime":
-						station.ThisMonth.LongestDryPeriod.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisMonth.LongestDryPeriod.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "longestWetPeriodVal":
 						station.ThisMonth.LongestWetPeriod.Val = int.Parse(value);
 						break;
 					case "longestWetPeriodTime":
-						station.ThisMonth.LongestWetPeriod.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisMonth.LongestWetPeriod.Ts = localeDateTimeStrToDate(value);
 						break;
 					default:
-						result = 0;
+						return "Data index not recognised";
 						break;
 				}
 				station.WriteMonthIniFile();
 			}
-			catch
+			catch (Exception ex)
 			{
-				result = 0;
+				return ex.Message;
 			}
-			return $"{{\"result\":\"{((result == 1) ? "Success" : "Failed")}\"}}";
+			return "Success";
 		}
 
 		internal string GetThisYearRecData()
 		{
-			const string timeStampFormat = "dd/MM/yyyy HH:mm";
-			const string dateStampFormat = "dd/MM/yyyy";
+			const string timeStampFormat = "g";
+			const string dateStampFormat = "d";
+			const string monthFormat = "MMM yyyy";
 
 			var json = new StringBuilder("{", 1800);
 			// Records - Temperature
@@ -3084,7 +3026,7 @@ namespace CumulusMX
 			json.Append($"\"highRain24hVal\":\"{station.ThisYear.HighRain24Hours.GetValString(cumulus.RainFormat)}\",");
 			json.Append($"\"highRain24hTime\":\"{station.ThisYear.HighRain24Hours.GetTsString(timeStampFormat)}\",");
 			json.Append($"\"highMonthlyRainVal\":\"{station.ThisYear.MonthlyRain.GetValString(cumulus.RainFormat)}\",");
-			json.Append($"\"highMonthlyRainTime\":\"{station.ThisYear.MonthlyRain.GetTsString("MM/yyyy")}\",");
+			json.Append($"\"highMonthlyRainTime\":\"{station.ThisYear.MonthlyRain.GetTsString(monthFormat)}\",");
 			json.Append($"\"longestDryPeriodVal\":\"{station.ThisYear.LongestDryPeriod.GetValString("F0")}\",");
 			json.Append($"\"longestDryPeriodTime\":\"{station.ThisYear.LongestDryPeriod.GetTsString(dateStampFormat)}\",");
 			json.Append($"\"longestWetPeriodVal\":\"{station.ThisYear.LongestWetPeriod.GetValString("F0")}\",");
@@ -3108,7 +3050,6 @@ namespace CumulusMX
 			var newData = text.Split('&');
 			var field = newData[0].Split('=')[1];
 			var value = newData[1].Split('=')[1];
-			var result = 1;
 			try
 			{
 				string[] dt;
@@ -3118,210 +3059,188 @@ namespace CumulusMX
 						station.ThisYear.HighTemp.Val = double.Parse(value);
 						break;
 					case "highTempTime":
-						dt = value.Split('+');
-						station.ThisYear.HighTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowTempVal":
 						station.ThisYear.LowTemp.Val = double.Parse(value);
 						break;
 					case "lowTempTime":
-						dt = value.Split('+');
-						station.ThisYear.LowTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highDewPointVal":
 						station.ThisYear.HighDewPoint.Val = double.Parse(value);
 						break;
 					case "highDewPointTime":
-						dt = value.Split('+');
-						station.ThisYear.HighDewPoint.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighDewPoint.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowDewPointVal":
 						station.ThisYear.LowDewPoint.Val = double.Parse(value);
 						break;
 					case "lowDewPointTime":
-						dt = value.Split('+');
-						station.ThisYear.LowDewPoint.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowDewPoint.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highApparentTempVal":
 						station.ThisYear.HighAppTemp.Val = double.Parse(value);
 						break;
 					case "highApparentTempTime":
-						dt = value.Split('+');
-						station.ThisYear.HighAppTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighAppTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowApparentTempVal":
 						station.ThisYear.LowAppTemp.Val = double.Parse(value);
 						break;
 					case "lowApparentTempTime":
-						dt = value.Split('+');
-						station.ThisYear.LowAppTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowAppTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highFeelsLikeVal":
 						station.ThisYear.HighFeelsLike.Val = double.Parse(value);
 						break;
 					case "highFeelsLikeTime":
-						dt = value.Split('+');
-						station.ThisYear.HighFeelsLike.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighFeelsLike.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowFeelsLikeVal":
 						station.ThisYear.LowFeelsLike.Val = double.Parse(value);
 						break;
 					case "lowFeelsLikeTime":
-						dt = value.Split('+');
-						station.ThisYear.LowFeelsLike.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowFeelsLike.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHumidexVal":
 						station.ThisYear.HighHumidex.Val = double.Parse(value);
 						break;
 					case "highHumidexTime":
-						dt = value.Split('+');
-						station.ThisYear.HighHumidex.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighHumidex.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowWindChillVal":
 						station.ThisYear.LowChill.Val = double.Parse(value);
 						break;
 					case "lowWindChillTime":
-						dt = value.Split('+');
-						station.ThisYear.LowChill.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowChill.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHeatIndexVal":
 						station.ThisYear.HighHeatIndex.Val = double.Parse(value);
 						break;
 					case "highHeatIndexTime":
-						dt = value.Split('+');
-						station.ThisYear.HighHeatIndex.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighHeatIndex.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highMinTempVal":
 						station.ThisYear.HighMinTemp.Val = double.Parse(value);
 						break;
 					case "highMinTempTime":
-						dt = value.Split('+');
-						station.ThisYear.HighMinTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighMinTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowMaxTempVal":
 						station.ThisYear.LowMaxTemp.Val = double.Parse(value);
 						break;
 					case "lowMaxTempTime":
-						dt = value.Split('+');
-						station.ThisYear.LowMaxTemp.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowMaxTemp.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highDailyTempRangeVal":
 						station.ThisYear.HighDailyTempRange.Val = double.Parse(value);
 						break;
 					case "highDailyTempRangeTime":
-						station.ThisYear.HighDailyTempRange.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisYear.HighDailyTempRange.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowDailyTempRangeVal":
 						station.ThisYear.LowDailyTempRange.Val = double.Parse(value);
 						break;
 					case "lowDailyTempRangeTime":
-						station.ThisYear.LowDailyTempRange.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisYear.LowDailyTempRange.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHumidityVal":
 						station.ThisYear.HighHumidity.Val = int.Parse(value);
 						break;
 					case "highHumidityTime":
-						dt = value.Split('+');
-						station.ThisYear.HighHumidity.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighHumidity.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowHumidityVal":
 						station.ThisYear.LowHumidity.Val = int.Parse(value);
 						break;
 					case "lowHumidityTime":
-						dt = value.Split('+');
-						station.ThisYear.LowHumidity.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowHumidity.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highBarometerVal":
 						station.ThisYear.HighPress.Val = double.Parse(value);
 						break;
 					case "highBarometerTime":
-						dt = value.Split('+');
-						station.ThisYear.HighPress.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighPress.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "lowBarometerVal":
 						station.ThisYear.LowPress.Val = double.Parse(value);
 						break;
 					case "lowBarometerTime":
-						dt = value.Split('+');
-						station.ThisYear.LowPress.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.LowPress.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highGustVal":
 						station.ThisYear.HighGust.Val = double.Parse(value);
 						break;
 					case "highGustTime":
-						dt = value.Split('+');
-						station.ThisYear.HighGust.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighGust.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highWindVal":
 						station.ThisYear.HighWind.Val = double.Parse(value);
 						break;
 					case "highWindTime":
-						dt = value.Split('+');
-						station.ThisYear.HighWind.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighWind.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highWindRunVal":
 						station.ThisYear.HighWindRun.Val = double.Parse(value);
 						break;
 					case "highWindRunTime":
-						station.ThisYear.HighWindRun.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisYear.HighWindRun.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highRainRateVal":
 						station.ThisYear.HighRainRate.Val = double.Parse(value);
 						break;
 					case "highRainRateTime":
-						dt = value.Split('+');
-						station.ThisYear.HighRainRate.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighRainRate.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highHourlyRainVal":
 						station.ThisYear.HourlyRain.Val = double.Parse(value);
 						break;
 					case "highHourlyRainTime":
-						dt = value.Split('+');
-						station.ThisYear.HourlyRain.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HourlyRain.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highDailyRainVal":
 						station.ThisYear.DailyRain.Val = double.Parse(value);
 						break;
 					case "highDailyRainTime":
-						station.ThisYear.DailyRain.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisYear.DailyRain.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highRain24hVal":
 						station.ThisYear.HighRain24Hours.Val = double.Parse(value);
 						break;
 					case "highRain24hTime":
-						dt = value.Split('+');
-						station.ThisYear.HighRain24Hours.Ts = Utils.ddmmyyhhmmStrToDate(dt[0], dt[1]);
+						station.ThisYear.HighRain24Hours.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "highMonthlyRainVal":
 						station.ThisYear.MonthlyRain.Val = double.Parse(value);
 						break;
 					case "highMonthlyRainTime":
 						// MM/yyyy
-						station.ThisYear.MonthlyRain.Ts = Utils.ddmmyyStrToDate("01/" + value);
+						station.ThisYear.MonthlyRain.Ts = localeMonthYearStrToDate(value);
 						break;
 					case "longestDryPeriodVal":
 						station.ThisYear.LongestDryPeriod.Val = int.Parse(value);
 						break;
 					case "longestDryPeriodTime":
-						station.ThisYear.LongestDryPeriod.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisYear.LongestDryPeriod.Ts = localeDateTimeStrToDate(value);
 						break;
 					case "longestWetPeriodVal":
 						station.ThisYear.LongestWetPeriod.Val = int.Parse(value);
 						break;
 					case "longestWetPeriodTime":
-						station.ThisYear.LongestWetPeriod.Ts = Utils.ddmmyyStrToDate(value);
+						station.ThisYear.LongestWetPeriod.Ts = localeDateTimeStrToDate(value);
 						break;
 					default:
-						result = 0;
+						return "Data index not recognised";
 						break;
 				}
 				station.WriteYearIniFile();
 			}
-			catch
+			catch (Exception ex)
 			{
-				result = 0;
+				return ex.Message;
 			}
-			return $"{{\"result\":\"{((result == 1) ? "Success" : "Failed")}\"}}";
+			return "Success";
 		}
 
 		internal string GetCurrentCond()
@@ -3802,6 +3721,23 @@ namespace CumulusMX
 		{
 			var lastrain = new LastHourRainLog(ts, rain);
 			h24Queue.Enqueue(lastrain);
+		}
+
+
+		private static DateTime localeDateTimeStrToDate(string dt)
+		{
+			dt = dt.Replace('+', ' ');
+
+			// let this throw on invalid input
+			return DateTime.Parse(dt);
+		}
+
+		private static DateTime localeMonthYearStrToDate(string dt)
+		{
+			dt = dt.Replace('+', ' ');
+
+			// let this throw on invalid input
+			return DateTime.ParseExact("01 " + dt, "dd MMM yyyy", CultureInfo.CurrentCulture);
 		}
 
 		private class LastHourRainLog

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -759,14 +759,13 @@ namespace CumulusMX
 			var rain24hLog = new Queue<LastHourRainLog>();
 
 			var totalRainfall = 0.0;
+			var monthlyRain = 0.0;
 
 			var watch = System.Diagnostics.Stopwatch.StartNew();
 
 
 			while (!finished)
 			{
-				double monthlyRain = 0;
-
 				if (File.Exists(logFile))
 				{
 					cumulus.LogDebugMessage($"GetAllTimeRecLogFile: Processing log file - {logFile}");
@@ -967,7 +966,7 @@ namespace CumulusMX
 								{
 									dayRain = rec.RainToday;
 								}
-								else if (rec.Raincounter - lastentrycounter < counterJumpTooBig)
+								else if ((rec.Raincounter - lastentrycounter > 0) && (rec.Raincounter - lastentrycounter < counterJumpTooBig))
 								{
 									dayRain += (rec.Raincounter - lastentrycounter) * cumulus.Calib.Rain.Mult;
 								}
@@ -2472,7 +2471,7 @@ namespace CumulusMX
 								{
 									dayRain = rec.RainToday;
 								}
-								else if (rec.Raincounter - lastentrycounter < counterJumpTooBig)
+								else if ((rec.Raincounter - lastentrycounter > 0) && (rec.Raincounter - lastentrycounter < counterJumpTooBig))
 								{
 									dayRain += (rec.Raincounter - lastentrycounter) * cumulus.Calib.Rain.Mult;
 								}

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -432,7 +432,7 @@ namespace CumulusMX
 					if (rec.HighRain24h > highRain24h.Value)
 					{
 						highRain24h.Value = rec.HighRain24h;
-						highRain24h.Ts = rec.Date.Date;
+						highRain24h.Ts = rec.HighRain24hTime;
 					}
 
 					// dry/wet period
@@ -763,6 +763,8 @@ namespace CumulusMX
 
 			var watch = System.Diagnostics.Stopwatch.StartNew();
 
+			double _day24h = 0;
+			DateTime _dayTs;
 
 			while (!finished)
 			{
@@ -777,7 +779,7 @@ namespace CumulusMX
 						foreach (var line in logfile)
 						{
 							// process each record in the file
-							linenum++;
+							linenum++; 
 
 							var rec = station.ParseLogFileRec(line, true);
 
@@ -800,12 +802,13 @@ namespace CumulusMX
 								else
 								{
 									// OK we are within 24 hours of the start date, so record rain values
-									Add24HourRainEntry(rec.Date, totalRainfall + rec.RainToday, ref rain24hLog);
+									AddLastHoursRainEntry(rec.Date, totalRainfall + rec.RainToday, ref rain1hLog, ref rain24hLog);
 									lastentryrain = rec.RainToday;
 									lastentrycounter = rec.Raincounter;
 									continue;
 								}
 							}
+
 							// low chill
 							if (rec.WindChill > Cumulus.DefaultHiVal && rec.WindChill < lowWindChill.Value)
 							{
@@ -1068,6 +1071,12 @@ namespace CumulusMX
 								highRain24h.Value = rain24h;
 								highRain24h.Ts = rec.Date;
 							}
+							if (rain24h > _day24h)
+							{
+								_day24h = rain24h;
+								_dayTs = rec.Date;
+								//System.Diagnostics.Debugger.Break();
+							}
 
 							// new meteo day, part 2
 							if (currentDay.Date != metoDate.Date)
@@ -1077,6 +1086,9 @@ namespace CumulusMX
 								dayLowTemp.Value = rec.OutdoorTemperature;
 								dayWindRun = 0;
 								totalRainfall += dayRain;
+								
+								_day24h = rain24h;
+								_dayTs = rec.Date;
 							}
 
 							lastentrydate = rec.Date;
@@ -1902,11 +1914,11 @@ namespace CumulusMX
 						highRainDay[monthOffset].Value = station.DayFile[i].TotalRain;
 						highRainDay[monthOffset].Ts = loggedDate;
 					}
-
+					// hi 24h rain
 					if (station.DayFile[i].HighRain24h > highRain24h[monthOffset].Value)
 					{
 						highRain24h[monthOffset].Value = station.DayFile[i].HighRain24h;
-						highRain24h[monthOffset].Ts = loggedDate;
+						highRain24h[monthOffset].Ts = station.DayFile[i].HighRain24hTime;
 					}
 
 					// monthly rain

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -698,7 +698,6 @@ namespace CumulusMX
 
 		public override void startReadingHistoryData()
 		{
-			cumulus.CurrentActivity = "Reading archive data";
 			//lastArchiveTimeUTC = getLastArchiveTime();
 			cumulus.LogMessage("Reading history data from log files");
 
@@ -757,7 +756,7 @@ namespace CumulusMX
 			//{
 			//    UpdateHighsAndLows(dataContext);
 			//}
-			cumulus.CurrentActivity = "Normal running";
+			cumulus.NormalRunning = true;
 			//if (cumulus.UseDavisLoop2 && cumulus.PeakGustMinutes >= 10)
 			//{
 			//    CalcRecentMaxGust = false;
@@ -2427,8 +2426,8 @@ namespace CumulusMX
 							if ((h == 0) && !midnightraindone)
 							{
 								ResetMidnightRain(timestamp);
-								ResetSunshineHours();
-								ResetMidnightTemperatures();
+								ResetSunshineHours(timestamp);
+								ResetMidnightTemperatures(timestamp);
 								midnightraindone = true;
 							}
 

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -3306,6 +3306,10 @@ namespace CumulusMX
 			else
 			{
 				cumulus.LogMessage($"ERROR: No broadcast data received from the WLL for {tmrBroadcastWatchdog.Interval / 1000} seconds");
+				if (!DataStopped)
+				{
+					DataStoppedTime = DateTime.Now;
+				}
 				DataStopped = true;
 				cumulus.DataStoppedAlarm.LastError = $"No broadcast data received from the WLL for {tmrBroadcastWatchdog.Interval / 1000} seconds";
 				cumulus.DataStoppedAlarm.Triggered = true;

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -1414,7 +1414,6 @@ namespace CumulusMX
 
 		public override void startReadingHistoryData()
 		{
-			cumulus.CurrentActivity = "Reading archive data";
 			cumulus.LogMessage("WLL history: Reading history data from log files");
 			LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
 
@@ -1442,7 +1441,7 @@ namespace CumulusMX
 			//{
 			//    UpdateHighsAndLows(dataContext);
 			//}
-			cumulus.CurrentActivity = "Normal running";
+			cumulus.NormalRunning = true;
 
 			// restore settings
 			cumulus.StationOptions.UseSpeedForAvgCalc = savedUseSpeedForAvgCalc;
@@ -1736,8 +1735,8 @@ namespace CumulusMX
 					if ((h == 0) && !midnightraindone)
 					{
 						ResetMidnightRain(timestamp);
-						ResetSunshineHours();
-						ResetMidnightTemperatures();
+						ResetSunshineHours(timestamp);
+						ResetMidnightTemperatures(timestamp);
 						midnightraindone = true;
 					}
 

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -1186,8 +1186,8 @@ namespace CumulusMX
 				if (h == 0 && !midnightraindone)
 				{
 					station.ResetMidnightRain(rec.Key);
-					station.ResetSunshineHours();
-					station.ResetMidnightTemperatures();
+					station.ResetSunshineHours(rec.Key);
+					station.ResetMidnightTemperatures(rec.Key);
 					midnightraindone = true;
 				}
 

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -140,7 +140,6 @@ namespace CumulusMX
 
 		public override void startReadingHistoryData()
 		{
-			cumulus.CurrentActivity = "Getting archive data";
 			//lastArchiveTimeUTC = getLastArchiveTime();
 
 			LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
@@ -165,7 +164,7 @@ namespace CumulusMX
 
 		private void bw_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
 		{
-			cumulus.CurrentActivity = "Normal running";
+			cumulus.NormalRunning = true;
 			cumulus.LogMessage("Archive reading thread completed");
 			Start();
 			DoDayResetIfNeeded();
@@ -394,8 +393,8 @@ namespace CumulusMX
 				if (h == 0 && !midnightraindone)
 				{
 					ResetMidnightRain(timestamp);
-					ResetSunshineHours();
-					ResetMidnightTemperatures();
+					ResetSunshineHours(timestamp);
+					ResetMidnightTemperatures(timestamp);
 					midnightraindone = true;
 				}
 

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -710,6 +710,11 @@ namespace CumulusMX
 
 			if (hidDevice == null)
 			{
+				if (!DataStopped)
+				{
+					DataStoppedTime = DateTime.Now;
+				}
+
 				DataStopped = true;
 				cumulus.DataStoppedAlarm.LastError = "USB device no longer detected";
 				cumulus.DataStoppedAlarm.Triggered = true;
@@ -726,6 +731,10 @@ namespace CumulusMX
 				cumulus.LogConsoleMessage("Error sending command to station - it may need resetting", ConsoleColor.Red, true);
 				cumulus.LogMessage(ex.Message);
 				cumulus.LogMessage("Error sending command to station - it may need resetting");
+				if (!DataStopped)
+				{
+					DataStoppedTime = DateTime.Now;
+				}
 				DataStopped = true;
 				cumulus.DataStoppedAlarm.LastError = "Error reading data from station - it may need resetting. " + ex.Message;
 				cumulus.DataStoppedAlarm.Triggered = true;
@@ -745,6 +754,10 @@ namespace CumulusMX
 					cumulus.LogConsoleMessage("Error reading data from station - it may need resetting", ConsoleColor.Red, true);
 					cumulus.LogMessage(ex.Message);
 					cumulus.LogMessage("Error reading data from station - it may need resetting");
+					if (!DataStopped)
+					{
+						DataStoppedTime = DateTime.Now;
+					}
 					DataStopped = true;
 					cumulus.DataStoppedAlarm.LastError = "Error reading data from station - it may need resetting. " + ex.Message;
 					cumulus.DataStoppedAlarm.Triggered = true;
@@ -783,6 +796,10 @@ namespace CumulusMX
 				cumulus.LogConsoleMessage("Error sending command to station - it may need resetting");
 				cumulus.LogMessage(ex.Message);
 				cumulus.LogMessage("Error sending command to station - it may need resetting");
+				if (!DataStopped)
+				{
+					DataStoppedTime = DateTime.Now;
+				}
 				DataStopped = true;
 				cumulus.DataStoppedAlarm.LastError = "Error sending command to station - it may need resetting: " + ex.Message;
 				cumulus.DataStoppedAlarm.Triggered = true;

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -1632,6 +1632,10 @@ namespace CumulusMX
 			else
 			{
 				cumulus.LogMessage($"ERROR: No data received from the GW1000 for {tmrDataWatchdog.Interval / 1000} seconds");
+				if (!DataStopped)
+				{
+					DataStoppedTime = DateTime.Now;
+				}
 				DataStopped = true;
 				cumulus.DataStoppedAlarm.LastError = $"No data received from the GW1000 for {tmrDataWatchdog.Interval / 1000} seconds";
 				cumulus.DataStoppedAlarm.Triggered = true;

--- a/CumulusMX/ImetStation.cs
+++ b/CumulusMX/ImetStation.cs
@@ -58,7 +58,6 @@ namespace CumulusMX
 				}
 
 				// Read the data from the logger
-				cumulus.CurrentActivity = "Reading archive data";
 				startReadingHistoryData();
 			}
 		}
@@ -442,7 +441,7 @@ namespace CumulusMX
 			//histprog.Close();
 			//mainWindow.FillLastHourGraphData();
 
-			cumulus.CurrentActivity = "Normal running";
+			cumulus.NormalRunning = true;
 			cumulus.LogMessage("Archive reading thread completed");
 			DoDayResetIfNeeded();
 			DoTrendValues(DateTime.Now);
@@ -799,8 +798,8 @@ namespace CumulusMX
 							if ((hour == 0) && !midnightraindone)
 							{
 								ResetMidnightRain(timestamp);
-								ResetSunshineHours();
-								ResetMidnightTemperatures();
+								ResetSunshineHours(timestamp);
+								ResetMidnightTemperatures(timestamp);
 								midnightraindone = true;
 							}
 						}

--- a/CumulusMX/IniFile.cs
+++ b/CumulusMX/IniFile.cs
@@ -305,7 +305,33 @@ namespace CumulusMX
 			}
 		}
 
-			// *** Encode byte array ***
+		internal void DeleteValue(string SectionName, string Key)
+		{
+			// *** Lazy loading ***
+			if (m_Lazy)
+			{
+				m_Lazy = false;
+				Refresh();
+			}
+
+			lock (m_Lock)
+			{
+				// *** Check if the section exists ***
+				Dictionary<string, string> Section;
+				if (!m_Sections.TryGetValue(SectionName, out Section)) return;
+
+				// *** Check if the key exists ***
+				string Value;
+				if (Section.TryGetValue(Key, out Value))
+				{
+					m_CacheModified = true;
+					Section.Remove(Key);
+				}
+			}
+
+		}
+
+		// *** Encode byte array ***
 		private string EncodeByteArray(byte[] Value)
 		{
 			if (Value == null) return null;

--- a/CumulusMX/InternetSettings.cs
+++ b/CumulusMX/InternetSettings.cs
@@ -70,8 +70,10 @@ namespace CumulusMX
 						cumulus.FTPRename = settings.website.general.ftprename;
 						cumulus.UTF8encode = settings.website.general.utf8encode;
 
+
 						if (cumulus.FtpOptions.FtpMode == Cumulus.FtpProtocols.FTP || cumulus.FtpOptions.FtpMode == Cumulus.FtpProtocols.FTPS)
 						{
+							cumulus.FtpOptions.AutoDetect = settings.website.advanced.autodetect;
 							cumulus.FtpOptions.ActiveMode = settings.website.advanced.activeftp;
 							cumulus.FtpOptions.DisableEPSV = settings.website.advanced.disableftpsepsv;
 						}
@@ -79,6 +81,7 @@ namespace CumulusMX
 						if (cumulus.FtpOptions.FtpMode == Cumulus.FtpProtocols.FTPS)
 						{
 							cumulus.FtpOptions.DisableExplicit = settings.website.advanced.disableftpsexplicit;
+							cumulus.FtpOptions.IgnoreCertErrors = settings.website.advanced.ignorecerts;
 						}
 					}
 
@@ -343,9 +346,11 @@ namespace CumulusMX
 
 			var websettingsadvanced = new JsonInternetSettingsWebsiteAdvanced()
 			{
+				autodetect = cumulus.FtpOptions.AutoDetect,
 				activeftp = cumulus.FtpOptions.ActiveMode,
 				disableftpsepsv = cumulus.FtpOptions.DisableEPSV,
-				disableftpsexplicit = cumulus.FtpOptions.DisableExplicit
+				disableftpsexplicit = cumulus.FtpOptions.DisableExplicit,
+				ignorecerts = cumulus.FtpOptions.IgnoreCertErrors
 			};
 
 			var websettingsgeneral = new JsonInternetSettingsWebSettingsGeneral()
@@ -653,9 +658,11 @@ namespace CumulusMX
 
 	public class JsonInternetSettingsWebsiteAdvanced
 	{
+		public bool autodetect { get; set; }
 		public bool activeftp { get; set; }
 		public bool disableftpsepsv { get; set; }
 		public bool disableftpsexplicit { get; set; }
+		public bool ignorecerts { get; set; }
 	}
 
 	public class JsonInternetSettingsWebsite

--- a/CumulusMX/MySQLTable.cs
+++ b/CumulusMX/MySQLTable.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CumulusMX
+{
+	internal class MySqlTable
+	{
+		internal string Name;
+		internal List<Column> Columns;
+
+		private string _insertStart;
+		private string _PrimaryKey;
+		private string _Comment;
+
+		public MySqlTable(string TableName)
+		{
+			Name = TableName;
+			Columns = new List<Column>();
+		}
+
+
+		public string CreateCommand
+		{
+			get
+			{
+				var create = new StringBuilder($"CREATE TABLE {Name} (", 2048);
+				// add the columns
+				foreach (var col in Columns)
+				{
+					create.Append($"{col.Name} {col.Attributes},");
+				}
+
+				// add the primary key (if any)
+				if (!string.IsNullOrEmpty(_PrimaryKey))
+				{
+					create.Append($" PRIMARY KEY ({_PrimaryKey})");
+				}
+
+				// close the column list
+				create.Append(')');
+
+				// strip trailing comma (if any)
+				if (create[create.Length - 1] == ',')
+				{
+					create.Length--;
+				}
+
+				// add the comment (if any)
+				if (!string.IsNullOrEmpty(_Comment))
+				{
+					create.Append(" COMMENT=" + _Comment);
+				}
+
+				return create.ToString();
+			}
+		}
+
+
+		public string StartOfInsert
+		{
+			get
+			{
+				if (_insertStart == null)
+				{
+					var insert = new StringBuilder($"INSERT IGNORE INTO {Name} (", 2048);
+					foreach (var col in Columns)
+					{
+						insert.Append(col.Name + ",");
+					}
+
+					// replace trailing comma with closing brace
+					insert[insert.Length - 1] = ')';
+					_insertStart = insert.ToString();
+				}
+
+				return _insertStart;
+			}
+		}
+
+		public string PrimaryKey
+		{
+			get 
+			{	
+				return _PrimaryKey;
+			}
+			set
+			{
+				_PrimaryKey = value;
+			}
+		}
+
+		public string Comment
+		{
+			get
+			{
+				return _Comment;
+			}
+			set
+			{
+				_Comment = value;
+			}
+		}
+
+
+		public void AddColumn(string ColName, string ColAttributes)
+		{
+			Columns.Add(new Column(ColName, ColAttributes));
+		}
+
+		public void Rebuild()
+		{
+			// reset the strings so they are recreated on next use
+			_insertStart = null;
+		}
+
+		internal class Column
+		{
+			internal string Name;
+			internal string Attributes;
+
+			public Column (string ColName, string ColAttributes)
+			{
+				Name = ColName;
+				Attributes = ColAttributes;
+			}
+		}
+	}
+}

--- a/CumulusMX/MysqlSettings.cs
+++ b/CumulusMX/MysqlSettings.cs
@@ -4,6 +4,7 @@ using System.Net;
 using MySqlConnector;
 using ServiceStack;
 using EmbedIO;
+using System.Text;
 
 namespace CumulusMX
 {
@@ -55,22 +56,67 @@ namespace CumulusMX
 			var customseconds = new JsonMysqlSettingsCustomSeconds()
 			{
 				enabled = cumulus.MySqlSettings.CustomSecs.Enabled,
-				command = cumulus.MySqlSettings.CustomSecs.Command,
 				interval = cumulus.MySqlSettings.CustomSecs.Interval
+
 			};
+
+			var cmdCnt = 1;
+			for (var i = 1; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomSecs.Commands[i]))
+					cmdCnt++;
+			}
+			customseconds.command = new string[cmdCnt];
+
+			var index = 0;
+			for (var i = 0; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomSecs.Commands[i]))
+					customseconds.command[index++] = cumulus.MySqlSettings.CustomSecs.Commands[i];
+			}
+
 
 			var customminutes = new JsonMysqlSettingsCustomMinutes()
 			{
 				enabled = cumulus.MySqlSettings.CustomMins.Enabled,
-				command = cumulus.MySqlSettings.CustomMins.Command,
 				intervalindex = cumulus.CustomMySqlMinutesIntervalIndex
 			};
 
+			cmdCnt = 1;
+			for (var i = 1; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomMins.Commands[i]))
+					cmdCnt++;
+			}
+			customminutes.command = new string[cmdCnt];
+
+			index = 0;
+			for (var i = 0; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomMins.Commands[i]))
+					customminutes.command[index++] = cumulus.MySqlSettings.CustomMins.Commands[i];
+			}
+
 			var customrollover = new JsonMysqlSettingsCustomRollover()
 			{
-				enabled = cumulus.MySqlSettings.CustomRollover.Enabled,
-				command = cumulus.MySqlSettings.CustomRollover.Command,
+				enabled = cumulus.MySqlSettings.CustomRollover.Enabled
 			};
+
+			cmdCnt = 1;
+			for (var i = 1; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomRollover.Commands[i]))
+					cmdCnt++;
+			}
+			customrollover.command = new string[cmdCnt];
+
+			index = 0;
+			for (var i = 0; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomRollover.Commands[i]))
+					customrollover.command[index++] = cumulus.MySqlSettings.CustomRollover.Commands[i];
+			}
+
 
 			var options = new JsonMysqlSettingsOptions()
 			{
@@ -146,6 +192,11 @@ namespace CumulusMX
 				if (cumulus.MySqlSettings.Monthly.Enabled)
 				{
 					cumulus.MySqlSettings.Monthly.TableName = String.IsNullOrWhiteSpace(settings.monthly.table) ? "Monthly" : settings.monthly.table;
+					if (settings.monthly.table != cumulus.MonthlyTable.Name)
+					{
+						cumulus.MonthlyTable.Name = settings.monthly.table;
+						cumulus.MonthlyTable.Rebuild();
+					}
 				}
 				//realtime
 				cumulus.MySqlSettings.Realtime.Enabled = settings.realtime.enabled;
@@ -154,25 +205,52 @@ namespace CumulusMX
 					cumulus.MySqlSettings.RealtimeRetention = settings.realtime.retentionVal + " " + settings.realtime.retentionUnit;
 					cumulus.MySqlSettings.Realtime.TableName = String.IsNullOrWhiteSpace(settings.realtime.table) ? "Realtime" : settings.realtime.table;
 					cumulus.MySqlSettings.RealtimeLimit1Minute = settings.realtime.limit1min;
+					if (settings.realtime.table != cumulus.RealtimeTable.Name)
+					{
+						cumulus.RealtimeTable.Name = settings.realtime.table;
+						cumulus.RealtimeTable.Rebuild();
+					}
 				}
 				//dayfile
 				cumulus.MySqlSettings.Dayfile.Enabled = settings.dayfile.enabled;
 				if (cumulus.MySqlSettings.Dayfile.Enabled)
 				{
 					cumulus.MySqlSettings.Dayfile.TableName = String.IsNullOrWhiteSpace(settings.dayfile.table) ? "Dayfile" : settings.dayfile.table;
+					if (settings.dayfile.table != cumulus.DayfileTable.Name)
+					{
+						cumulus.DayfileTable.Name = settings.dayfile.table;
+						cumulus.DayfileTable.Rebuild();
+					}
 				}
 				// custom seconds
 				cumulus.MySqlSettings.CustomSecs.Enabled = settings.customseconds.enabled;
 				if (cumulus.MySqlSettings.CustomSecs.Enabled)
 				{
-					cumulus.MySqlSettings.CustomSecs.Command = settings.customseconds.command;
+					cumulus.MySqlSettings.CustomSecs.Commands[0] = settings.customseconds.command[0] ?? string.Empty;
+					for (var i = 1; i < 10; i++)
+					{
+						if (i < settings.customseconds.command.Length)
+							cumulus.MySqlSettings.CustomSecs.Commands[i] = settings.customseconds.command[i] ?? null;
+						else
+							cumulus.MySqlSettings.CustomSecs.Commands[i] = null;
+					}
+
 					cumulus.MySqlSettings.CustomSecs.Interval = settings.customseconds.interval;
 				}
 				// custom minutes
 				cumulus.MySqlSettings.CustomMins.Enabled = settings.customminutes.enabled;
 				if (cumulus.MySqlSettings.CustomMins.Enabled)
 				{
-					cumulus.MySqlSettings.CustomMins.Command = settings.customminutes.command;
+					cumulus.MySqlSettings.CustomMins.Commands[0] = settings.customminutes.command[0] ?? string.Empty;
+					for (var i = 1; i < 10; i++)
+					{
+						if (i < settings.customminutes.command.Length)
+							cumulus.MySqlSettings.CustomMins.Commands[i] = settings.customminutes.command[i] ?? null;
+						else
+							cumulus.MySqlSettings.CustomMins.Commands[i] = null;
+					}
+
+
 					cumulus.CustomMySqlMinutesIntervalIndex = settings.customminutes.intervalindex;
 					if (cumulus.CustomMySqlMinutesIntervalIndex >= 0 && cumulus.CustomMySqlMinutesIntervalIndex < cumulus.FactorsOf60.Length)
 					{
@@ -187,20 +265,19 @@ namespace CumulusMX
 				cumulus.MySqlSettings.CustomRollover.Enabled = settings.customrollover.enabled;
 				if (cumulus.MySqlSettings.CustomRollover.Enabled)
 				{
-					cumulus.MySqlSettings.CustomRollover.Command = settings.customrollover.command;
+					cumulus.MySqlSettings.CustomRollover.Commands[0] = settings.customrollover.command[0];
+					for (var i = 1; i < 10; i++)
+					{
+						if (i < settings.customrollover.command.Length)
+							cumulus.MySqlSettings.CustomRollover.Commands[i] = settings.customrollover.command[i] ?? null;
+						else
+							cumulus.MySqlSettings.CustomRollover.Commands[i] = null;
+					}
+
 				}
 
 				// Save the settings
 				cumulus.WriteIniFile();
-
-				cumulus.SetMonthlySqlCreateString();
-				cumulus.SetStartOfMonthlyInsertSQL();
-
-				cumulus.SetDayfileSqlCreateString();
-				cumulus.SetStartOfDayfileInsertSQL();
-
-				cumulus.SetRealtimeSqlCreateString();
-				cumulus.SetStartOfRealtimeInsertSQL();
 
 				cumulus.CustomMysqlSecondsTimer.Interval = cumulus.MySqlSettings.CustomSecs.Interval * 1000;
 				cumulus.CustomMysqlSecondsTimer.Enabled = cumulus.MySqlSettings.CustomSecs.Enabled;
@@ -251,28 +328,92 @@ namespace CumulusMX
 			return res;
 		}
 
-		//public string CreateMonthlySQL(HttpListenerContext context)
+		private string UpdateMySQLTable(MySqlTable table)
+		{
+			string res;
+			int colsNow;
+			int cnt = 0;
+
+			try
+			{
+				using (var mySqlConn = new MySqlConnection(cumulus.MySqlConnSettings.ToString()))
+				{
+					mySqlConn.Open();
+
+					// first get a count of the columns the table currenty has
+					using (MySqlCommand cmd = new MySqlCommand($"SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='{table.Name}' AND TABLE_SCHEMA='{cumulus.MySqlConnSettings.Database}'", mySqlConn))
+					{
+						colsNow = int.Parse(cmd.ExecuteScalar().ToString());
+					}
+
+					if (colsNow < table.Columns.Count)
+					{
+						var update = new StringBuilder("ALTER TABLE " + table.Name, 1024);
+						while (colsNow < table.Columns.Count)
+						{
+							update.Append($" ADD COLUMN {table.Columns[colsNow].Name} {table.Columns[colsNow].Attributes},");
+							colsNow++;
+							cnt++;
+						}
+
+						// strip trailing comma
+						update.Length--;
+
+						using(MySqlCommand cmd = new MySqlCommand(update.ToString(), mySqlConn))
+						{
+							int aff = cmd.ExecuteNonQuery();
+							cumulus.LogMessage($"MySQL Update Table: {aff} items were affected.");
+							res = $"Added {cnt} columns to {table.Name} table";
+
+						}
+					}
+					else
+					{
+						res = $"The {table.Name} already has the correct number of columns = {table.Columns.Count}";
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage("MySQL Update Table: Error encountered during MySQL operation.");
+				cumulus.LogMessage(ex.Message);
+				res = "Error: " + ex.Message;
+			}
+
+			return res;
+		}
+
 		public string CreateMonthlySQL(IHttpContext context)
 		{
 			context.Response.StatusCode = 200;
-			string json = "{\"result\":\"" + CreateMySQLTable(cumulus.CreateMonthlySQL) + "\"}";
-			return json;
+			return "{\"result\":\"" + CreateMySQLTable(cumulus.MonthlyTable.CreateCommand) + "\"}";
 		}
 
-		//public string CreateDayfileSQL(HttpListenerContext context)
 		public string CreateDayfileSQL(IHttpContext context)
 		{
 			context.Response.StatusCode = 200;
-			string json = "{\"result\":\"" + CreateMySQLTable(cumulus.CreateDayfileSQL) + "\"}";
-			return json;
+			return "{\"result\":\"" + CreateMySQLTable(cumulus.DayfileTable.CreateCommand) + "\"}";
 		}
 
-		//public string CreateRealtimeSQL(HttpListenerContext context)
 		public string CreateRealtimeSQL(IHttpContext context)
 		{
 			context.Response.StatusCode = 200;
-			string json = "{\"result\":\"" + CreateMySQLTable(cumulus.CreateRealtimeSQL) + "\"}";
-			return json;
+			return  "{\"result\":\"" + CreateMySQLTable(cumulus.RealtimeTable.CreateCommand) + "\"}";
+		}
+
+		public string UpdateMonthlySQL(IHttpContext context)
+		{
+			return "{\"result\":\"" + UpdateMySQLTable(cumulus.MonthlyTable) + "\"}";
+		}
+
+		public string UpdateDayfileSQL(IHttpContext context)
+		{
+			return "{\"result\":\"" + UpdateMySQLTable(cumulus.DayfileTable) + "\"}";
+		}
+
+		public string UpdateRealtimeSQL(IHttpContext context)
+		{
+			return "{\"result\":\"" + UpdateMySQLTable(cumulus.RealtimeTable) + "\"}";
 		}
 	}
 
@@ -328,20 +469,20 @@ namespace CumulusMX
 	public class JsonMysqlSettingsCustomSeconds
 	{
 		public bool enabled { get; set; }
-		public string command { get; set; }
+		public string[] command { get; set; }
 		public int interval { get; set; }
 	}
 
 	public class JsonMysqlSettingsCustomMinutes
 	{
 		public bool enabled { get; set; }
-		public string command { get; set; }
+		public string[] command { get; set; }
 		public int intervalindex { get; set; }
 	}
 
 	public class JsonMysqlSettingsCustomRollover
 	{
 		public bool enabled { get; set; }
-		public string command { get; set; }
+		public string[] command { get; set; }
 	}
 }

--- a/CumulusMX/ProgramSettings.cs
+++ b/CumulusMX/ProgramSettings.cs
@@ -28,6 +28,12 @@ namespace CumulusMX
 				startupdelaymaxuptime = cumulus.ProgramOptions.StartupDelayMaxUptime
 			};
 
+			var shutdown = new JsonProgramSettingsShutdownOptions()
+			{
+				datastoppedexit = cumulus.ProgramOptions.DataStoppedExit,
+				datastoppedmins = cumulus.ProgramOptions.DataStoppedMins
+			};
+
 			var logging = new JsonProgramSettingsLoggingOptions()
 			{
 				debuglogging = cumulus.ProgramOptions.DebugLogging,
@@ -52,6 +58,7 @@ namespace CumulusMX
 			{
 				accessible = cumulus.ProgramOptions.EnableAccessibility,
 				startup = startup,
+				shutdown = shutdown,
 				logging = logging,
 				options = options,
 				culture = culture
@@ -98,10 +105,15 @@ namespace CumulusMX
 				cumulus.ProgramOptions.StartupPingEscapeTime = settings.startup.startuppingescape;
 				cumulus.ProgramOptions.StartupDelaySecs = settings.startup.startupdelay;
 				cumulus.ProgramOptions.StartupDelayMaxUptime = settings.startup.startupdelaymaxuptime;
+
+				cumulus.ProgramOptions.DataStoppedExit = settings.shutdown.datastoppedexit;
+				cumulus.ProgramOptions.DataStoppedMins = settings.shutdown.datastoppedmins;
+
 				cumulus.ProgramOptions.DebugLogging = settings.logging.debuglogging;
 				cumulus.ProgramOptions.DataLogging = settings.logging.datalogging;
 				cumulus.SmtpOptions.Logging = settings.logging.emaillogging;
 				cumulus.ErrorLogSpikeRemoval = settings.logging.spikelogging;
+
 				cumulus.ProgramOptions.WarnMultiple = settings.options.stopsecondinstance;
 				cumulus.ProgramOptions.ListWebTags = settings.options.listwebtags;
 				cumulus.ProgramOptions.Culture.RemoveSpaceFromDateSeparator = settings.culture.removespacefromdateseparator;
@@ -155,6 +167,7 @@ namespace CumulusMX
 	{
 		public bool accessible { get; set; }
 		public JsonProgramSettingsStartupOptions startup { get; set; }
+		public JsonProgramSettingsShutdownOptions shutdown { get; set; }
 		public JsonProgramSettingsLoggingOptions logging { get; set; }
 		public JsonProgramSettingsGeneralOptions options { get; set; }
 		public JsonProgramSettingsCultureOptions culture { get; set; }
@@ -184,5 +197,10 @@ namespace CumulusMX
 	public class JsonProgramSettingsCultureOptions
 	{
 		public bool removespacefromdateseparator { get; set; }
+	}
+	public class JsonProgramSettingsShutdownOptions
+	{
+		public bool datastoppedexit { get; set; }
+		public int datastoppedmins { get; set; }
 	}
 }

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX BETA")]
-[assembly: AssemblyDescription("Version 3.20.0 - Build 3198 - BETA")]
+[assembly: AssemblyDescription("Version 3.20.0 - Build 3199 - BETA")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX BETA")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.20.0.3198")]
-[assembly: AssemblyFileVersion("3.20.0.3198")]
+[assembly: AssemblyVersion("3.20.0.3199")]
+[assembly: AssemblyFileVersion("3.20.0.3199")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Cumulus MX BETA")]
-[assembly: AssemblyDescription("Version 3.20.0 - Build 3199 - BETA")]
+[assembly: AssemblyTitle("Cumulus MX")]
+[assembly: AssemblyDescription("Version 3.20.0 - Build 3200")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Cumulus MX BETA")]
+[assembly: AssemblyProduct("Cumulus MX")]
 [assembly: AssemblyCopyright("Copyright ©  2015-2022 Cumulus MX")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.20.0.3199")]
-[assembly: AssemblyFileVersion("3.20.0.3199")]
+[assembly: AssemblyVersion("3.20.0.3200")]
+[assembly: AssemblyFileVersion("3.20.0.3200")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.20.0 - Build 3197")]
+[assembly: AssemblyTitle("Cumulus MX BETA")]
+[assembly: AssemblyDescription("Version 3.20.0 - Build 3198 - BETA")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Cumulus MX")]
+[assembly: AssemblyProduct("Cumulus MX BETA")]
 [assembly: AssemblyCopyright("Copyright ©  2015-2022 Cumulus MX")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.20.0.3197")]
-[assembly: AssemblyFileVersion("3.20.0.3197")]
+[assembly: AssemblyVersion("3.20.0.3198")]
+[assembly: AssemblyFileVersion("3.20.0.3198")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.19.2 - Build 3195")]
+[assembly: AssemblyDescription("Version 3.20.0 - Build 3196")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.19.2.3195")]
-[assembly: AssemblyFileVersion("3.19.2.3195")]
+[assembly: AssemblyVersion("3.20.0.3196")]
+[assembly: AssemblyFileVersion("3.20.0.3196")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.20.0 - Build 3201")]
+[assembly: AssemblyDescription("Version 3.20.0 - Build 3202")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.20.0.3201")]
-[assembly: AssemblyFileVersion("3.20.0.3201")]
+[assembly: AssemblyVersion("3.20.0.3202")]
+[assembly: AssemblyFileVersion("3.20.0.3202")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.20.0 - Build 3200")]
+[assembly: AssemblyDescription("Version 3.20.0 - Build 3201")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.20.0.3200")]
-[assembly: AssemblyFileVersion("3.20.0.3200")]
+[assembly: AssemblyVersion("3.20.0.3201")]
+[assembly: AssemblyFileVersion("3.20.0.3201")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.20.0 - Build 3196")]
+[assembly: AssemblyDescription("Version 3.20.0 - Build 3197")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.20.0.3196")]
-[assembly: AssemblyFileVersion("3.20.0.3196")]
+[assembly: AssemblyVersion("3.20.0.3197")]
+[assembly: AssemblyFileVersion("3.20.0.3197")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -1365,7 +1365,7 @@ namespace CumulusMX
 		{
 			if (station == null)
 			{
-				return "{\"result\":\"Not possible, station is not initialised\"}";
+				return "Not possible, station is not initialised}";
 			}
 
 			try
@@ -1377,13 +1377,13 @@ namespace CumulusMX
 				var includeGraphs = json.Contains("true");
 
 				if (!cumulus.FtpOptions.Enabled && !cumulus.FtpOptions.LocalCopyEnabled)
-					return "{\"result\":\"FTP/local copy is not enabled!\"}";
+					return "FTP/local copy is not enabled!";
 
 
 				if (cumulus.WebUpdating == 1)
 				{
 					cumulus.LogMessage("FTP Now: Warning, a previous web update is still in progress, first chance, skipping attempt");
-					return "{\"result\":\"A web update is already in progress\"}";
+					return "A web update is already in progress";
 				}
 
 				if (cumulus.WebUpdating >= 2)
@@ -1410,7 +1410,7 @@ namespace CumulusMX
 					cumulus.WebUpdating = 1;
 					cumulus.ftpThread = new Thread(cumulus.DoHTMLFiles) { IsBackground = true };
 					cumulus.ftpThread.Start();
-					return "{\"result\":\"An existing FTP process was aborted, and a new FTP process invoked\"}";
+					return "An existing FTP process was aborted, and a new FTP process invoked";
 				}
 
 				// Graph configs may have changed, so force re-create and upload the json files - just flag everything!
@@ -1430,13 +1430,13 @@ namespace CumulusMX
 				cumulus.WebUpdating = 1;
 				cumulus.ftpThread = new Thread(cumulus.DoHTMLFiles) { IsBackground = true };
 				cumulus.ftpThread.Start();
-				return "{\"result\":\"FTP process invoked\"}";
+				return "FTP process invoked";
 			}
 			catch (Exception ex)
 			{
 				cumulus.LogMessage($"FTP Now: {ex.Message}");
 				context.Response.StatusCode = 500;
-				return $"{{\"result\":\"Error: {ex.Message}\"}}";
+				return $"Error: {ex.Message}";
 			}
 		}
 

--- a/CumulusMX/TempestStation.cs
+++ b/CumulusMX/TempestStation.cs
@@ -108,8 +108,8 @@ namespace CumulusMX
 				if (h == 0 && !midnightraindone)
 				{
 					ResetMidnightRain(timestamp);
-					ResetSunshineHours();
-					ResetMidnightTemperatures();
+					ResetSunshineHours(timestamp);
+					ResetMidnightTemperatures(timestamp);
 					midnightraindone = true;
 				}
 
@@ -232,7 +232,7 @@ namespace CumulusMX
 		public override void Start()
 		{
 
-			cumulus.CurrentActivity = "Normal running";
+			cumulus.NormalRunning = true;
 			StationListener.WeatherPacketReceived = WeatherPacketReceived;
 			StationListener.Start(cumulus);
 			DoDayResetIfNeeded();

--- a/CumulusMX/ThirdPartySettings.cs
+++ b/CumulusMX/ThirdPartySettings.cs
@@ -272,7 +272,15 @@ namespace CumulusMX
 					cumulus.CustomHttpSecondsTimer.Enabled = cumulus.CustomHttpSecondsEnabled;
 					if (cumulus.CustomHttpSecondsEnabled)
 					{
-						cumulus.CustomHttpSecondsString = settings.customhttp.customseconds.url ?? string.Empty;
+						cumulus.CustomHttpSecondsStrings[0] = settings.customhttp.customseconds.url[0] ?? string.Empty;
+						for (var i = 1; i < 10; i++)
+						{
+							if (i < settings.customhttp.customseconds.url.Length)
+								cumulus.CustomHttpSecondsStrings[i] = settings.customhttp.customseconds.url[i] ?? null;
+							else
+								cumulus.CustomHttpSecondsStrings[i] = null;
+						}
+
 						cumulus.CustomHttpSecondsInterval = settings.customhttp.customseconds.interval;
 						cumulus.CustomHttpSecondsTimer.Interval = cumulus.CustomHttpSecondsInterval * 1000;
 					}
@@ -280,7 +288,15 @@ namespace CumulusMX
 					cumulus.CustomHttpMinutesEnabled = settings.customhttp.customminutes.enabled;
 					if (cumulus.CustomHttpMinutesEnabled)
 					{
-						cumulus.CustomHttpMinutesString = settings.customhttp.customminutes.url ?? string.Empty;
+						cumulus.CustomHttpMinutesStrings[0] = settings.customhttp.customminutes.url[0] ?? string.Empty;
+						for (var i = 1; i < 10; i++)
+						{
+							if (i < settings.customhttp.customseconds.url.Length)
+								cumulus.CustomHttpMinutesStrings[i] = settings.customhttp.customminutes.url[i] ?? null;
+							else
+								cumulus.CustomHttpMinutesStrings[i] = null;
+						}
+
 						cumulus.CustomHttpMinutesIntervalIndex = settings.customhttp.customminutes.intervalindex;
 						if (cumulus.CustomHttpMinutesIntervalIndex >= 0 && cumulus.CustomHttpMinutesIntervalIndex < cumulus.FactorsOf60.Length)
 						{
@@ -295,7 +311,14 @@ namespace CumulusMX
 					cumulus.CustomHttpRolloverEnabled = settings.customhttp.customrollover.enabled;
 					if (cumulus.CustomHttpRolloverEnabled)
 					{
-						cumulus.CustomHttpRolloverString = settings.customhttp.customrollover.url ?? string.Empty;
+						cumulus.CustomHttpRolloverStrings[0] = settings.customhttp.customrollover.url[0] ?? string.Empty;
+						for (var i = 1; i < 10; i++)
+						{
+							if (i < settings.customhttp.customrollover.url.Length)
+								cumulus.CustomHttpMinutesStrings[i] = settings.customhttp.customrollover.url[i] ?? null;
+							else
+								cumulus.CustomHttpMinutesStrings[i] = null;
+						}
 					}
 				}
 				catch (Exception ex)
@@ -438,22 +461,66 @@ namespace CumulusMX
 			var customseconds = new JsonThirdPartySettingsCustomHttpSeconds()
 			{
 				enabled = cumulus.CustomHttpSecondsEnabled,
-				interval = cumulus.CustomHttpSecondsInterval,
-				url = cumulus.CustomHttpSecondsString
+				interval = cumulus.CustomHttpSecondsInterval
 			};
+
+			var urlCnt = 1;
+			for (int i = 1; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomHttpSecondsStrings[i]))
+					urlCnt++;
+			}
+			customseconds.url = new string[urlCnt];
+
+			var index = 0;
+			for (var i = 0; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomHttpSecondsStrings[i]))
+					customseconds.url[index++] = cumulus.CustomHttpSecondsStrings[i];
+			}
 
 			var customminutes = new JsonThirdPartySettingsCustomHttpMinutes()
 			{
 				enabled = cumulus.CustomHttpMinutesEnabled,
-				intervalindex = cumulus.CustomHttpMinutesIntervalIndex,
-				url = cumulus.CustomHttpMinutesString
+				intervalindex = cumulus.CustomHttpMinutesIntervalIndex
 			};
+
+			urlCnt = 1;
+			for (int i = 1; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomHttpMinutesStrings[i]))
+					urlCnt++;
+			}
+
+			customminutes.url = new string[urlCnt];
+
+			index = 0;
+			for (var i = 0; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomHttpMinutesStrings[i]))
+					customminutes.url[index++] = cumulus.CustomHttpMinutesStrings[i];
+			}
 
 			var customrollover = new JsonThirdPartySettingsCustomHttpRollover()
 			{
-				enabled = cumulus.CustomHttpRolloverEnabled,
-				url = cumulus.CustomHttpRolloverString
+				enabled = cumulus.CustomHttpRolloverEnabled
 			};
+
+			urlCnt = 1;
+			for (int i = 1; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomHttpRolloverStrings[i]))
+					urlCnt++;
+			}
+
+			customrollover.url = new string[urlCnt];
+
+			index = 0;
+			for (var i = 0; i < urlCnt; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomHttpRolloverStrings[i]))
+					customrollover.url[index] = cumulus.CustomHttpRolloverStrings[i];
+			}
 
 			var customhttp = new JsonThirdPartySettingsCustomHttpSettings() { customseconds = customseconds, customminutes = customminutes, customrollover = customrollover };
 
@@ -605,21 +672,21 @@ namespace CumulusMX
 
 	public class JsonThirdPartySettingsCustomHttpSeconds
 	{
-		public string url { get; set; }
+		public string[] url { get; set; }
 		public bool enabled { get; set; }
 		public int interval { get; set; }
 	}
 
 	public class JsonThirdPartySettingsCustomHttpMinutes
 	{
-		public string url { get; set; }
+		public string[] url { get; set; }
 		public bool enabled { get; set; }
 		public int intervalindex { get; set; }
 	}
 
 	public class JsonThirdPartySettingsCustomHttpRollover
 	{
-		public string url { get; set; }
+		public string[] url { get; set; }
 		public bool enabled { get; set; }
 	}
 

--- a/CumulusMX/WM918Station.cs
+++ b/CumulusMX/WM918Station.cs
@@ -176,7 +176,7 @@ namespace CumulusMX
 			try
 			{
 				comport.Open();
-				cumulus.CurrentActivity = "Normal running";
+				cumulus.NormalRunning = true;
 
 				LoadLastHoursFromDataLogs(DateTime.Now);
 

--- a/CumulusMX/WMR200Station.cs
+++ b/CumulusMX/WMR200Station.cs
@@ -90,7 +90,6 @@ namespace CumulusMX
 
 		public override void startReadingHistoryData()
 		{
-			cumulus.CurrentActivity = "Getting archive data";
 			cumulus.LogConsoleMessage("Reading archive data");
 
 			//lastArchiveTimeUTC = getLastArchiveTime();
@@ -1418,8 +1417,8 @@ namespace CumulusMX
 			if ((h == 0) && !midnightraindone)
 			{
 				ResetMidnightRain(timestamp);
-				ResetSunshineHours();
-				ResetMidnightTemperatures();
+				ResetSunshineHours(timestamp);
+				ResetMidnightTemperatures(timestamp);
 				midnightraindone = true;
 			}
 			// there seems to be no way of determining the log interval other than subtracting one logMainUnit.Units.MainUnit.cumulus.LogMessage

--- a/CumulusMX/WMR928Station.cs
+++ b/CumulusMX/WMR928Station.cs
@@ -47,7 +47,7 @@ namespace CumulusMX
 				comport = new SerialPort(cumulus.ComportName, 9600, Parity.None, 8, StopBits.One) {Handshake = Handshake.None, RtsEnable = true, DtrEnable = true};
 				comport.Open();
 
-				cumulus.CurrentActivity = "Normal running";
+				cumulus.NormalRunning = true;
 
 				LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
 				DoDayResetIfNeeded();

--- a/CumulusMX/WS2300Station.cs
+++ b/CumulusMX/WS2300Station.cs
@@ -58,7 +58,7 @@ namespace CumulusMX
 			if (comport.IsOpen)
 			{
 				// Read the data from the logger
-				cumulus.CurrentActivity = "Reading archive data";
+				cumulus.NormalRunning = true;
 				startReadingHistoryData();
 			}
 		}
@@ -93,7 +93,7 @@ namespace CumulusMX
 			//histprog.histprogPB.Value = 100;
 			//histprog.Close();
 			//mainWindow.FillLastHourGraphData();
-			cumulus.CurrentActivity = "Normal running";
+			cumulus.NormalRunning = true;
 			StartLoop();
 			DoDayResetIfNeeded();
 			DoTrendValues(DateTime.Now);
@@ -257,8 +257,8 @@ namespace CumulusMX
 				if ((h == 0) && !midnightraindone)
 				{
 					ResetMidnightRain(timestamp);
-					ResetSunshineHours();
-					ResetMidnightTemperatures();
+					ResetSunshineHours(timestamp);
+					ResetMidnightTemperatures(timestamp);
 					midnightraindone = true;
 				}
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -3050,12 +3050,12 @@ namespace CumulusMX
 			if (OutdoorTemperature > AllTime.HighTemp.Val)
 				SetAlltime(AllTime.HighTemp, OutdoorTemperature, timestamp);
 
-			cumulus.HighTempAlarm.Triggered = DoAlarm(OutdoorTemperature, cumulus.HighTempAlarm.Value, cumulus.HighTempAlarm.Enabled, true);
+			cumulus.HighTempAlarm.CheckAlarm(OutdoorTemperature);
 
 			if (OutdoorTemperature < AllTime.LowTemp.Val)
 				SetAlltime(AllTime.LowTemp, OutdoorTemperature, timestamp);
 
-			cumulus.LowTempAlarm.Triggered = DoAlarm(OutdoorTemperature, cumulus.LowTempAlarm.Value, cumulus.LowTempAlarm.Enabled, false);
+			cumulus.LowTempAlarm.CheckAlarm(OutdoorTemperature);
 
 			CheckMonthlyAlltime("HighTemp", OutdoorTemperature, true, timestamp);
 			CheckMonthlyAlltime("LowTemp", OutdoorTemperature, false, timestamp);
@@ -3519,14 +3519,14 @@ namespace CumulusMX
 				SetAlltime(AllTime.HighPress, Pressure, timestamp);
 			}
 
-			cumulus.HighPressAlarm.Triggered = DoAlarm(Pressure, cumulus.HighPressAlarm.Value, cumulus.HighPressAlarm.Enabled, true);
+			cumulus.HighPressAlarm.CheckAlarm(Pressure);
 
 			if (Pressure < AllTime.LowPress.Val)
 			{
 				SetAlltime(AllTime.LowPress, Pressure, timestamp);
 			}
 
-			cumulus.LowPressAlarm.Triggered = DoAlarm(Pressure, cumulus.LowPressAlarm.Value, cumulus.LowPressAlarm.Enabled, false);
+			cumulus.LowPressAlarm.CheckAlarm(Pressure);
 			CheckMonthlyAlltime("LowPress", Pressure, false, timestamp);
 			CheckMonthlyAlltime("HighPress", Pressure, true, timestamp);
 
@@ -3733,7 +3733,7 @@ namespace CumulusMX
 
 				CheckMonthlyAlltime("HighRainRate", RainRate, true, timestamp);
 
-				cumulus.HighRainRateAlarm.Triggered = DoAlarm(RainRate, cumulus.HighRainRateAlarm.Value, cumulus.HighRainRateAlarm.Enabled, true);
+				cumulus.HighRainRateAlarm.CheckAlarm(RainRate);
 
 				if (RainRate > HiLoToday.HighRainRate)
 				{
@@ -3839,7 +3839,7 @@ namespace CumulusMX
 
 				CheckMonthlyAlltime("MonthlyRain", RainMonth, true, timestamp);
 
-				cumulus.HighRainTodayAlarm.Triggered = DoAlarm(RainToday, cumulus.HighRainTodayAlarm.Value, cumulus.HighRainTodayAlarm.Enabled, true);
+				cumulus.HighRainTodayAlarm.CheckAlarm(RainToday);
 
 				// Yesterday"s rain - Scale for units
 				// rainyest = rainyesterday * RainMult;
@@ -4024,22 +4024,6 @@ namespace CumulusMX
 		}
 		*/
 
-		public bool DoAlarm(double value, double threshold, bool enabled, bool testAbove)
-		{
-			if (enabled)
-			{
-				if (testAbove)
-				{
-					return value > threshold;
-				}
-				else
-				{
-					return value < threshold;
-				}
-			}
-			return false;
-		}
-
 		public void DoWind(double gustpar, int bearingpar, double speedpar, DateTime timestamp)
 		{
 #if DEBUG
@@ -4176,7 +4160,7 @@ namespace CumulusMX
 
 			WindAverage *= cumulus.Calib.WindSpeed.Mult;
 
-			cumulus.HighWindAlarm.Triggered = DoAlarm(WindAverage, cumulus.HighWindAlarm.Value, cumulus.HighWindAlarm.Enabled, true);
+			cumulus.HighWindAlarm.CheckAlarm(WindAverage);
 
 
 			if (CalcRecentMaxGust)
@@ -4196,7 +4180,7 @@ namespace CumulusMX
 				RecentMaxGust = maxgust * cumulus.Calib.WindGust.Mult;
 			}
 
-			cumulus.HighGustAlarm.Triggered = DoAlarm(RecentMaxGust, cumulus.HighGustAlarm.Value, cumulus.HighGustAlarm.Enabled, true);
+			cumulus.HighGustAlarm.CheckAlarm(RecentMaxGust);
 
 			if (WindAverage > HiLoToday.HighWind)
 			{
@@ -6257,14 +6241,12 @@ namespace CumulusMX
 				{
 					// calculate and display the temp trend
 					temptrendval = (retVals.Last().OutsideTemp - retVals.First().OutsideTemp) / 3.0F;
-					cumulus.TempChangeAlarm.UpTriggered = DoAlarm(temptrendval, cumulus.TempChangeAlarm.Value, cumulus.TempChangeAlarm.Enabled, true);
-					cumulus.TempChangeAlarm.DownTriggered = DoAlarm(temptrendval, cumulus.TempChangeAlarm.Value * -1, cumulus.TempChangeAlarm.Enabled, false);
+					cumulus.TempChangeAlarm.CheckAlarm(temptrendval);
 
 
 					// calculate and display the pressure trend
 					presstrendval = (retVals.Last().Pressure - retVals.First().Pressure) / 3.0;
-					cumulus.PressChangeAlarm.UpTriggered = DoAlarm(presstrendval, cumulus.PressChangeAlarm.Value, cumulus.PressChangeAlarm.Enabled, true);
-					cumulus.PressChangeAlarm.DownTriggered = DoAlarm(presstrendval, cumulus.PressChangeAlarm.Value * -1, cumulus.PressChangeAlarm.Enabled, false);
+					cumulus.PressChangeAlarm.CheckAlarm(presstrendval);
 
 					// Convert for display
 					//trendval = ConvertPressMBToUser(presstrendval);
@@ -6404,7 +6386,7 @@ namespace CumulusMX
 
 							CheckMonthlyAlltime("HighRainRate", RainRate, true, ts);
 
-							cumulus.HighRainRateAlarm.Triggered = DoAlarm(RainRate, cumulus.HighRainRateAlarm.Value, cumulus.HighRainRateAlarm.Enabled, true);
+							cumulus.HighRainRateAlarm.CheckAlarm(RainRate);
 
 							if (RainRate > HiLoToday.HighRainRate)
 							{
@@ -10554,6 +10536,11 @@ namespace CumulusMX
 						}
 						json.Append("],");
 					}
+					else if (string.IsNullOrEmpty(search))
+					{
+						// no search so we can bail out as we already know the total number of records
+						break;
+					}
 				}
 
 				// trim last ","
@@ -12041,7 +12028,7 @@ namespace CumulusMX
 				// check for monthly all time records (and set)
 				CheckMonthlyAlltime("HighGust", gust, true, timestamp);
 
-				cumulus.HighGustAlarm.Triggered = DoAlarm(gust, cumulus.HighGustAlarm.Value, cumulus.HighGustAlarm.Enabled, true);
+				cumulus.HighGustAlarm.CheckAlarm(gust);
 			}
 			return true;
 		}

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -583,13 +583,15 @@ namespace CumulusMX
 			cumulus.LogConsoleMessage("Last update=" + timestampstr);
 
 			cumulus.LastUpdateTime = DateTime.Parse(timestampstr);
+			var todayDate = cumulus.LastUpdateTime.Date;
+
 			cumulus.LogMessage("Last update time from today.ini: " + cumulus.LastUpdateTime);
 
-			DateTime currentMonthTS = cumulus.LastUpdateTime.AddHours(cumulus.GetHourInc());
+			DateTime metoTodayDate = cumulus.LastUpdateTime.AddHours(cumulus.GetHourInc()).Date;
 
-			int defaultyear = currentMonthTS.Year;
-			int defaultmonth = currentMonthTS.Month;
-			int defaultday = currentMonthTS.Day;
+			int defaultyear = metoTodayDate.Year;
+			int defaultmonth = metoTodayDate.Month;
+			int defaultday = metoTodayDate.Day;
 
 			CurrentYear = ini.GetValue("General", "CurrentYear", defaultyear);
 			CurrentMonth = ini.GetValue("General", "CurrentMonth", defaultmonth);
@@ -630,17 +632,17 @@ namespace CumulusMX
 
 			// Solar
 			HiLoToday.HighSolar = ini.GetValue("Solar", "HighSolarRad", 0.0);
-			HiLoToday.HighSolarTime = ini.GetValue("Solar", "HighSolarRadTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighSolarTime = ini.GetValue("Solar", "HighSolarRadTime", todayDate);
 			HiLoToday.HighUv = ini.GetValue("Solar", "HighUV", 0.0);
-			HiLoToday.HighUvTime = ini.GetValue("Solar", "HighUVTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighUvTime = ini.GetValue("Solar", "HighUVTime", metoTodayDate);
 			StartOfDaySunHourCounter = ini.GetValue("Solar", "SunStart", -9999.0);
 			RG11RainToday = ini.GetValue("Rain", "RG11Today", 0.0);
 
 			// Wind
 			HiLoToday.HighWind = ini.GetValue("Wind", "Speed", 0.0);
-			HiLoToday.HighWindTime = ini.GetValue("Wind", "SpTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighWindTime = ini.GetValue("Wind", "SpTime", metoTodayDate);
 			HiLoToday.HighGust = ini.GetValue("Wind", "Gust", 0.0);
-			HiLoToday.HighGustTime = ini.GetValue("Wind", "Time", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighGustTime = ini.GetValue("Wind", "Time", metoTodayDate);
 			HiLoToday.HighGustBearing = ini.GetValue("Wind", "Bearing", 0);
 			WindRunToday = ini.GetValue("Wind", "Windrun", 0.0);
 			DominantWindBearing = ini.GetValue("Wind", "DominantWindBearing", 0);
@@ -649,9 +651,9 @@ namespace CumulusMX
 			DominantWindBearingY = ini.GetValue("Wind", "DominantWindBearingY", 0.0);
 			// Temperature
 			HiLoToday.LowTemp = ini.GetValue("Temp", "Low", 999.0);
-			HiLoToday.LowTempTime = ini.GetValue("Temp", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.LowTempTime = ini.GetValue("Temp", "LTime", metoTodayDate);
 			HiLoToday.HighTemp = ini.GetValue("Temp", "High", -999.0);
-			HiLoToday.HighTempTime = ini.GetValue("Temp", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighTempTime = ini.GetValue("Temp", "HTime", metoTodayDate);
 			if ((HiLoToday.HighTemp > -400) && (HiLoToday.LowTemp < 400))
 				HiLoToday.TempRange = HiLoToday.HighTemp - HiLoToday.LowTemp;
 			else
@@ -664,21 +666,21 @@ namespace CumulusMX
 			GrowingDegreeDaysThisYear2 = ini.GetValue("Temp", "GrowingDegreeDaysThisYear2", 0.0);
 			// Temperature midnight rollover
 			HiLoTodayMidnight.LowTemp = ini.GetValue("TempMidnight", "Low", 999.0);
-			HiLoTodayMidnight.LowTempTime = ini.GetValue("TempMidnight", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoTodayMidnight.LowTempTime = ini.GetValue("TempMidnight", "LTime", metoTodayDate);
 			HiLoTodayMidnight.HighTemp = ini.GetValue("TempMidnight", "High", -999.0);
-			HiLoTodayMidnight.HighTempTime = ini.GetValue("TempMidnight", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoTodayMidnight.HighTempTime = ini.GetValue("TempMidnight", "HTime", metoTodayDate);
 			// PressureHighDewpoint
 			HiLoToday.LowPress = ini.GetValue("Pressure", "Low", 9999.0);
-			HiLoToday.LowPressTime = ini.GetValue("Pressure", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.LowPressTime = ini.GetValue("Pressure", "LTime", metoTodayDate);
 			HiLoToday.HighPress = ini.GetValue("Pressure", "High", 0.0);
-			HiLoToday.HighPressTime = ini.GetValue("Pressure", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighPressTime = ini.GetValue("Pressure", "HTime", metoTodayDate);
 			// rain
 			HiLoToday.HighRainRate = ini.GetValue("Rain", "High", 0.0);
-			HiLoToday.HighRainRateTime = ini.GetValue("Rain", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighRainRateTime = ini.GetValue("Rain", "HTime", metoTodayDate);
 			HiLoToday.HighHourlyRain = ini.GetValue("Rain", "HourlyHigh", 0.0);
-			HiLoToday.HighHourlyRainTime = ini.GetValue("Rain", "HHourlyTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighHourlyRainTime = ini.GetValue("Rain", "HHourlyTime", metoTodayDate);
 			HiLoToday.HighRain24h = ini.GetValue("Rain", "High24h", 0.0);
-			HiLoToday.HighRain24hTime = ini.GetValue("Rain", "High24hTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighRain24hTime = ini.GetValue("Rain", "High24hTime", metoTodayDate);
 			raindaystart = ini.GetValue("Rain", "Start", -1.0);
 			cumulus.LogMessage($"ReadTodayfile: Rain day start = {raindaystart}");
 			RainYesterday = ini.GetValue("Rain", "Yesterday", 0.0);
@@ -690,35 +692,35 @@ namespace CumulusMX
 			// humidity
 			HiLoToday.LowHumidity = ini.GetValue("Humidity", "Low", 100);
 			HiLoToday.HighHumidity = ini.GetValue("Humidity", "High", 0);
-			HiLoToday.LowHumidityTime = ini.GetValue("Humidity", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
-			HiLoToday.HighHumidityTime = ini.GetValue("Humidity", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.LowHumidityTime = ini.GetValue("Humidity", "LTime", metoTodayDate);
+			HiLoToday.HighHumidityTime = ini.GetValue("Humidity", "HTime", metoTodayDate);
 			// Solar
 			SunshineHours = ini.GetValue("Solar", "SunshineHours", 0.0);
 			SunshineToMidnight = ini.GetValue("Solar", "SunshineHoursToMidnight", 0.0);
 			// heat index
 			HiLoToday.HighHeatIndex = ini.GetValue("HeatIndex", "High", -999.0);
-			HiLoToday.HighHeatIndexTime = ini.GetValue("HeatIndex", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighHeatIndexTime = ini.GetValue("HeatIndex", "HTime", metoTodayDate);
 			// Apparent temp
 			HiLoToday.HighAppTemp = ini.GetValue("AppTemp", "High", -999.0);
-			HiLoToday.HighAppTempTime = ini.GetValue("AppTemp", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighAppTempTime = ini.GetValue("AppTemp", "HTime", metoTodayDate);
 			HiLoToday.LowAppTemp = ini.GetValue("AppTemp", "Low", 999.0);
-			HiLoToday.LowAppTempTime = ini.GetValue("AppTemp", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.LowAppTempTime = ini.GetValue("AppTemp", "LTime", metoTodayDate);
 			// wind chill
 			HiLoToday.LowWindChill = ini.GetValue("WindChill", "Low", 999.0);
-			HiLoToday.LowWindChillTime = ini.GetValue("WindChill", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.LowWindChillTime = ini.GetValue("WindChill", "LTime", metoTodayDate);
 			// Dew point
 			HiLoToday.HighDewPoint = ini.GetValue("Dewpoint", "High", -999.0);
-			HiLoToday.HighDewPointTime = ini.GetValue("Dewpoint", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighDewPointTime = ini.GetValue("Dewpoint", "HTime", metoTodayDate);
 			HiLoToday.LowDewPoint = ini.GetValue("Dewpoint", "Low", 999.0);
-			HiLoToday.LowDewPointTime = ini.GetValue("Dewpoint", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.LowDewPointTime = ini.GetValue("Dewpoint", "LTime", metoTodayDate);
 			// Feels like
 			HiLoToday.HighFeelsLike = ini.GetValue("FeelsLike", "High", -999.0);
-			HiLoToday.HighFeelsLikeTime = ini.GetValue("FeelsLike", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighFeelsLikeTime = ini.GetValue("FeelsLike", "HTime", metoTodayDate);
 			HiLoToday.LowFeelsLike = ini.GetValue("FeelsLike", "Low", 999.0);
-			HiLoToday.LowFeelsLikeTime = ini.GetValue("FeelsLike", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.LowFeelsLikeTime = ini.GetValue("FeelsLike", "LTime", metoTodayDate);
 			// Humidex
 			HiLoToday.HighHumidex = ini.GetValue("Humidex", "High", -999.0);
-			HiLoToday.HighHumidexTime = ini.GetValue("Humidex", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighHumidexTime = ini.GetValue("Humidex", "HTime", metoTodayDate);
 
 			// Records
 			AlltimeRecordTimestamp = ini.GetValue("Records", "Alltime", DateTime.MinValue);
@@ -1970,8 +1972,8 @@ namespace CumulusMX
 
 			if (now.Hour == 0)
 			{
-				ResetSunshineHours();
-				ResetMidnightTemperatures();
+				ResetSunshineHours(now);
+				ResetMidnightTemperatures(now);
 			}
 
 			RemoveOldRecentData(now);
@@ -2847,7 +2849,7 @@ namespace CumulusMX
 		}
 
 
-		public void ResetSunshineHours() // called at midnight irrespective of roll-over time
+		public void ResetSunshineHours(DateTime logdate) // called at midnight irrespective of roll-over time
 		{
 			YestSunshineHours = SunshineHours;
 
@@ -2856,10 +2858,10 @@ namespace CumulusMX
 			SunshineToMidnight = SunshineHours;
 			SunshineHours = 0;
 			StartOfDaySunHourCounter = SunHourCounter;
-			WriteYesterdayFile();
+			WriteYesterdayFile(logdate);
 		}
 
-		public void ResetMidnightTemperatures() // called at midnight irrespective of roll-over time
+		public void ResetMidnightTemperatures(DateTime logdate) // called at midnight irrespective of roll-over time
 		{
 			HiLoYestMidnight.LowTemp = HiLoTodayMidnight.LowTemp;
 			HiLoYestMidnight.HighTemp = HiLoTodayMidnight.HighTemp;
@@ -2869,7 +2871,7 @@ namespace CumulusMX
 			HiLoTodayMidnight.LowTemp = 999;
 			HiLoTodayMidnight.HighTemp = -999;
 
-			WriteYesterdayFile();
+			WriteYesterdayFile(logdate);
 		}
 
 		/*
@@ -2897,7 +2899,7 @@ namespace CumulusMX
 
 		public void SwitchToNormalRunning()
 		{
-			cumulus.CurrentActivity = "Normal running";
+			cumulus.NormalRunning = true;
 
 			DoDayResetIfNeeded();
 			DoTrendValues(DateTime.Now);
@@ -4530,14 +4532,14 @@ namespace CumulusMX
 
 		//private bool manualftp;
 
-		public void WriteYesterdayFile()
+		public void WriteYesterdayFile(DateTime logdate)
 		{
 			cumulus.LogMessage("Writing yesterday.ini");
 			var hourInc = cumulus.GetHourInc();
 
 			IniFile ini = new IniFile(cumulus.YesterdayFile);
 
-			ini.SetValue("General", "Date", DateTime.Now.AddHours(hourInc));
+			ini.SetValue("General", "Date", logdate.AddHours(hourInc));
 			// Wind
 			ini.SetValue("Wind", "Speed", HiLoYest.HighWind);
 			ini.SetValue("Wind", "SpTime", HiLoYest.HighWindTime.ToString("HH:mm"));
@@ -4657,7 +4659,7 @@ namespace CumulusMX
 			HiLoYest.HighHourlyRain = ini.GetValue("Rain", "HourlyHigh", 0.0);
 			HiLoYest.HighHourlyRainTime = ini.GetValue("Rain", "HHourlyTime", DateTime.MinValue);
 			HiLoYest.HighRain24h = ini.GetValue("Rain", "High24h", 0.0);
-			HiLoToday.HighRain24hTime = ini.GetValue("Rain", "High24hTime", DateTime.MinValue);
+			HiLoYest.HighRain24hTime = ini.GetValue("Rain", "High24hTime", DateTime.MinValue);
 			RG11RainYesterday = ini.GetValue("Rain", "RG11Yesterday", 0.0);
 			// humidity
 			HiLoYest.LowHumidity = ini.GetValue("Humidity", "Low", 0);
@@ -4711,7 +4713,8 @@ namespace CumulusMX
 				DayResetDay = drday;
 
 				// any last updates?
-				DoTrendValues(timestamp);
+				// subtract 1 minute to keep within the previous met day
+				DoTrendValues(timestamp, true);
 
 				if (cumulus.MySqlSettings.CustomRollover.Enabled)
 				{
@@ -5015,7 +5018,7 @@ namespace CumulusMX
 					ThisMonth.LowPress.Val = Pressure;
 					ThisMonth.HighRainRate.Val = RainRate;
 					ThisMonth.HourlyRain.Val = RainLastHour;
-					ThisMonth.HighRain24Hours.Val = Cumulus.DefaultHiVal;
+					ThisMonth.HighRain24Hours.Val = RainLast24Hour;
 					ThisMonth.DailyRain.Val = Cumulus.DefaultHiVal;
 					ThisMonth.HighHumidity.Val = OutdoorHumidity;
 					ThisMonth.LowHumidity.Val = OutdoorHumidity;
@@ -5344,7 +5347,7 @@ namespace CumulusMX
 
 				// Save the current values in case of program restart
 				WriteTodayFile(timestamp, true);
-				WriteYesterdayFile();
+				WriteYesterdayFile(timestamp);
 
 				if (cumulus.NOAAconf.Create)
 				{
@@ -6240,10 +6243,17 @@ namespace CumulusMX
 			}
 		}
 
-		public void DoTrendValues(DateTime ts)
+		public void DoTrendValues(DateTime ts, bool rollover = false)
 		{
 			double trendval, retVal;
 			List<RecentData> retVals;
+			var recTs = ts;
+
+			// if this is the special case of rollover processing, we want the High today record to on the previous day at 23:59 or 08:59
+			if (rollover)
+			{
+				recTs = recTs.AddMinutes(-1);
+			}
 
 			// Do 3 hour trends
 			try
@@ -6328,7 +6338,7 @@ namespace CumulusMX
 							if (RainLastHour > HiLoToday.HighHourlyRain)
 							{
 								HiLoToday.HighHourlyRain = RainLastHour;
-								HiLoToday.HighHourlyRainTime = ts;
+								HiLoToday.HighHourlyRainTime = recTs;
 								WriteTodayFile(ts, false);
 							}
 
@@ -6407,7 +6417,7 @@ namespace CumulusMX
 							if (RainRate > HiLoToday.HighRainRate)
 							{
 								HiLoToday.HighRainRate = RainRate;
-								HiLoToday.HighRainRateTime = ts;
+								HiLoToday.HighRainRateTime = recTs;
 								WriteTodayFile(ts, false);
 							}
 
@@ -6458,7 +6468,8 @@ namespace CumulusMX
 					if (RainLast24Hour > HiLoToday.HighRain24h)
 					{
 						HiLoToday.HighRain24h = RainLast24Hour;
-						HiLoToday.HighRain24hTime = ts;
+						HiLoToday.HighRain24hTime = recTs;
+						WriteTodayFile(recTs, false);
 					}
 
 					if (RainLast24Hour > AllTime.HighRain24Hours.Val)
@@ -6558,9 +6569,8 @@ namespace CumulusMX
 			if (cumulus.LastUpdateTime.Date != DateTime.Now.Date)
 			{
 				ResetMidnightRain(DateTime.Now);
-				ResetSunshineHours();
-				//RecalcSolarFactor(DateTime.Now);
-				ResetMidnightTemperatures();
+				ResetSunshineHours(DateTime.Now);
+				ResetMidnightTemperatures(DateTime.Now);
 			}
 		}
 
@@ -11149,8 +11159,6 @@ namespace CumulusMX
 			// Read the day file list and extract the data from there
 			if (DayFile.Count() > 0)
 			{
-				var len = DayFile.Count() - 1;
-
 				for (var i = 0; i < DayFile.Count(); i++)
 				{
 					var recDate = DateTimeToUnix(DayFile[i].Date) * 1000;
@@ -11311,8 +11319,6 @@ namespace CumulusMX
 			// Read the day file list and extract the data from there
 			if (DayFile.Count() > 0)
 			{
-				var len = DayFile.Count() - 1;
-
 				for (var i = 0; i < DayFile.Count(); i++)
 				{
 					var recDate = DateTimeToUnix(DayFile[i].Date) * 1000;
@@ -11357,8 +11363,6 @@ namespace CumulusMX
 			// Read the day file list and extract the data from there
 			if (DayFile.Count() > 0)
 			{
-				var len = DayFile.Count() - 1;
-
 				for (var i = 0; i < DayFile.Count(); i++)
 				{
 
@@ -11401,8 +11405,6 @@ namespace CumulusMX
 			// Read the day file list and extract the data from there
 			if (DayFile.Count() > 0)
 			{
-				var len = DayFile.Count() - 1;
-
 				for (var i = 0; i < DayFile.Count(); i++)
 				{
 
@@ -11443,13 +11445,11 @@ namespace CumulusMX
 			// Read the dayfile and extract the records from there
 			if (DayFile.Count() > 0)
 			{
-				var len = DayFile.Count() - 1;
-
 				for (var i = 0; i < DayFile.Count(); i++)
 				{
 					long recDate = DateTimeToUnix(DayFile[i].Date) * 1000;
 
-					windDir.Append($"[{recDate},{DayFile[i].DominantWindBearing.ToString()}],");
+					windDir.Append($"[{recDate},{DayFile[i].DominantWindBearing}],");
 
 				}
 			}
@@ -11479,8 +11479,6 @@ namespace CumulusMX
 			// Read the day file list and extract the data from there
 			if (DayFile.Count() > 0)
 			{
-				var len = DayFile.Count() - 1;
-
 				for (var i = 0; i < DayFile.Count(); i++)
 				{
 
@@ -11523,8 +11521,6 @@ namespace CumulusMX
 			// Read the day file list and extract the data from there
 			if (DayFile.Count() > 0)
 			{
-				var len = DayFile.Count() - 1;
-
 				for (var i = 0; i < DayFile.Count(); i++)
 				{
 					long recDate = DateTimeToUnix(DayFile[i].Date) * 1000;

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -4718,6 +4718,9 @@ namespace CumulusMX
 				int month = timestamp.Month;
 				DayResetDay = drday;
 
+				// any last updates?
+				DoTrendValues(timestamp);
+
 				if (cumulus.MySqlSettings.CustomRollover.Enabled)
 				{
 					cumulus.CustomMysqlRolloverTimerTick();

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -151,6 +151,8 @@ namespace CumulusMX
 			public double HighHumidex;
 			public DateTime HighHumidexTime;
 			public double ChillHours;
+			public double HighRain24h;
+			public DateTime HighRain24hTime;
 		}
 
 		public List<dayfilerec> DayFile = new List<dayfilerec>();
@@ -248,6 +250,8 @@ namespace CumulusMX
 			public DateTime LowHumidityTime;
 			public double HighHeatIndex;
 			public DateTime HighHeatIndexTime;
+			public double HighRain24h;
+			public DateTime HighRain24hTime;
 			public double LowWindChill;
 			public DateTime LowWindChillTime;
 			public double HighDewPoint;
@@ -269,6 +273,7 @@ namespace CumulusMX
 			HighHumidex = -500,
 			HighHeatIndex = -500,
 			HighDewPoint = -500,
+			HighRain24h = -500,
 			LowTemp = 999,
 			LowAppTemp = 999,
 			LowFeelsLike = 999,
@@ -287,6 +292,7 @@ namespace CumulusMX
 			HighHumidex = -500,
 			HighHeatIndex = -500,
 			HighDewPoint = -500,
+			HighRain24h = -500,
 			LowTemp = 999,
 			LowAppTemp = 999,
 			LowFeelsLike = 999,
@@ -5014,7 +5020,7 @@ namespace CumulusMX
 					ThisMonth.LowPress.Val = Pressure;
 					ThisMonth.HighRainRate.Val = RainRate;
 					ThisMonth.HourlyRain.Val = RainLastHour;
-					ThisMonth.Rain24Hours.Val = Cumulus.DefaultHiVal;
+					ThisMonth.HighRain24Hours.Val = Cumulus.DefaultHiVal;
 					ThisMonth.DailyRain.Val = Cumulus.DefaultHiVal;
 					ThisMonth.HighHumidity.Val = OutdoorHumidity;
 					ThisMonth.LowHumidity.Val = OutdoorHumidity;
@@ -5044,7 +5050,7 @@ namespace CumulusMX
 					ThisMonth.LowPress.Ts = timestamp;
 					ThisMonth.HighRainRate.Ts = timestamp;
 					ThisMonth.HourlyRain.Ts = timestamp;
-					ThisMonth.Rain24Hours.Ts = timestamp;
+					ThisMonth.HighRain24Hours.Ts = timestamp;
 					ThisMonth.DailyRain.Ts = timestamp;
 					ThisMonth.HighHumidity.Ts = timestamp;
 					ThisMonth.LowHumidity.Ts = timestamp;
@@ -5083,7 +5089,7 @@ namespace CumulusMX
 					ThisYear.LowPress.Val = Pressure;
 					ThisYear.HighRainRate.Val = RainRate;
 					ThisYear.HourlyRain.Val = RainLastHour;
-					ThisYear.Rain24Hours.Val = Cumulus.DefaultHiVal;
+					ThisYear.HighRain24Hours.Val = Cumulus.DefaultHiVal;
 					ThisYear.DailyRain.Val = Cumulus.DefaultHiVal;
 					ThisYear.MonthlyRain.Val = Cumulus.DefaultHiVal;
 					ThisYear.HighHumidity.Val = OutdoorHumidity;
@@ -5114,7 +5120,7 @@ namespace CumulusMX
 					ThisYear.LowPress.Ts = timestamp;
 					ThisYear.HighRainRate.Ts = timestamp;
 					ThisYear.HourlyRain.Ts = timestamp;
-					ThisYear.Rain24Hours.Ts = timestamp;
+					ThisYear.HighRain24Hours.Ts = timestamp;
 					ThisYear.DailyRain.Ts = timestamp;
 					ThisYear.MonthlyRain.Ts = timestamp;
 					ThisYear.HighHumidity.Ts = timestamp;
@@ -5516,6 +5522,9 @@ namespace CumulusMX
 			// 49  Time of low feels like
 			// 50  High Humidex
 			// 51  Time of high Humidex
+			// 52  Chill hours
+			// 53  Max Rain 24 hours
+			// 54  Max Rain 24 hours Time
 
 			double AvgTemp;
 			if (tempsamplestoday > 0)
@@ -5590,7 +5599,9 @@ namespace CumulusMX
 			strb.Append(HiLoToday.LowFeelsLikeTime.ToString("HH:mm") + cumulus.ListSeparator);
 			strb.Append(HiLoToday.HighHumidex.ToString(cumulus.TempFormat) + cumulus.ListSeparator);
 			strb.Append(HiLoToday.HighHumidexTime.ToString("HH:mm") + cumulus.ListSeparator);
-			strb.Append(ChillHours.ToString(cumulus.TempFormat));
+			strb.Append(ChillHours.ToString(cumulus.TempFormat) + cumulus.ListSeparator);
+			strb.Append(HiLoToday.HighRain24h.ToString(cumulus.RainFormat) + cumulus.ListSeparator);
+			strb.Append(HiLoToday.HighRain24hTime.ToString("HH:mm"));
 
 			cumulus.LogMessage("Dayfile.txt entry:");
 			cumulus.LogMessage(strb.ToString());
@@ -5690,7 +5701,9 @@ namespace CumulusMX
 				LowFeelsLikeTime = HiLoToday.LowFeelsLikeTime,
 				HighHumidex = HiLoToday.HighHumidex,
 				HighHumidexTime = HiLoToday.HighHumidexTime,
-				ChillHours = ChillHours
+				ChillHours = ChillHours,
+				HighRain24h = HiLoToday.HighRain24h,
+				HighRain24hTime = HiLoToday.HighRain24hTime
 			};
 
 			DayFile.Add(newRec);
@@ -5756,7 +5769,10 @@ namespace CumulusMX
 				queryString.Append(HiLoToday.LowFeelsLike.ToString(cumulus.TempFormat, InvC) + ",");
 				queryString.Append(HiLoToday.LowFeelsLikeTime.ToString("\\'HH:mm\\'") + ",");
 				queryString.Append(HiLoToday.HighHumidex.ToString(cumulus.TempFormat, InvC) + ",");
-				queryString.Append(HiLoToday.HighHumidexTime.ToString("\\'HH:mm\\'"));
+				queryString.Append(HiLoToday.HighHumidexTime.ToString("\\'HH:mm\\'") + ",");
+				queryString.Append(ChillHours.ToString(cumulus.TempFormat, InvC) + ",");
+				queryString.Append(HiLoToday.HighRain24h.ToString(cumulus.RainFormat, InvC) + ",");
+				queryString.Append(HiLoToday.HighRain24hTime.ToString("\\'HH:mm\\'"));
 
 				queryString.Append(')');
 
@@ -6434,24 +6450,30 @@ namespace CumulusMX
 
 					RainLast24Hour = trendval * cumulus.Calib.Rain.Mult;
 
-					if (RainLast24Hour > AllTime.Rain24Hours.Val)
+					if (RainLast24Hour > HiLoToday.HighRain24h)
 					{
-						SetAlltime(AllTime.Rain24Hours, RainLast24Hour, ts);
+						HiLoToday.HighRain24h = RainLast24Hour;
+						HiLoToday.HighRain24hTime = ts;
 					}
 
-					CheckMonthlyAlltime("Rain24Hours", RainLast24Hour, true, ts);
-
-					if (RainLast24Hour > ThisMonth.Rain24Hours.Val)
+					if (RainLast24Hour > AllTime.HighRain24Hours.Val)
 					{
-						ThisMonth.Rain24Hours.Val = RainLast24Hour;
-						ThisMonth.Rain24Hours.Ts = ts;
+						SetAlltime(AllTime.HighRain24Hours, RainLast24Hour, ts);
+					}
+
+					CheckMonthlyAlltime("HighRain24Hours", RainLast24Hour, true, ts);
+
+					if (RainLast24Hour > ThisMonth.HighRain24Hours.Val)
+					{
+						ThisMonth.HighRain24Hours.Val = RainLast24Hour;
+						ThisMonth.HighRain24Hours.Ts = ts;
 						WriteMonthIniFile();
 					}
 
-					if (RainLast24Hour > ThisYear.Rain24Hours.Val)
+					if (RainLast24Hour > ThisYear.HighRain24Hours.Val)
 					{
-						ThisYear.Rain24Hours.Val = RainLast24Hour;
-						ThisYear.Rain24Hours.Ts = ts;
+						ThisYear.HighRain24Hours.Val = RainLast24Hour;
+						ThisYear.HighRain24Hours.Ts = ts;
 						WriteYearIniFile();
 					}
 				}
@@ -7136,6 +7158,16 @@ namespace CumulusMX
 
 				if (st.Count > idx++ && double.TryParse(st[52], out varDbl))
 					rec.ChillHours = varDbl;
+				else
+					rec.ChillHours = -9999;
+
+				if (st.Count > idx++ && double.TryParse(st[53], out varDbl))
+					rec.HighRain24h = varDbl;
+				else
+					rec.HighRain24h = -9999;
+
+				if (st.Count > idx++ && st[54].Length == 5)
+					rec.HighRain24hTime = GetDateTime(rec.Date, st[54]);
 			}
 			catch (Exception ex)
 			{
@@ -7793,8 +7825,8 @@ namespace CumulusMX
 			AllTime.HourlyRain.Val = ini.GetValue("Rain", "highhourlyrainvalue", Cumulus.DefaultHiVal);
 			AllTime.HourlyRain.Ts = ini.GetValue("Rain", "highhourlyraintime", cumulus.defaultRecordTS);
 
-			AllTime.Rain24Hours.Val = ini.GetValue("Rain", "high24hourrainvalue", Cumulus.DefaultHiVal);
-			AllTime.Rain24Hours.Ts = ini.GetValue("Rain", "high24hourraintime", cumulus.defaultRecordTS);
+			AllTime.HighRain24Hours.Val = ini.GetValue("Rain", "high24hourrainvalue", Cumulus.DefaultHiVal);
+			AllTime.HighRain24Hours.Ts = ini.GetValue("Rain", "high24hourraintime", cumulus.defaultRecordTS);
 
 			AllTime.MonthlyRain.Val = ini.GetValue("Rain", "highmonthlyrainvalue", Cumulus.DefaultHiVal);
 			AllTime.MonthlyRain.Ts = ini.GetValue("Rain", "highmonthlyraintime", cumulus.defaultRecordTS);
@@ -7868,8 +7900,8 @@ namespace CumulusMX
 				ini.SetValue("Rain", "highdailyraintime", AllTime.DailyRain.Ts);
 				ini.SetValue("Rain", "highhourlyrainvalue", AllTime.HourlyRain.Val);
 				ini.SetValue("Rain", "highhourlyraintime", AllTime.HourlyRain.Ts);
-				ini.SetValue("Rain", "high24hourrainvalue", AllTime.Rain24Hours.Val);
-				ini.SetValue("Rain", "high24hourraintime", AllTime.Rain24Hours.Ts);
+				ini.SetValue("Rain", "high24hourrainvalue", AllTime.HighRain24Hours.Val);
+				ini.SetValue("Rain", "high24hourraintime", AllTime.HighRain24Hours.Ts);
 				ini.SetValue("Rain", "highmonthlyrainvalue", AllTime.MonthlyRain.Val);
 				ini.SetValue("Rain", "highmonthlyraintime", AllTime.MonthlyRain.Ts);
 				ini.SetValue("Rain", "longestdryperiodvalue", AllTime.LongestDryPeriod.Val);
@@ -7963,8 +7995,8 @@ namespace CumulusMX
 				MonthlyRecs[month].HourlyRain.Val = ini.GetValue("Rain" + monthstr, "highhourlyrainvalue", Cumulus.DefaultHiVal);
 				MonthlyRecs[month].HourlyRain.Ts = ini.GetValue("Rain" + monthstr, "highhourlyraintime", cumulus.defaultRecordTS);
 
-				MonthlyRecs[month].Rain24Hours.Val = ini.GetValue("Rain" + monthstr, "high24hourrainvalue", Cumulus.DefaultHiVal);
-				MonthlyRecs[month].Rain24Hours.Ts = ini.GetValue("Rain" + monthstr, "high24hourraintime", cumulus.defaultRecordTS);
+				MonthlyRecs[month].HighRain24Hours.Val = ini.GetValue("Rain" + monthstr, "high24hourrainvalue", Cumulus.DefaultHiVal);
+				MonthlyRecs[month].HighRain24Hours.Ts = ini.GetValue("Rain" + monthstr, "high24hourraintime", cumulus.defaultRecordTS);
 
 				MonthlyRecs[month].MonthlyRain.Val = ini.GetValue("Rain" + monthstr, "highmonthlyrainvalue", Cumulus.DefaultHiVal);
 				MonthlyRecs[month].MonthlyRain.Ts = ini.GetValue("Rain" + monthstr, "highmonthlyraintime", cumulus.defaultRecordTS);
@@ -8042,8 +8074,8 @@ namespace CumulusMX
 					ini.SetValue("Rain" + monthstr, "highdailyraintime", MonthlyRecs[month].DailyRain.Ts);
 					ini.SetValue("Rain" + monthstr, "highhourlyrainvalue", MonthlyRecs[month].HourlyRain.Val);
 					ini.SetValue("Rain" + monthstr, "highhourlyraintime", MonthlyRecs[month].HourlyRain.Ts);
-					ini.SetValue("Rain" + monthstr, "high24hourrainvalue", MonthlyRecs[month].Rain24Hours.Val);
-					ini.SetValue("Rain" + monthstr, "high24hourraintime", MonthlyRecs[month].Rain24Hours.Ts);
+					ini.SetValue("Rain" + monthstr, "high24hourrainvalue", MonthlyRecs[month].HighRain24Hours.Val);
+					ini.SetValue("Rain" + monthstr, "high24hourraintime", MonthlyRecs[month].HighRain24Hours.Ts);
 					ini.SetValue("Rain" + monthstr, "highmonthlyrainvalue", MonthlyRecs[month].MonthlyRain.Val);
 					ini.SetValue("Rain" + monthstr, "highmonthlyraintime", MonthlyRecs[month].MonthlyRain.Ts);
 					ini.SetValue("Rain" + monthstr, "longestdryperiodvalue", MonthlyRecs[month].LongestDryPeriod.Val);
@@ -8085,7 +8117,7 @@ namespace CumulusMX
 			ThisMonth.LowPress.Val = Cumulus.DefaultLoVal;
 			ThisMonth.HighRainRate.Val = Cumulus.DefaultHiVal;
 			ThisMonth.HourlyRain.Val = Cumulus.DefaultHiVal;
-			ThisMonth.Rain24Hours.Val = Cumulus.DefaultHiVal;
+			ThisMonth.HighRain24Hours.Val = Cumulus.DefaultHiVal;
 			ThisMonth.DailyRain.Val = Cumulus.DefaultHiVal;
 			ThisMonth.HighHumidity.Val = Cumulus.DefaultHiVal;
 			ThisMonth.LowHumidity.Val = Cumulus.DefaultLoVal;
@@ -8113,7 +8145,7 @@ namespace CumulusMX
 			ThisMonth.LowPress.Ts = cumulus.defaultRecordTS;
 			ThisMonth.HighRainRate.Ts = cumulus.defaultRecordTS;
 			ThisMonth.HourlyRain.Ts = cumulus.defaultRecordTS;
-			ThisMonth.Rain24Hours.Ts = cumulus.defaultRecordTS;
+			ThisMonth.HighRain24Hours.Ts = cumulus.defaultRecordTS;
 			ThisMonth.DailyRain.Ts = cumulus.defaultRecordTS;
 			ThisMonth.HighHumidity.Ts = cumulus.defaultRecordTS;
 			ThisMonth.LowHumidity.Ts = cumulus.defaultRecordTS;
@@ -8172,8 +8204,8 @@ namespace CumulusMX
 				ThisMonth.HourlyRain.Ts = ini.GetValue("Rain", "HHourlyTime", cumulus.defaultRecordTS);
 				ThisMonth.DailyRain.Val = ini.GetValue("Rain", "DailyHigh", Cumulus.DefaultHiVal);
 				ThisMonth.DailyRain.Ts = ini.GetValue("Rain", "HDailyTime", cumulus.defaultRecordTS);
-				ThisMonth.Rain24Hours.Val = ini.GetValue("Rain", "24Hour", Cumulus.DefaultHiVal);
-				ThisMonth.Rain24Hours.Ts = ini.GetValue("Rain", "24HourTime", cumulus.defaultRecordTS);
+				ThisMonth.HighRain24Hours.Val = ini.GetValue("Rain", "24Hour", Cumulus.DefaultHiVal);
+				ThisMonth.HighRain24Hours.Ts = ini.GetValue("Rain", "24HourTime", cumulus.defaultRecordTS);
 				ThisMonth.LongestDryPeriod.Val = ini.GetValue("Rain", "LongestDryPeriod", 0);
 				ThisMonth.LongestDryPeriod.Ts = ini.GetValue("Rain", "LongestDryPeriodTime", cumulus.defaultRecordTS);
 				ThisMonth.LongestWetPeriod.Val = ini.GetValue("Rain", "LongestWetPeriod", 0);
@@ -8256,8 +8288,8 @@ namespace CumulusMX
 					ini.SetValue("Rain", "HHourlyTime", ThisMonth.HourlyRain.Ts);
 					ini.SetValue("Rain", "DailyHigh", ThisMonth.DailyRain.Val);
 					ini.SetValue("Rain", "HDailyTime", ThisMonth.DailyRain.Ts);
-					ini.SetValue("Rain", "24Hour", ThisMonth.Rain24Hours.Val);
-					ini.SetValue("Rain", "24HourTime", ThisMonth.Rain24Hours.Ts);
+					ini.SetValue("Rain", "24Hour", ThisMonth.HighRain24Hours.Val);
+					ini.SetValue("Rain", "24HourTime", ThisMonth.HighRain24Hours.Ts);
 					ini.SetValue("Rain", "LongestDryPeriod", ThisMonth.LongestDryPeriod.Val);
 					ini.SetValue("Rain", "LongestDryPeriodTime", ThisMonth.LongestDryPeriod.Ts);
 					ini.SetValue("Rain", "LongestWetPeriod", ThisMonth.LongestWetPeriod.Val);
@@ -8348,8 +8380,8 @@ namespace CumulusMX
 				ThisYear.HourlyRain.Ts = ini.GetValue("Rain", "HHourlyTime", cumulus.defaultRecordTS);
 				ThisYear.DailyRain.Val = ini.GetValue("Rain", "DailyHigh", Cumulus.DefaultHiVal);
 				ThisYear.DailyRain.Ts = ini.GetValue("Rain", "HDailyTime", cumulus.defaultRecordTS);
-				ThisYear.Rain24Hours.Val = ini.GetValue("Rain", "24Hour", Cumulus.DefaultHiVal);
-				ThisYear.Rain24Hours.Ts = ini.GetValue("Rain", "24HourTime", cumulus.defaultRecordTS);
+				ThisYear.HighRain24Hours.Val = ini.GetValue("Rain", "24Hour", Cumulus.DefaultHiVal);
+				ThisYear.HighRain24Hours.Ts = ini.GetValue("Rain", "24HourTime", cumulus.defaultRecordTS);
 				ThisYear.MonthlyRain.Val = ini.GetValue("Rain", "MonthlyHigh", Cumulus.DefaultHiVal);
 				ThisYear.MonthlyRain.Ts = ini.GetValue("Rain", "HMonthlyTime", cumulus.defaultRecordTS);
 				ThisYear.LongestDryPeriod.Val = ini.GetValue("Rain", "LongestDryPeriod", 0);
@@ -8433,8 +8465,8 @@ namespace CumulusMX
 					ini.SetValue("Rain", "HHourlyTime", ThisYear.HourlyRain.Ts);
 					ini.SetValue("Rain", "DailyHigh", ThisYear.DailyRain.Val);
 					ini.SetValue("Rain", "HDailyTime", ThisYear.DailyRain.Ts);
-					ini.SetValue("Rain", "24Hour", ThisYear.Rain24Hours.Val);
-					ini.SetValue("Rain", "24HourTime", ThisYear.Rain24Hours.Ts);
+					ini.SetValue("Rain", "24Hour", ThisYear.HighRain24Hours.Val);
+					ini.SetValue("Rain", "24HourTime", ThisYear.HighRain24Hours.Ts);
 					ini.SetValue("Rain", "MonthlyHigh", ThisYear.MonthlyRain.Val);
 					ini.SetValue("Rain", "HMonthlyTime", ThisYear.MonthlyRain.Ts);
 					ini.SetValue("Rain", "LongestDryPeriod", ThisYear.LongestDryPeriod.Val);
@@ -8498,7 +8530,7 @@ namespace CumulusMX
 			ThisYear.LowPress.Val = Cumulus.DefaultLoVal;
 			ThisYear.HighRainRate.Val = Cumulus.DefaultHiVal;
 			ThisYear.HourlyRain.Val = Cumulus.DefaultHiVal;
-			ThisYear.Rain24Hours.Val = Cumulus.DefaultHiVal;
+			ThisYear.HighRain24Hours.Val = Cumulus.DefaultHiVal;
 			ThisYear.DailyRain.Val = Cumulus.DefaultHiVal;
 			ThisYear.MonthlyRain.Val = Cumulus.DefaultHiVal;
 			ThisYear.HighHumidity.Val = Cumulus.DefaultHiVal;
@@ -8528,7 +8560,7 @@ namespace CumulusMX
 			ThisYear.HighRainRate.Ts = cumulus.defaultRecordTS;
 			ThisYear.HourlyRain.Ts = cumulus.defaultRecordTS;
 			ThisYear.DailyRain.Ts = cumulus.defaultRecordTS;
-			ThisYear.Rain24Hours.Ts = cumulus.defaultRecordTS;
+			ThisYear.HighRain24Hours.Ts = cumulus.defaultRecordTS;
 			ThisYear.MonthlyRain.Ts = cumulus.defaultRecordTS;
 			ThisYear.HighHumidity.Ts = cumulus.defaultRecordTS;
 			ThisYear.LowHumidity.Ts = cumulus.defaultRecordTS;
@@ -9486,7 +9518,7 @@ namespace CumulusMX
 			json.Append(',');
 			json.Append(alltimejsonformat(AllTime.DailyRain, cumulus.Units.RainText, cumulus.RainFormat, "D"));
 			json.Append(',');
-			json.Append(alltimejsonformat(AllTime.Rain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "D"));
+			json.Append(alltimejsonformat(AllTime.HighRain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "f"));
 			json.Append(',');
 			json.Append(alltimejsonformat(AllTime.MonthlyRain, cumulus.Units.RainText, cumulus.RainFormat, "Y"));
 			json.Append(',');
@@ -9584,7 +9616,7 @@ namespace CumulusMX
 			json.Append(',');
 			json.Append(monthlyjsonformat(MonthlyRecs[month].DailyRain, cumulus.Units.RainText, cumulus.RainFormat, "D"));
 			json.Append(',');
-			json.Append(monthlyjsonformat(MonthlyRecs[month].Rain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "D"));
+			json.Append(monthlyjsonformat(MonthlyRecs[month].HighRain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "f"));
 			json.Append(',');
 			json.Append(monthlyjsonformat(MonthlyRecs[month].MonthlyRain, cumulus.Units.RainText, cumulus.RainFormat, "Y"));
 			json.Append(',');
@@ -9682,7 +9714,7 @@ namespace CumulusMX
 			json.Append(',');
 			json.Append(monthyearjsonformat(ThisMonth.DailyRain, cumulus.Units.RainText, cumulus.RainFormat, "D"));
 			json.Append(',');
-			json.Append(monthyearjsonformat(ThisMonth.Rain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "D"));
+			json.Append(monthyearjsonformat(ThisMonth.HighRain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "f"));
 			json.Append(',');
 			//json.Append(monthyearjsonformat(ThisMonth.WetMonth.Desc, month, cumulus.Units.RainText, cumulus.RainFormat, "Y"));
 			//json.Append(',');
@@ -9775,7 +9807,7 @@ namespace CumulusMX
 			json.Append(',');
 			json.Append(monthyearjsonformat(ThisYear.DailyRain, cumulus.Units.RainText, cumulus.RainFormat, "D"));
 			json.Append(',');
-			json.Append(monthyearjsonformat(ThisYear.Rain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "D"));
+			json.Append(monthyearjsonformat(ThisYear.HighRain24Hours, cumulus.Units.RainText, cumulus.RainFormat, "f"));
 			json.Append(',');
 			json.Append(monthyearjsonformat(ThisYear.MonthlyRain, cumulus.Units.RainText, cumulus.RainFormat, "Y"));
 			json.Append(',');
@@ -12539,7 +12571,7 @@ namespace CumulusMX
 		public AllTimeRec HighFeelsLike { get; set; } = new AllTimeRec(25);
 		public AllTimeRec LowFeelsLike { get; set; } = new AllTimeRec(26);
 		public AllTimeRec HighHumidex { get; set; } = new AllTimeRec(27);
-		public AllTimeRec Rain24Hours { get; set; } = new AllTimeRec(28);
+		public AllTimeRec HighRain24Hours { get; set; } = new AllTimeRec(28);
 	}
 
 	public class AllTimeRec

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -630,17 +630,17 @@ namespace CumulusMX
 
 			// Solar
 			HiLoToday.HighSolar = ini.GetValue("Solar", "HighSolarRad", 0.0);
-			HiLoToday.HighSolarTime = ini.GetValue("Solar", "HighSolarRadTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighSolarTime = ini.GetValue("Solar", "HighSolarRadTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.HighUv = ini.GetValue("Solar", "HighUV", 0.0);
-			HiLoToday.HighUvTime = ini.GetValue("Solar", "HighUVTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighUvTime = ini.GetValue("Solar", "HighUVTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			StartOfDaySunHourCounter = ini.GetValue("Solar", "SunStart", -9999.0);
 			RG11RainToday = ini.GetValue("Rain", "RG11Today", 0.0);
 
 			// Wind
 			HiLoToday.HighWind = ini.GetValue("Wind", "Speed", 0.0);
-			HiLoToday.HighWindTime = ini.GetValue("Wind", "SpTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighWindTime = ini.GetValue("Wind", "SpTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.HighGust = ini.GetValue("Wind", "Gust", 0.0);
-			HiLoToday.HighGustTime = ini.GetValue("Wind", "Time", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighGustTime = ini.GetValue("Wind", "Time", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.HighGustBearing = ini.GetValue("Wind", "Bearing", 0);
 			WindRunToday = ini.GetValue("Wind", "Windrun", 0.0);
 			DominantWindBearing = ini.GetValue("Wind", "DominantWindBearing", 0);
@@ -649,9 +649,9 @@ namespace CumulusMX
 			DominantWindBearingY = ini.GetValue("Wind", "DominantWindBearingY", 0.0);
 			// Temperature
 			HiLoToday.LowTemp = ini.GetValue("Temp", "Low", 999.0);
-			HiLoToday.LowTempTime = ini.GetValue("Temp", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.LowTempTime = ini.GetValue("Temp", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.HighTemp = ini.GetValue("Temp", "High", -999.0);
-			HiLoToday.HighTempTime = ini.GetValue("Temp", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighTempTime = ini.GetValue("Temp", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			if ((HiLoToday.HighTemp > -400) && (HiLoToday.LowTemp < 400))
 				HiLoToday.TempRange = HiLoToday.HighTemp - HiLoToday.LowTemp;
 			else
@@ -669,14 +669,16 @@ namespace CumulusMX
 			HiLoTodayMidnight.HighTempTime = ini.GetValue("TempMidnight", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// PressureHighDewpoint
 			HiLoToday.LowPress = ini.GetValue("Pressure", "Low", 9999.0);
-			HiLoToday.LowPressTime = ini.GetValue("Pressure", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.LowPressTime = ini.GetValue("Pressure", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.HighPress = ini.GetValue("Pressure", "High", 0.0);
-			HiLoToday.HighPressTime = ini.GetValue("Pressure", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighPressTime = ini.GetValue("Pressure", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// rain
 			HiLoToday.HighRainRate = ini.GetValue("Rain", "High", 0.0);
-			HiLoToday.HighRainRateTime = ini.GetValue("Rain", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighRainRateTime = ini.GetValue("Rain", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.HighHourlyRain = ini.GetValue("Rain", "HourlyHigh", 0.0);
-			HiLoToday.HighHourlyRainTime = ini.GetValue("Rain", "HHourlyTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighHourlyRainTime = ini.GetValue("Rain", "HHourlyTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighRain24h = ini.GetValue("Rain", "High24h", 0.0);
+			HiLoToday.HighRain24hTime = ini.GetValue("Rain", "High24hTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			raindaystart = ini.GetValue("Rain", "Start", -1.0);
 			cumulus.LogMessage($"ReadTodayfile: Rain day start = {raindaystart}");
 			RainYesterday = ini.GetValue("Rain", "Yesterday", 0.0);
@@ -688,35 +690,35 @@ namespace CumulusMX
 			// humidity
 			HiLoToday.LowHumidity = ini.GetValue("Humidity", "Low", 100);
 			HiLoToday.HighHumidity = ini.GetValue("Humidity", "High", 0);
-			HiLoToday.LowHumidityTime = ini.GetValue("Humidity", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
-			HiLoToday.HighHumidityTime = ini.GetValue("Humidity", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.LowHumidityTime = ini.GetValue("Humidity", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
+			HiLoToday.HighHumidityTime = ini.GetValue("Humidity", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// Solar
 			SunshineHours = ini.GetValue("Solar", "SunshineHours", 0.0);
 			SunshineToMidnight = ini.GetValue("Solar", "SunshineHoursToMidnight", 0.0);
 			// heat index
 			HiLoToday.HighHeatIndex = ini.GetValue("HeatIndex", "High", -999.0);
-			HiLoToday.HighHeatIndexTime = ini.GetValue("HeatIndex", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighHeatIndexTime = ini.GetValue("HeatIndex", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// Apparent temp
 			HiLoToday.HighAppTemp = ini.GetValue("AppTemp", "High", -999.0);
-			HiLoToday.HighAppTempTime = ini.GetValue("AppTemp", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighAppTempTime = ini.GetValue("AppTemp", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.LowAppTemp = ini.GetValue("AppTemp", "Low", 999.0);
-			HiLoToday.LowAppTempTime = ini.GetValue("AppTemp", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.LowAppTempTime = ini.GetValue("AppTemp", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// wind chill
 			HiLoToday.LowWindChill = ini.GetValue("WindChill", "Low", 999.0);
-			HiLoToday.LowWindChillTime = ini.GetValue("WindChill", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.LowWindChillTime = ini.GetValue("WindChill", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// Dew point
 			HiLoToday.HighDewPoint = ini.GetValue("Dewpoint", "High", -999.0);
-			HiLoToday.HighDewPointTime = ini.GetValue("Dewpoint", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighDewPointTime = ini.GetValue("Dewpoint", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.LowDewPoint = ini.GetValue("Dewpoint", "Low", 999.0);
-			HiLoToday.LowDewPointTime = ini.GetValue("Dewpoint", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.LowDewPointTime = ini.GetValue("Dewpoint", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// Feels like
 			HiLoToday.HighFeelsLike = ini.GetValue("FeelsLike", "High", -999.0);
-			HiLoToday.HighFeelsLikeTime = ini.GetValue("FeelsLike", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighFeelsLikeTime = ini.GetValue("FeelsLike", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			HiLoToday.LowFeelsLike = ini.GetValue("FeelsLike", "Low", 999.0);
-			HiLoToday.LowFeelsLikeTime = ini.GetValue("FeelsLike", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.LowFeelsLikeTime = ini.GetValue("FeelsLike", "LTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 			// Humidex
 			HiLoToday.HighHumidex = ini.GetValue("Humidex", "High", -999.0);
-			HiLoToday.HighHumidexTime = ini.GetValue("Humidex", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay, 0, 0, 0));
+			HiLoToday.HighHumidexTime = ini.GetValue("Humidex", "HTime", new DateTime(CurrentYear, CurrentMonth, CurrentDay));
 
 			// Records
 			AlltimeRecordTimestamp = ini.GetValue("Records", "Alltime", DateTime.MinValue);
@@ -780,6 +782,8 @@ namespace CumulusMX
 				ini.SetValue("Rain", "HTime", HiLoToday.HighRainRateTime.ToString("HH:mm"));
 				ini.SetValue("Rain", "HourlyHigh", HiLoToday.HighHourlyRain);
 				ini.SetValue("Rain", "HHourlyTime", HiLoToday.HighHourlyRainTime.ToString("HH:mm"));
+				ini.SetValue("Rain", "High24h", HiLoToday.HighRain24h);
+				ini.SetValue("Rain", "High24hTime", HiLoToday.HighRain24hTime.ToString("HH:mm"));
 				ini.SetValue("Rain", "Start", raindaystart);
 				ini.SetValue("Rain", "Yesterday", RainYesterday);
 				ini.SetValue("Rain", "LastTip", LastRainTip);
@@ -4562,11 +4566,13 @@ namespace CumulusMX
 			ini.SetValue("Pressure", "LTime", HiLoYest.LowPressTime.ToString("HH:mm"));
 			ini.SetValue("Pressure", "High", HiLoYest.HighPress);
 			ini.SetValue("Pressure", "HTime", HiLoYest.HighPressTime.ToString("HH:mm"));
-			// rain rate
+			// rain
 			ini.SetValue("Rain", "High", HiLoYest.HighRainRate);
 			ini.SetValue("Rain", "HTime", HiLoYest.HighRainRateTime.ToString("HH:mm"));
 			ini.SetValue("Rain", "HourlyHigh", HiLoYest.HighHourlyRain);
 			ini.SetValue("Rain", "HHourlyTime", HiLoYest.HighHourlyRainTime.ToString("HH:mm"));
+			ini.SetValue("Rain", "High24h", HiLoYest.HighRain24h);
+			ini.SetValue("Rain", "High24hTime", HiLoYest.HighRain24hTime.ToString("HH:mm"));
 			ini.SetValue("Rain", "RG11Yesterday", RG11RainYesterday);
 			// humidity
 			ini.SetValue("Humidity", "Low", HiLoYest.LowHumidity);
@@ -4645,11 +4651,13 @@ namespace CumulusMX
 			HiLoYest.LowPressTime = ini.GetValue("Pressure", "LTime", DateTime.MinValue);
 			HiLoYest.HighPress = ini.GetValue("Pressure", "High", 0.0);
 			HiLoYest.HighPressTime = ini.GetValue("Pressure", "HTime", DateTime.MinValue);
-			// rain rate
+			// rain
 			HiLoYest.HighRainRate = ini.GetValue("Rain", "High", 0.0);
 			HiLoYest.HighRainRateTime = ini.GetValue("Rain", "HTime", DateTime.MinValue);
 			HiLoYest.HighHourlyRain = ini.GetValue("Rain", "HourlyHigh", 0.0);
 			HiLoYest.HighHourlyRainTime = ini.GetValue("Rain", "HHourlyTime", DateTime.MinValue);
+			HiLoYest.HighRain24h = ini.GetValue("Rain", "High24h", 0.0);
+			HiLoToday.HighRain24hTime = ini.GetValue("Rain", "High24hTime", DateTime.MinValue);
 			RG11RainYesterday = ini.GetValue("Rain", "RG11Yesterday", 0.0);
 			// humidity
 			HiLoYest.LowHumidity = ini.GetValue("Humidity", "Low", 0);
@@ -5076,7 +5084,7 @@ namespace CumulusMX
 					ThisYear.LowPress.Val = Pressure;
 					ThisYear.HighRainRate.Val = RainRate;
 					ThisYear.HourlyRain.Val = RainLastHour;
-					ThisYear.HighRain24Hours.Val = Cumulus.DefaultHiVal;
+					ThisYear.HighRain24Hours.Val = RainLast24Hour;
 					ThisYear.DailyRain.Val = Cumulus.DefaultHiVal;
 					ThisYear.MonthlyRain.Val = Cumulus.DefaultHiVal;
 					ThisYear.HighHumidity.Val = OutdoorHumidity;
@@ -5231,6 +5239,11 @@ namespace CumulusMX
 				HiLoYest.HighHourlyRainTime = HiLoToday.HighHourlyRainTime;
 				HiLoToday.HighHourlyRain = RainLastHour;
 				HiLoToday.HighHourlyRainTime = timestamp;
+
+				HiLoYest.HighRain24h = HiLoToday.HighRain24h;
+				HiLoYest.HighRain24hTime = HiLoToday.HighRain24hTime;
+				HiLoToday.HighRain24h = RainLast24Hour;
+				HiLoToday.HighRain24hTime = timestamp;
 
 				YesterdayWindRun = WindRunToday;
 				WindRunToday = 0;
@@ -10330,7 +10343,20 @@ namespace CumulusMX
 			json.Append(unitStr);
 			json.Append(sepStr);
 			json.Append(HiLoYest.HighHourlyRainTime.ToShortTimeString());
+			json.Append("\"],");
+
+			json.Append("[\"High 24 Hour Rain\",\"");
+			json.Append(HiLoToday.HighRain24h.ToString(cumulus.RainFormat));
+			json.Append(unitStr);
+			json.Append(sepStr);
+			json.Append(HiLoToday.HighRain24hTime.ToShortTimeString());
+			json.Append(sepStr);
+			json.Append(HiLoYest.HighRain24h.ToString(cumulus.RainFormat));
+			json.Append(unitStr);
+			json.Append(sepStr);
+			json.Append(HiLoYest.HighRain24hTime.ToShortTimeString());
 			json.Append("\"]");
+
 
 			json.Append("]}");
 			return json.ToString();

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1449,6 +1449,12 @@ namespace CumulusMX
 
 				if (DataStopped)
 				{
+					// check if we want to exit on data stopped
+					if (cumulus.ProgramOptions.DataStoppedExit && DataStoppedTime.AddMinutes(cumulus.ProgramOptions.DataStoppedMins) < DateTime.Now)
+					{
+						cumulus.LogMessage($"*** Exiting Cumulus due to Data Stopped condition for > {cumulus.ProgramOptions.DataStoppedMins} minutes");
+						Program.exitSystem = true;
+					}
 					// No data coming in, do not do anything else
 					return;
 				}
@@ -1967,6 +1973,10 @@ namespace CumulusMX
 			if ((LastDataReadTimestamp != DateTime.MinValue) && (LastDataReadTimestamp == SavedLastDataReadTimestamp) && (LastDataReadTimestamp < DateTime.Now))
 			{
 				// Data input appears to have has stopped
+				if (!DataStopped)
+				{
+					DataStoppedTime = DateTime.Now;
+				}
 				DataStopped = true;
 				cumulus.DataStoppedAlarm.Triggered = true;
 				/*if (RestartIfDataStops)
@@ -6566,6 +6576,7 @@ namespace CumulusMX
 		public DateTime StartOfStorm { get; set; }
 		public bool SensorContactLost { get; set; }
 		public bool DataStopped { get; set; }
+		public DateTime DataStoppedTime { get; set; }
 		public bool IsRaining { get; set; }
 
 		public void LoadLastHoursFromDataLogs(DateTime ts)

--- a/CumulusMX/packages.config
+++ b/CumulusMX/packages.config
@@ -5,8 +5,8 @@
   <package id="MailKit" version="3.3.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net452" />
   <package id="MimeKit" version="3.3.0" targetFramework="net48" />
-  <package id="MQTTnet" version="4.0.1.184" targetFramework="net48" />
-  <package id="MySqlConnector" version="2.1.10" targetFramework="net48" />
+  <package id="MQTTnet" version="4.0.2.221" targetFramework="net48" />
+  <package id="MySqlConnector" version="2.1.11" targetFramework="net48" />
   <package id="Portable.BouncyCastle" version="1.9.0" targetFramework="net48" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />

--- a/CumulusMX/packages.config
+++ b/CumulusMX/packages.config
@@ -13,7 +13,7 @@
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="6.1.0" targetFramework="net48" />
+  <package id="ServiceStack.Text" version="6.2.0" targetFramework="net48" />
   <package id="SSH.NET" version="2020.0.2" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net48" />

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -1388,7 +1388,7 @@ namespace CumulusMX
 			if (station.AllTime.HighRainRate.Ts >= threshold ||
 				station.AllTime.DailyRain.Ts >= threshold ||
 				station.AllTime.HourlyRain.Ts >= threshold ||
-				station.AllTime.Rain24Hours.Ts >= threshold ||
+				station.AllTime.HighRain24Hours.Ts >= threshold ||
 				station.AllTime.LongestDryPeriod.Ts >= threshold ||
 				station.AllTime.LongestWetPeriod.Ts >= threshold ||
 				station.AllTime.MonthlyRain.Ts >= threshold
@@ -1512,7 +1512,7 @@ namespace CumulusMX
 
 		private string TagHighRain24HourRecordSet(Dictionary<string, string> tagParams)
 		{
-			return station.AllTime.Rain24Hours.Ts < DateTime.Now.AddHours(-cumulus.RecordSetTimeoutHrs) ? "0" : "1";
+			return station.AllTime.HighRain24Hours.Ts < DateTime.Now.AddHours(-cumulus.RecordSetTimeoutHrs) ? "0" : "1";
 		}
 
 		private string TagHighMonthlyRainRecordSet(Dictionary<string,string> tagParams)
@@ -2331,12 +2331,12 @@ namespace CumulusMX
 
 		private string Tagr24hourH(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.AllTime.Rain24Hours.Val, tagParams, cumulus.RainDPlaces);
+			return CheckRcDp(station.AllTime.HighRain24Hours.Val, tagParams, cumulus.RainDPlaces);
 		}
 
 		private string TagTr24hourH(Dictionary<string, string> tagParams)
 		{
-			return GetFormattedDateTime(station.AllTime.Rain24Hours.Ts, "\\a\\t HH:mm o\\n dd MMMM yyyy", tagParams);
+			return GetFormattedDateTime(station.AllTime.HighRain24Hours.Ts, "\\a\\t HH:mm o\\n dd MMMM yyyy", tagParams);
 		}
 
 		private string TagLongestDryPeriod(Dictionary<string,string> tagParams)
@@ -2668,13 +2668,13 @@ namespace CumulusMX
 		private string TagByMonthRain24HourH(Dictionary<string, string> tagParams)
 		{
 			var month = GetMonthParam(tagParams);
-			return GetMonthlyAlltimeValueStr(station.MonthlyRecs[month].Rain24Hours, tagParams, cumulus.RainDPlaces);
+			return GetMonthlyAlltimeValueStr(station.MonthlyRecs[month].HighRain24Hours, tagParams, cumulus.RainDPlaces);
 		}
 
 		private string TagByMonthRain24HourHt(Dictionary<string, string> tagParams)
 		{
 			var month = GetMonthParam(tagParams);
-			return GetFormattedDateTime(station.MonthlyRecs[month].Rain24Hours.Ts, "\\a\\t HH:mm o\\n dd MMMM yyyy", tagParams);
+			return GetFormattedDateTime(station.MonthlyRecs[month].HighRain24Hours.Ts, "\\a\\t HH:mm o\\n dd MMMM yyyy", tagParams);
 		}
 
 
@@ -4294,7 +4294,7 @@ namespace CumulusMX
 
 		private string TagMonthRain24HourH(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.ThisMonth.Rain24Hours.Val, tagParams, cumulus.RainDPlaces);
+			return CheckRcDp(station.ThisMonth.HighRain24Hours.Val, tagParams, cumulus.RainDPlaces);
 		}
 
 
@@ -4416,7 +4416,7 @@ namespace CumulusMX
 
 		private string TagMonthRain24HourHt(Dictionary<string, string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisMonth.Rain24Hours.Ts, "t", tagParams);
+			return GetFormattedDateTime(station.ThisMonth.HighRain24Hours.Ts, "t", tagParams);
 		}
 
 
@@ -4528,7 +4528,7 @@ namespace CumulusMX
 
 		private string TagMonthRain24HourHd(Dictionary<string, string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisMonth.Rain24Hours.Ts, "dd MMMM", tagParams);
+			return GetFormattedDateTime(station.ThisMonth.HighRain24Hours.Ts, "dd MMMM", tagParams);
 		}
 
 		private string TagMonthHighDailyTempRangeD(Dictionary<string,string> tagParams)
@@ -4679,7 +4679,7 @@ namespace CumulusMX
 
 		private string TagYearRain24HourH(Dictionary<string, string> tagParams)
 		{
-			return CheckRcDp(station.ThisYear.Rain24Hours.Val, tagParams, cumulus.RainDPlaces);
+			return CheckRcDp(station.ThisYear.HighRain24Hours.Val, tagParams, cumulus.RainDPlaces);
 		}
 
 
@@ -4805,7 +4805,7 @@ namespace CumulusMX
 
 		private string TagYearRain24HourHt(Dictionary<string, string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisYear.Rain24Hours.Ts, "t", tagParams);
+			return GetFormattedDateTime(station.ThisYear.HighRain24Hours.Ts, "t", tagParams);
 		}
 
 
@@ -4916,7 +4916,7 @@ namespace CumulusMX
 
 		private string TagYearRain24HourHd(Dictionary<string, string> tagParams)
 		{
-			return GetFormattedDateTime(station.ThisYear.Rain24Hours.Ts, "dd MMMM", tagParams);
+			return GetFormattedDateTime(station.ThisYear.HighRain24Hours.Ts, "dd MMMM", tagParams);
 		}
 
 

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -1872,6 +1872,16 @@ namespace CumulusMX
 			return GetFormattedDateTime(station.HiLoToday.HighHourlyRainTime, "HH:mm", tagParams);
 		}
 
+		private string Tagrain24hourTh(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.HiLoToday.HighRain24h, tagParams, cumulus.RainDPlaces);
+		}
+
+		private string TagTrain24hourTh(Dictionary<string, string> tagParams)
+		{
+			return GetFormattedDateTime(station.HiLoToday.HighRain24hTime, "HH:mm", tagParams);
+		}
+
 		private string TaghourlyrainYh(Dictionary<string,string> tagParams)
 		{
 			return CheckRcDp(station.HiLoYest.HighHourlyRain, tagParams, cumulus.RainDPlaces);
@@ -1880,6 +1890,16 @@ namespace CumulusMX
 		private string TagThourlyrainYh(Dictionary<string,string> tagParams)
 		{
 			return GetFormattedDateTime(station.HiLoYest.HighHourlyRainTime, "HH:mm", tagParams);
+		}
+
+		private string Tagrain24hourYh(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.HiLoYest.HighRain24h, tagParams, cumulus.RainDPlaces);
+		}
+
+		private string TagTrain24hourYh(Dictionary<string, string> tagParams)
+		{
+			return GetFormattedDateTime(station.HiLoYest.HighRain24hTime, "HH:mm", tagParams);
 		}
 
 		private string TagSolarYh(Dictionary<string,string> tagParams)
@@ -5553,8 +5573,12 @@ namespace CumulusMX
 				{ "TrrateTM", TagTrrateTm },
 				{ "hourlyrainTH", TaghourlyrainTh },
 				{ "ThourlyrainTH", TagThourlyrainTh },
+				{ "rain24hourTH", Tagrain24hourTh },
+				{ "Train24hourTH", TagTrain24hourTh },
 				{ "hourlyrainYH", TaghourlyrainYh },
 				{ "ThourlyrainYH", TagThourlyrainYh },
+				{ "rain24hourYH", Tagrain24hourYh },
+				{ "Train24hourYH", TagTrain24hourYh },
 				{ "solarTH", TagSolarTh },
 				{ "TsolarTH", TagTsolarTh },
 				{ "UVTH", TagUvth },

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -541,7 +541,7 @@ namespace CumulusMX
 
 		private string TagTime(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(DateTime.Now, tagParams);
+			return GetFormattedDateTime(DateTime.Now, "HH:mm\" on \"dd MMMM yyyy", tagParams);
 		}
 
 		private static string TagDaysSince30Dec1899(Dictionary<string,string> tagParams)
@@ -552,7 +552,7 @@ namespace CumulusMX
 
 		private string TagTimeUtc(Dictionary<string,string> tagParams)
 		{
-			return GetFormattedDateTime(DateTime.UtcNow, tagParams);
+			return GetFormattedDateTime(DateTime.UtcNow, "HH:mm\" on \"dd MMMM yyyy", tagParams);
 		}
 
 		private static string TagTimehhmmss(Dictionary<string,string> tagParams)
@@ -2004,7 +2004,7 @@ namespace CumulusMX
 		}
 
 		private string TagtempMidnightRangeY(Dictionary<string, string> tagParams)
-		{	
+		{
 			return CheckRcDp((station.HiLoYestMidnight.HighTemp - station.HiLoYestMidnight.LowTemp), tagParams, cumulus.TempDPlaces);
 		}
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -15,6 +15,9 @@ New
 	- Added to all the record editors
 	- Added to MySQL. There is a MySQL script in the MXutils folder to alter existing tables
 - Adds the ability to search in the Dayfile viewer/editor
+- FTP and FTPS now has an option to enable automatic detection of the connection settings
+	- This and another new setting Ignore Certificate Errors are in Internet Settings | Web/TFP Site | Advanced Settings
+	- NOTE: If you use an FTP server without a public certificate that previously worked, you MUST enable the setting. This is a breaking change
 
 Changed
 - Alarm latch time hours are now decimal values rather than integer
@@ -23,6 +26,7 @@ Changed
 - The Monthly records editor month tabs have improved accessibility
 - The default web site monthly records page month selection button have improved accessibility
 - Local API, removed BOM from all API responses
+
 
 
 3.19.3 - b3196

--- a/Updates.txt
+++ b/Updates.txt
@@ -14,6 +14,7 @@ New
 	- Updated dayfile header. Also abbreviated and changed to CSV from PipeSV
 	- Added to all the record editors
 	- Added to MySQL. There is a MySQL script in the MXutils folder to alter existing tables
+- Adds the ability to search in the Dayfile viewer/editor
 
 Changed
 - Alarm latch time hours are now decimal values rather than integer

--- a/Updates.txt
+++ b/Updates.txt
@@ -14,10 +14,15 @@ New
 	- Updated dayfile header. Also abbreviated and changed to CSV from PipeSV
 	- Added to all the record editors
 	- Added to MySQL. There is a MySQL script in the MXutils folder to alter existing tables
+	- New web tags:
+		<#rain24hourTH>, <#Train24hourTH>
+		<#rain24hourYH>, <#Train24hourYH>
+	- Default web site updated to show all the relevant records
 - Adds the ability to search in the Dayfile viewer/editor
 - FTP and FTPS now has an option to enable automatic detection of the connection settings
 	- This and another new setting Ignore Certificate Errors are in Internet Settings | Web/TFP Site | Advanced Settings
-	- NOTE: If you use an FTP server without a public certificate that previously worked, you MUST enable the setting. This is a breaking change
+	- NOTE: If you use an FTP server without a public certificate, you *MUST* enable the setting. This is a breaking change
+- Custom HTTP calls (seconds, minutes, rollover) can now have up to 10 URLs each
 
 Changed
 - Alarm latch time hours are now decimal values rather than integer
@@ -26,7 +31,8 @@ Changed
 - The Monthly records editor month tabs have improved accessibility
 - The default web site monthly records page month selection button have improved accessibility
 - Local API, removed BOM from all API responses
-
+- The date pickers for the log file view/editor pages and the new This Period now display the date in the CMX locale format
+- The Cumulus.ini file now only contains FTP ExtraFiles entries that have either a local or remote filename entered
 
 
 3.19.3 - b3196

--- a/Updates.txt
+++ b/Updates.txt
@@ -9,6 +9,11 @@ New
 - Add a This Period records display like C1
 - New option to exit Cumulus MX after a data stopped condition - Program Options > Shutdown
 - All DateTime web tags now accept format strings of "Unix" and "JS", if either of these is supplied the datetime will be output as either a Unix or JavaScript timestamp
+- Rain 24 hour:
+	- Added to day file, records 54, 55 (value, time)
+	- Updated dayfile header. Also abbreviated and changed to CSV from PipeSV
+	- Added to all the record editors
+	- Added to MySQL. There is a MySQL script in the MXutils folder to alter existing tables
 
 Changed
 - Alarm latch time hours are now decimal values rather than integer

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,6 +3,7 @@
 Fixed
 - Buffering of failed MySQL queries
 - MySQL library update to fix crashes with a null reference
+- NOAA Monthly report selector showing two "March"s and no February on the first day of each new month
 
 New
 - Add custom actions for alarms. Call a script or external exe etc.

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,9 +2,11 @@
 ——————————————
 Fixed
 - Buffering of failed MySQL queries
+- MySQL library update to fix crashes with a null reference
 
 New
 - Add custom actions for alarms. Call a script or external exe etc.
+- Add a This Period records display like C1
 
 Changed
 - Alarm latch time hours are now decimal values rather than integer

--- a/Updates.txt
+++ b/Updates.txt
@@ -21,7 +21,7 @@ Changed
 - Moon Rise/Set web tags now have the date set to the current day
 - The records editors now work in your locale date/time formats, they also now report any errors setting values
 - The Monthly records editor month tabs have improved accessibility
-- The default web site monthly records page month button have improved accessibility
+- The default web site monthly records page month selection button have improved accessibility
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -18,6 +18,7 @@ New
 Changed
 - Alarm latch time hours are now decimal values rather than integer
 - Moon Rise/Set web tags now have the date set to the current day
+- The records editors now work in your locale date/time formats, they also now report any errors setting values
 
 
 3.19.2 - b3195

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,7 @@
-3.20.0 - b3197
+3198 fixes
+- #time and #timeutc web tags default formats
+
+3.20.0 - b3198
 ——————————————
 Fixed
 - Buffering of failed MySQL queries
@@ -32,7 +35,7 @@ Changed
 - The default web site monthly records page month selection button have improved accessibility
 - Local API, removed BOM from all API responses
 - The date pickers for the log file view/editor pages and the new This Period now display the date in the CMX locale format
-- The Cumulus.ini file now only contains FTP ExtraFiles entries that have either a local or remote filename entered
+- The Cumulus.ini file now only contains FTP ExtraFiles entries that have either a local or remote filename entered (potentially removes 800 lines from the file!)
 
 
 3.19.3 - b3196

--- a/Updates.txt
+++ b/Updates.txt
@@ -22,7 +22,7 @@ Changed
 - The records editors now work in your locale date/time formats, they also now report any errors setting values
 - The Monthly records editor month tabs have improved accessibility
 - The default web site monthly records page month selection button have improved accessibility
-
+- Local API, removed BOM from all API responses
 
 
 3.19.2 - b3195

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.20.0 - b3196
+3.20.0 - b3197
 ——————————————
 Fixed
 - Buffering of failed MySQL queries
@@ -23,6 +23,12 @@ Changed
 - The Monthly records editor month tabs have improved accessibility
 - The default web site monthly records page month selection button have improved accessibility
 - Local API, removed BOM from all API responses
+
+
+3.19.3 - b3196
+——————————————
+Fixed
+- Error when sending an Is Raining alarm email
 
 
 3.19.2 - b3195

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,10 +7,12 @@ Fixed
 New
 - Add custom actions for alarms. Call a script or external exe etc.
 - Add a This Period records display like C1
+- New option to exit Cumulus MX after a data stopped condition - Program Options > Shutdown
+- All DateTime web tags now accept format strings of "Unix" and "JS", if either of these is supplied the datetime will be output as either a Unix or JavaScript timestamp
 
 Changed
 - Alarm latch time hours are now decimal values rather than integer
-
+- Moon Rise/Set web tags now have the date set to the current day
 
 
 3.19.2 - b3195

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,9 +1,10 @@
-3.20.0 - b3200
+3.20.0 - b3201
 ——————————————
 Fixed
 - Buffering of failed MySQL queries
 - MySQL library update to fix crashes with a null reference
 - NOAA Monthly report selector showing two "March"s and no February on the first day of each new month
+- Alarms being triggered during data catch-up. These are now suppressed
 
 New
 - Add custom actions for alarms. Call a script or external exe etc.

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,13 @@
+3.20.0 - b3196
+——————————————
+Fixed
+
+
+New
+- Add custom actions for alarms. Call a script or external exe etc.
+
+
+
 3.19.2 - b3195
 ——————————————
 Fixed

--- a/Updates.txt
+++ b/Updates.txt
@@ -19,6 +19,9 @@ Changed
 - Alarm latch time hours are now decimal values rather than integer
 - Moon Rise/Set web tags now have the date set to the current day
 - The records editors now work in your locale date/time formats, they also now report any errors setting values
+- The Monthly records editor month tabs have improved accessibility
+- The default web site monthly records page month button have improved accessibility
+
 
 
 3.19.2 - b3195

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,10 +1,13 @@
 3.20.0 - b3196
 ——————————————
 Fixed
-
+- Buffering of failed MySQL queries
 
 New
 - Add custom actions for alarms. Call a script or external exe etc.
+
+Changed
+- Alarm latch time hours are now decimal values rather than integer
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.20.0 - b3201
+3.20.0 - b3202
 ——————————————
 Fixed
 - Buffering of failed MySQL queries

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.20.0 - b3199
+3.20.0 - b3200
 ——————————————
 Fixed
 - Buffering of failed MySQL queries

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,7 +1,4 @@
-3198 fixes
-- #time and #timeutc web tags default formats
-
-3.20.0 - b3198
+3.20.0 - b3199
 ——————————————
 Fixed
 - Buffering of failed MySQL queries
@@ -16,7 +13,7 @@ New
 	- Added to day file, records 54, 55 (value, time)
 	- Updated dayfile header. Also abbreviated and changed to CSV from PipeSV
 	- Added to all the record editors
-	- Added to MySQL. There is a MySQL script in the MXutils folder to alter existing tables
+	- Added to MySQL. See new feature below for updating your existing Dayfile table. There is also a MySQL script in the MXutils folder to alter existing table
 	- New web tags:
 		<#rain24hourTH>, <#Train24hourTH>
 		<#rain24hourYH>, <#Train24hourYH>
@@ -25,7 +22,13 @@ New
 - FTP and FTPS now has an option to enable automatic detection of the connection settings
 	- This and another new setting Ignore Certificate Errors are in Internet Settings | Web/TFP Site | Advanced Settings
 	- NOTE: If you use an FTP server without a public certificate, you *MUST* enable the setting. This is a breaking change
-- Custom HTTP calls (seconds, minutes, rollover) can now have up to 10 URLs each
+- Custom HTTP calls (seconds, minutes, rollover) can now each have up to 10 URLs
+- Custom MySQL Uploads (seconds, minutes, rollover) can now each have up to 10 commands
+- The MySQL Settings page gets new functions for updating existing tables by adding columns to match the current schema
+- A new "Utils" menu on the Dashboard interface
+	- The FTP Now function has been moved there
+	- New option to reload the Dayfile into CMX from file. CMX holds a copy of the Dayfile in memory, if you edit it externally, use this to refresh the values in CMX without restating
+	- New option to purge the failed MySQL command queue. If you have failed commands (normally custom commands) that will never work, then you can remove them from the failed retry queue without restarting CMX
 
 Changed
 - Alarm latch time hours are now decimal values rather than integer


### PR DESCRIPTION
Fixed
- Buffering of failed MySQL queries
- MySQL library update to fix crashes with a null reference
- NOAA Monthly report selector showing two "March"s and no February on the first day of each new month
- Alarms being triggered during data catch-up. These are now suppressed

New
- Add custom actions for alarms. Call a script or external exe etc.
- Add a This Period records display like C1
- New option to exit Cumulus MX after a data stopped condition - Program Options > Shutdown
- All DateTime web tags now accept format strings of "Unix" and "JS", if either of these is supplied the datetime will be output as either a Unix or JavaScript timestamp
- Rain 24 hour:
	- Added to day file, records 54, 55 (value, time)
	- Updated dayfile header. Also abbreviated and changed to CSV from PipeSV
	- Added to all the record editors
	- Added to MySQL. See new feature below for updating your existing Dayfile table. There is also a MySQL script in the MXutils folder to alter existing table
	- New web tags:
		<#rain24hourTH>, <#Train24hourTH>
		<#rain24hourYH>, <#Train24hourYH>
	- Default web site updated to show all the relevant records
- Adds the ability to search in the Dayfile viewer/editor
- FTP and FTPS now has an option to enable automatic detection of the connection settings
	- This and another new setting Ignore Certificate Errors are in Internet Settings | Web/TFP Site | Advanced Settings
	- NOTE: If you use an FTP server without a public certificate, you *MUST* enable the setting. This is a breaking change
- Custom HTTP calls (seconds, minutes, rollover) can now each have up to 10 URLs
- Custom MySQL Uploads (seconds, minutes, rollover) can now each have up to 10 commands
- The MySQL Settings page gets new functions for updating existing tables by adding columns to match the current schema
- A new "Utils" menu on the Dashboard interface
	- The FTP Now function has been moved there
	- New option to reload the Dayfile into CMX from file. CMX holds a copy of the Dayfile in memory, if you edit it externally, use this to refresh the values in CMX without restating
	- New option to purge the failed MySQL command queue. If you have failed commands (normally custom commands) that will never work, then you can remove them from the failed retry queue without restarting CMX

Changed
- Alarm latch time hours are now decimal values rather than integer
- Moon Rise/Set web tags now have the date set to the current day
- The records editors now work in your locale date/time formats, they also now report any errors setting values
- The Monthly records editor month tabs have improved accessibility
- The default web site monthly records page month selection button have improved accessibility
- Local API, removed BOM from all API responses
- The date pickers for the log file view/editor pages and the new This Period now display the date in the CMX locale format
- The Cumulus.ini file now only contains FTP ExtraFiles entries that have either a local or remote filename entered (potentially removes 800 lines from the file!)
