### PR TITLE
Build 3204 - Version 3.21.0

### DIFF
--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -1393,8 +1393,9 @@ namespace CumulusMX
 								var cnt = 0;
 								while (Program.cumulus.MySqlFailedList.TryDequeue(out var item))
 								{
-									cnt++;
+									cnt++;									
 								};
+								_ = Station.RecentDataDb.Execute("DELETE FROM SqlCache");
 								await writer.WriteAsync($"Failed queue cleared of {cnt} commands");
 								break;
 							default:

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -198,6 +198,9 @@ namespace CumulusMX
 							case "datalogs":
 								await writer.WriteAsync(dataEditor.EditDatalog(HttpContext));
 								break;
+							case "mysqlcache":
+								await writer.WriteAsync(dataEditor.EditMySqlCache(HttpContext));
+								break;
 							default:
 								Response.StatusCode = 404;
 								break;
@@ -263,6 +266,9 @@ namespace CumulusMX
 							case "diarysummary":
 								//return await this.JsonResponseAsync(Station.GetDiarySummary(year, month));
 								await writer.WriteAsync(Station.GetDiarySummary());
+								break;
+							case "mysqlcache.json":
+								await writer.WriteAsync(Station.GetCachedSqlCommands(draw, start, length, search));
 								break;
 							default:
 								Response.StatusCode = 404;
@@ -1396,7 +1402,16 @@ namespace CumulusMX
 									cnt++;									
 								};
 								_ = Station.RecentDataDb.Execute("DELETE FROM SqlCache");
-								await writer.WriteAsync($"Failed queue cleared of {cnt} commands");
+								string msg;
+								if (cnt == 0)
+								{
+									msg = "The MySQL cache is already empty!";
+								}
+								else
+								{
+									msg = $"Cached MySQL queue cleared of {cnt} commands";
+								}
+								await writer.WriteAsync(msg);
 								break;
 							default:
 								Response.StatusCode = 404;

--- a/CumulusMX/App.config
+++ b/CumulusMX/App.config
@@ -30,6 +30,10 @@
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MimeKit" publicKeyToken="bede1c8a46c66814" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -8825,9 +8825,6 @@ namespace CumulusMX
 					return true;
 				}
 
-
-				LogFtpDebugMessage($"FTP[{cycleStr}]: Uploading {localfile} to {remotefiletmp}");
-
 				if (FTPRename)
 				{
 					// delete the existing tmp file

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -8161,7 +8161,7 @@ namespace CumulusMX
 
 		public void DoLocalCopy()
 		{
-			var remotePath = "";
+			var remotePath = FtpOptions.LocalCopyFolder;
 
 			try
 			{
@@ -8172,7 +8172,7 @@ namespace CumulusMX
 
 				if (FtpOptions.LocalCopyFolder.Length > 0)
 				{
-					remotePath = (FtpOptions.LocalCopyFolder[-1] == DirectorySeparator || FtpOptions.LocalCopyFolder[-1] == folderSep2) ? FtpOptions.LocalCopyFolder : FtpOptions.LocalCopyFolder + DirectorySeparator;
+					remotePath = (FtpOptions.LocalCopyFolder.EndsWith(DirectorySeparator.ToString()) || FtpOptions.LocalCopyFolder.EndsWith(folderSep2.ToString())) ? FtpOptions.LocalCopyFolder : FtpOptions.LocalCopyFolder + DirectorySeparator;
 				}
 				else
 				{

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -8827,6 +8827,22 @@ namespace CumulusMX
 
 				LogFtpDebugMessage($"FTP[{cycleStr}]: Uploading {localfile} to {remotefiletmp}");
 
+				if (FTPRename || DeleteBeforeUpload)
+				{
+					// delete the existing tmp file
+					try
+					{
+						if (conn.FileExists(remotefiletmp))
+						{
+							conn.DeleteFile(remotefiletmp);
+						}
+					}
+					catch
+					{
+						// continue on error
+					}
+				}
+				
 				var status = conn.UploadFile(localfile, remotefiletmp);
 
 				if (status.IsFailure())
@@ -8857,7 +8873,7 @@ namespace CumulusMX
 							{
 								LogFtpMessage($"FTP[{cycleStr}]: Inner Exception: {ex.GetBaseException().Message}");
 							}
-							return conn.IsConnected;
+							// continue on error
 						}
 					}
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -9685,18 +9685,21 @@ namespace CumulusMX
 						LogMessage($"{callingFunction}: Connection to MySQL server has failed, adding this update to the failed list");
 						if (callingFunction.StartsWith("Realtime["))
 						{
-							_ = station.RecentDataDb.Insert(new SqlCache() { statement = cmds[0] });
+							var tmp = new SqlCache() { statement = cmds[0] };
+							_ = station.RecentDataDb.Insert(tmp);
 
 							// don't bother buffering the realtime deletes - if present
-							MySqlFailedList.Enqueue(new SqlCache() { statement = cmds[0] });
+							MySqlFailedList.Enqueue(tmp);
 						}
 						else
 						{
 							for (var i = 0; i < cmds.Count; i++)
 							{
-								_ = station.RecentDataDb.Insert(new SqlCache() { statement = cmds[i] });
+								var tmp = new SqlCache() { statement = cmds[i] };
 
-								MySqlFailedList.Enqueue(new SqlCache() { statement = cmds[i] });
+								_ = station.RecentDataDb.Insert(tmp);
+
+								MySqlFailedList.Enqueue(tmp);
 							}
 						}
 					}

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -94,8 +94,8 @@
     <Reference Include="BouncyCastle.Crypto, Version=1.9.0.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
       <HintPath>..\packages\Portable.BouncyCastle.1.9.0\lib\net40\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
-    <Reference Include="EmbedIO, Version=3.4.3.0, Culture=neutral, PublicKeyToken=5e5f048b6e04267e, processorArchitecture=MSIL">
-      <HintPath>..\packages\EmbedIO.3.4.3\lib\netstandard2.0\EmbedIO.dll</HintPath>
+    <Reference Include="EmbedIO, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\EmbedIO.3.5.0\lib\netstandard2.0\EmbedIO.dll</HintPath>
     </Reference>
     <Reference Include="FluentFTP, Version=37.0.3.0, Culture=neutral, PublicKeyToken=f4af092b1d8df44f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -107,23 +107,23 @@
     <Reference Include="MailKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
       <HintPath>..\packages\MailKit.3.3.0\lib\net48\MailKit.dll</HintPath>
     </Reference>
-    <Reference Include="MimeKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
-      <HintPath>..\packages\MimeKit.3.3.0\lib\net48\MimeKit.dll</HintPath>
+    <Reference Include="MimeKit, Version=3.4.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
+      <HintPath>..\packages\MimeKit.3.4.0\lib\net48\MimeKit.dll</HintPath>
     </Reference>
-    <Reference Include="MQTTnet, Version=4.0.2.221, Culture=neutral, PublicKeyToken=fdb7629f2e364a63, processorArchitecture=MSIL">
-      <HintPath>..\packages\MQTTnet.4.0.2.221\lib\net461\MQTTnet.dll</HintPath>
+    <Reference Include="MQTTnet, Version=4.1.0.247, Culture=neutral, PublicKeyToken=fdb7629f2e364a63, processorArchitecture=MSIL">
+      <HintPath>..\packages\MQTTnet.4.1.0.247\lib\net461\MQTTnet.dll</HintPath>
     </Reference>
     <Reference Include="MySqlConnector, Version=2.0.0.0, Culture=neutral, PublicKeyToken=d33d3e53aa5f8c92, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySqlConnector.2.1.11\lib\net471\MySqlConnector.dll</HintPath>
+      <HintPath>..\packages\MySqlConnector.2.1.13\lib\net471\MySqlConnector.dll</HintPath>
     </Reference>
     <Reference Include="Renci.SshNet, Version=2020.0.2.0, Culture=neutral, PublicKeyToken=1cee9f8bde3db106, processorArchitecture=MSIL">
       <HintPath>..\packages\SSH.NET.2020.0.2\lib\net40\Renci.SshNet.dll</HintPath>
     </Reference>
     <Reference Include="ServiceStack.Text, Version=6.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.6.2.0\lib\net472\ServiceStack.Text.dll</HintPath>
+      <HintPath>..\packages\ServiceStack.Text.6.3.0\lib\net472\ServiceStack.Text.dll</HintPath>
     </Reference>
-    <Reference Include="Swan.Lite, Version=3.0.0.0, Culture=neutral, PublicKeyToken=30c707c872729fff, processorArchitecture=MSIL">
-      <HintPath>..\packages\Unosquare.Swan.Lite.3.0.0\lib\net461\Swan.Lite.dll</HintPath>
+    <Reference Include="Swan.Lite, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Unosquare.Swan.Lite.3.1.0\lib\net461\Swan.Lite.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/CumulusMX/MysqlSettings.cs
+++ b/CumulusMX/MysqlSettings.cs
@@ -333,7 +333,6 @@ namespace CumulusMX
 		private string UpdateMySQLTable(MySqlTable table)
 		{
 			string res;
-			int colsNow;
 			int cnt = 0;
 
 			try
@@ -381,7 +380,7 @@ namespace CumulusMX
 					}
 					else
 					{
-						res = $"The {table.Name} table already has all the required columns = {table.Columns.Count}";
+						res = $"The {table.Name} table already has all the required columns. Required = {table.Columns.Count}, actual = {currCols.Count}";
 						cumulus.LogMessage("MySQL Update Table: " + res);
 					}
 				}

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.20.1 - Build 3203")]
+[assembly: AssemblyDescription("Version 3.21.0 - Build 3204")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.20.1.3203")]
-[assembly: AssemblyFileVersion("3.20.1.3203")]
+[assembly: AssemblyVersion("3.21.0.3204")]
+[assembly: AssemblyFileVersion("3.21.0.3204")]

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -408,8 +408,17 @@ namespace CumulusMX
 			//RecentDataDb = new SQLiteConnection(":memory:", true);
 			RecentDataDb = new SQLiteConnection(cumulus.dbfile, false);
 			RecentDataDb.CreateTable<RecentData>();
+			RecentDataDb.CreateTable<SqlCache>();
 			// switch off full synchronisation - the data base isn't that critical and we get a performance boost
 			RecentDataDb.Execute("PRAGMA synchronous = NORMAL");
+
+			// preload the failed sql cache - if any
+			var data = RecentDataDb.Query<SqlCache>("SELECT * FROM SqlCache ORDER BY key");
+
+			foreach (var rec in data)
+			{
+				cumulus.MySqlFailedList.Enqueue(rec);
+			}
 
 			var rnd = new Random();
 			versionCheckTime = new DateTime(1, 1, 1, rnd.Next(0, 23), rnd.Next(0, 59), 0);
@@ -12541,7 +12550,12 @@ namespace CumulusMX
 		public double avgPress { get; set; }
 	}
 
-
+	public class SqlCache
+	{
+		[AutoIncrement, PrimaryKey]
+		public int? key { get; set; }
+		public string statement { get; set; }
+	}
 
 	/*
 	public class StandardData

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -19,6 +19,7 @@ using Timer = System.Timers.Timer;
 using ServiceStack.Text;
 using System.Web;
 using System.Threading.Tasks;
+using static System.Collections.Specialized.BitVector32;
 
 namespace CumulusMX
 {
@@ -413,15 +414,26 @@ namespace CumulusMX
 			RecentDataDb.Execute("PRAGMA synchronous = NORMAL");
 
 			// preload the failed sql cache - if any
+			ReloadFailedMySQLCommands();
+
+			var rnd = new Random();
+			versionCheckTime = new DateTime(1, 1, 1, rnd.Next(0, 23), rnd.Next(0, 59), 0);
+		}
+
+		public void ReloadFailedMySQLCommands()
+		{
+			while (cumulus.MySqlFailedList.TryDequeue(out var tmp))
+			{
+				// do nothing
+			};
+
+			// preload the failed sql cache - if any
 			var data = RecentDataDb.Query<SqlCache>("SELECT * FROM SqlCache ORDER BY key");
 
 			foreach (var rec in data)
 			{
 				cumulus.MySqlFailedList.Enqueue(rec);
 			}
-
-			var rnd = new Random();
-			versionCheckTime = new DateTime(1, 1, 1, rnd.Next(0, 23), rnd.Next(0, 59), 0);
 		}
 
 		private void GetRainCounter()
@@ -10611,7 +10623,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogMessage(ex.ToString());
+				cumulus.LogMessage("GetDayFile: Error - " + ex.ToString());
 			}
 
 			return "";
@@ -10829,6 +10841,75 @@ namespace CumulusMX
 			}
 
 			return "";
+		}
+
+
+		public string GetCachedSqlCommands(string draw, int start, int length, string search)
+		{
+			try
+			{
+				var filtered = 0;
+				var thisDraw = 0;
+
+				var json = new StringBuilder(350 * cumulus.MySqlFailedList.Count);
+
+				json.Append("{\"data\":[");
+
+				//var lines = File.ReadLines(cumulus.DayFile).Skip(start).Take(length);
+
+				foreach (var rec in cumulus.MySqlFailedList)
+				{
+					// if we have a search string and no match, skip to next line
+					if (!string.IsNullOrEmpty(search) && !rec.statement.Contains(search))
+					{
+						continue;
+					}
+
+					// this line either matches the search
+					filtered++;
+
+					// skip records until we get to the start entry
+					if (filtered <= start)
+					{
+						continue;
+					}
+
+					// only send the number requested
+					if (thisDraw < length)
+					{
+						// track the number of lines we have to return so far
+						thisDraw++;
+
+						json.Append($"[{rec.key},\"{rec.statement}\"],");
+					}
+					else if (string.IsNullOrEmpty(search))
+					{
+						// no search so we can bail out as we already know the total number of records
+						break;
+					}
+				}
+
+				// trim last ","
+				if (thisDraw > 0)
+					json.Length--;
+				json.Append("],\"recordsTotal\":");
+				json.Append(cumulus.MySqlFailedList.Count);
+				json.Append(",\"draw\":");
+				json.Append(draw);
+				json.Append(",\"recordsFiltered\":");
+				json.Append(string.IsNullOrEmpty(search) ? cumulus.MySqlFailedList.Count : filtered);
+				json.Append('}');
+
+				return json.ToString();
+
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogMessage(ex.ToString());
+			}
+
+			return "";
+
 		}
 
 		public string GetUnits()

--- a/CumulusMX/packages.config
+++ b/CumulusMX/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="EmbedIO" version="3.4.3" targetFramework="net48" />
+  <package id="EmbedIO" version="3.5.0" targetFramework="net48" />
   <package id="HidSharp" version="2.1.0" targetFramework="net452" />
   <package id="MailKit" version="3.3.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net452" />
-  <package id="MimeKit" version="3.3.0" targetFramework="net48" />
-  <package id="MQTTnet" version="4.0.2.221" targetFramework="net48" />
-  <package id="MySqlConnector" version="2.1.11" targetFramework="net48" />
+  <package id="MimeKit" version="3.4.0" targetFramework="net48" />
+  <package id="MQTTnet" version="4.1.0.247" targetFramework="net48" />
+  <package id="MySqlConnector" version="2.1.13" targetFramework="net48" />
   <package id="Portable.BouncyCastle" version="1.9.0" targetFramework="net48" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="6.2.0" targetFramework="net48" />
+  <package id="ServiceStack.Text" version="6.3.0" targetFramework="net48" />
   <package id="SSH.NET" version="2020.0.2" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="6.0.0" targetFramework="net48" />
@@ -23,5 +23,5 @@
   <package id="System.Text.Encoding.CodePages" version="6.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
-  <package id="Unosquare.Swan.Lite" version="3.0.0" targetFramework="net48" />
+  <package id="Unosquare.Swan.Lite" version="3.1.0" targetFramework="net48" />
 </packages>

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,13 @@
+3.21.0 - b3204
+——————————————
+Fixed
+- FTP delete before upload logic changed.
+	- Previously, the existing file was deleted, then the new file uploaded. The process errored if the delete failed due to file not existing
+	- Now, the new file is uploaded to a tmp file, the original file is deleted (if it exists), then the tmp file is renamed to the final filename
+	- This has the advantage of minimising the time the remote file is unavailable
+
+
+
 3.20.1 - b3203
 ——————————————
 Fixed

--- a/Updates.txt
+++ b/Updates.txt
@@ -5,7 +5,7 @@ Fixed
 	- Previously, the existing file was deleted, then the new file uploaded. The process errored if the delete failed due to file not existing
 	- Now, the new file is uploaded to a tmp file, the original file is deleted (if it exists), then the tmp file is renamed to the final filename
 	- This has the advantage of minimising the time the remote file is unavailable
-
+- Local file copy giving "index out of bounds" error
 
 Changed
 - Failed MySQL commands are now stored in the SQLite database to persist across Cumulus runs

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,8 +7,12 @@ Fixed
 	- This has the advantage of minimising the time the remote file is unavailable
 - Local file copy giving "index out of bounds" error
 
+New
+- Failed MySQL commands are now can now be individually edited/deleted
+
 Changed
 - Failed MySQL commands are now stored in the SQLite database to persist across Cumulus runs
+- Third party components updated
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,6 +7,10 @@ Fixed
 	- This has the advantage of minimising the time the remote file is unavailable
 
 
+Changed
+- Failed MySQL commands are now stored in the SQLite database to persist across Cumulus runs
+
+
 
 3.20.1 - b3203
 ——————————————

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,10 +1,7 @@
 3.21.0 - b3204
 ——————————————
 Fixed
-- FTP delete before upload logic changed.
-	- Previously, the existing file was deleted, then the new file uploaded. The process errored if the delete failed due to file not existing
-	- Now, the new file is uploaded to a tmp file, the original file is deleted (if it exists), then the tmp file is renamed to the final filename
-	- This has the advantage of minimising the time the remote file is unavailable
+- FTP delete before upload aborting if the initial delete fails due to file not existing
 - Local file copy giving "index out of bounds" error
 
 New


### PR DESCRIPTION
Fixed
- FTP delete before upload aborting if the initial delete fails due to file not existing
- Local file copy giving "index out of bounds" error

New
- Failed MySQL commands are now can now be individually edited/deleted

Changed
- Failed MySQL commands are now stored in the SQLite database to persist across Cumulus runs
- Third party components updated
