### PR TITLE
v3.22.0 Updates

### DIFF
--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -23,6 +23,7 @@ namespace CumulusMX
 		public static CalibrationSettings calibrationSettings;
 		public static NOAASettings noaaSettings;
 		public static MysqlSettings mySqlSettings;
+		public static CustomLogs customLogs;
 		public static Wizard wizard;
 		internal static AlarmSettings alarmSettings;
 		internal static DataEditor dataEditor;
@@ -1068,6 +1069,12 @@ namespace CumulusMX
 								Response.ContentType = "text/plain";
 								await writer.WriteAsync(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
 								break;
+							case "customlogsintvl.json":
+								await writer.WriteAsync(customLogs.GetAlpacaFormDataIntvl());
+								break;
+							case "customlogsdaily.json":
+								await writer.WriteAsync(customLogs.GetAlpacaFormDataDaily());
+								break;
 							default:
 								Response.StatusCode = 404;
 								break;
@@ -1145,6 +1152,12 @@ namespace CumulusMX
 								break;
 							case "wizard.json":
 								await writer.WriteAsync(wizard.UpdateConfig(HttpContext));
+								break;
+							case "updatecustomlogsintvl.json":
+								await writer.WriteAsync(customLogs.UpdateConfigIntvl(HttpContext));
+								break;
+							case "updatecustomlogsdaily.json":
+								await writer.WriteAsync(customLogs.UpdateConfigDaily(HttpContext));
 								break;
 							default:
 								Response.StatusCode = 404;

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -7581,7 +7581,7 @@ namespace CumulusMX
 		{
 			for (var i = 0; i < 10; i++)
 			{
-				if (CustomIntvlLogSettings[i].Enabled)
+				if (CustomIntvlLogSettings[i].Enabled && timestamp.Minute % CustomIntvlLogSettings[i].Interval == 0)
 				{
 					DoCustomIntervalLog(i, timestamp);
 				}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -5300,7 +5300,7 @@ namespace CumulusMX
 					CustomDailyLogSettings[i].FileName = ini.GetValue("CustomLogs", "DailyFilename" + i, "");
 
 				if (ini.ValueExists("CustomLogs", "DailyContent" + i))
-					CustomDailyLogSettings[i].ContentString = ini.GetValue("CustomLogs", "DailyContent" + i, "");
+					CustomDailyLogSettings[i].ContentString = ini.GetValue("CustomLogs", "DailyContent" + i, "").Replace("\n", "").Replace("\r", "");
 
 				if (string.IsNullOrEmpty(CustomDailyLogSettings[i].FileName) || string.IsNullOrEmpty(CustomDailyLogSettings[i].ContentString))
 					CustomDailyLogSettings[i].Enabled = false;
@@ -5313,7 +5313,7 @@ namespace CumulusMX
 					CustomIntvlLogSettings[i].FileName = ini.GetValue("CustomLogs", "IntervalFilename" + i, "");
 
 				if (ini.ValueExists("CustomLogs", "IntervalContent" + i))
-					CustomIntvlLogSettings[i].ContentString = ini.GetValue("CustomLogs", "IntervalContent" + i, "");
+					CustomIntvlLogSettings[i].ContentString = ini.GetValue("CustomLogs", "IntervalContent" + i, "").Replace("\n", "").Replace("\r", "");
 
 				if (string.IsNullOrEmpty(CustomIntvlLogSettings[i].FileName) || string.IsNullOrEmpty(CustomIntvlLogSettings[i].ContentString))
 					CustomIntvlLogSettings[i].Enabled = false;
@@ -11680,5 +11680,4 @@ namespace CumulusMX
 			RainNorms = new double[13];
 		}
 	}
-
 }

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -104,11 +104,11 @@
     <Reference Include="HidSharp, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\HidSharp.2.1.0\lib\net35\HidSharp.dll</HintPath>
     </Reference>
-    <Reference Include="MailKit, Version=3.3.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
-      <HintPath>..\packages\MailKit.3.3.0\lib\net48\MailKit.dll</HintPath>
+    <Reference Include="MailKit, Version=3.4.0.0, Culture=neutral, PublicKeyToken=4e064fe7c44a8f1b, processorArchitecture=MSIL">
+      <HintPath>..\packages\MailKit.3.4.1\lib\net48\MailKit.dll</HintPath>
     </Reference>
     <Reference Include="MimeKit, Version=3.4.0.0, Culture=neutral, PublicKeyToken=bede1c8a46c66814, processorArchitecture=MSIL">
-      <HintPath>..\packages\MimeKit.3.4.0\lib\net48\MimeKit.dll</HintPath>
+      <HintPath>..\packages\MimeKit.3.4.1\lib\net48\MimeKit.dll</HintPath>
     </Reference>
     <Reference Include="MQTTnet, Version=4.1.0.247, Culture=neutral, PublicKeyToken=fdb7629f2e364a63, processorArchitecture=MSIL">
       <HintPath>..\packages\MQTTnet.4.1.0.247\lib\net461\MQTTnet.dll</HintPath>
@@ -197,6 +197,7 @@
     <Compile Include="CalibrationsLimits.cs" />
     <Compile Include="CalibrationSettings.cs" />
     <Compile Include="Cumulus.cs" />
+    <Compile Include="CustomLogs.cs" />
     <Compile Include="DataEditor.cs" />
     <Compile Include="DataStruct.cs" />
     <Compile Include="DavisAirLink.cs" />

--- a/CumulusMX/CustomLogs.cs
+++ b/CumulusMX/CustomLogs.cs
@@ -1,0 +1,233 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using EmbedIO;
+using ServiceStack;
+
+namespace CumulusMX
+{
+	public class CustomLogs
+	{
+		private readonly Cumulus cumulus;
+
+		public CustomLogs(Cumulus cumulus)
+		{
+			this.cumulus = cumulus;
+		}
+
+		public string GetAlpacaFormDataIntvl()
+		{
+			var interval = new List<CustomLogsIntervalSettings>();
+
+			for (var i = 0; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomIntvlLogSettings[i].FileName) || !string.IsNullOrEmpty(cumulus.CustomIntvlLogSettings[i].ContentString))
+				{
+					interval.Add(new CustomLogsIntervalSettings()
+					{
+						enabled = cumulus.CustomIntvlLogSettings[i].Enabled,
+						filename = cumulus.CustomIntvlLogSettings[i].FileName,
+						content = cumulus.CustomIntvlLogSettings[i].ContentString,
+						intervalidx = cumulus.CustomIntvlLogSettings[i].IntervalIdx
+					});
+				}
+			}
+
+
+
+			var settings = new CustomLogsSettings()
+			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
+				interval = interval
+			};
+
+			return settings.ToJson();
+		}
+
+		public string GetAlpacaFormDataDaily()
+		{
+			var daily = new List<CustomLogsDailySettings>();
+
+			for (var i = 0; i < 10; i++)
+			{
+				if (!string.IsNullOrEmpty(cumulus.CustomDailyLogSettings[i].FileName) || !string.IsNullOrEmpty(cumulus.CustomDailyLogSettings[i].ContentString))
+				{
+					daily.Add(new CustomLogsDailySettings()
+					{
+						enabled = cumulus.CustomDailyLogSettings[i].Enabled,
+						filename = cumulus.CustomDailyLogSettings[i].FileName,
+						content = cumulus.CustomDailyLogSettings[i].ContentString
+					});
+				}
+			}
+
+			var settings = new CustomLogsSettings()
+			{
+				accessible = cumulus.ProgramOptions.EnableAccessibility,
+				daily = daily
+			};
+
+			return settings.ToJson();
+		}
+
+		public string UpdateConfigIntvl(IHttpContext context)
+		{
+			string json = "";
+			CustomLogsSettings settings;
+			try
+			{
+				var data = new StreamReader(context.Request.InputStream).ReadToEnd();
+
+				// Start at char 5 to skip the "json:" prefix
+				json = WebUtility.UrlDecode(data.Substring(5));
+
+				// de-serialize it to the settings structure
+				settings = json.FromJson<CustomLogsSettings>();
+			}
+			catch (Exception ex)
+			{
+				var msg = "Error de-serializing Custom Interval Log Settings JSON: " + ex.Message;
+				cumulus.LogMessage(msg);
+				cumulus.LogDebugMessage("Custom Interval Log Data: " + json);
+				context.Response.StatusCode = 500;
+				return msg;
+			}
+
+			// process the settings
+			try
+			{
+				cumulus.LogMessage("Updating custom interval log settings");
+
+				for (var i = 0; i < 10; i++)
+				{
+					if (i < settings.interval.Count)
+					{	
+						cumulus.CustomIntvlLogSettings[i].FileName = settings.interval[i].filename ?? null;
+						cumulus.CustomIntvlLogSettings[i].ContentString = settings.interval[i].content ?? null;
+						cumulus.CustomIntvlLogSettings[i].IntervalIdx = settings.interval[i].intervalidx;
+						cumulus.CustomIntvlLogSettings[i].Interval = cumulus.FactorsOf60[settings.interval[i].intervalidx];
+
+						if (string.IsNullOrEmpty(cumulus.CustomIntvlLogSettings[i].FileName) || string.IsNullOrEmpty(cumulus.CustomIntvlLogSettings[i].ContentString))
+							cumulus.CustomIntvlLogSettings[i].Enabled = false;
+						else
+							cumulus.CustomIntvlLogSettings[i].Enabled = settings.interval[i].enabled;
+					}
+					else
+					{
+						cumulus.CustomIntvlLogSettings[i].Enabled = false;
+						cumulus.CustomIntvlLogSettings[i].FileName = null;
+						cumulus.CustomIntvlLogSettings[i].ContentString = null;
+						cumulus.CustomIntvlLogSettings[i].IntervalIdx = cumulus.DataLogInterval;
+					}
+				}
+
+				// Save the settings
+				cumulus.WriteIniFile();
+
+				context.Response.StatusCode = 200;
+			}
+			catch (Exception ex)
+			{
+				var msg = "Error processing settings: " + ex.Message;
+				cumulus.LogMessage(msg);
+				context.Response.StatusCode = 500;
+				return msg;
+			}
+			return "success";
+		}
+
+		public string UpdateConfigDaily(IHttpContext context)
+		{
+			string json = "";
+			CustomLogsSettings settings;
+			try
+			{
+				var data = new StreamReader(context.Request.InputStream).ReadToEnd();
+
+				// Start at char 5 to skip the "json:" prefix
+				json = WebUtility.UrlDecode(data.Substring(5));
+
+				// de-serialize it to the settings structure
+				settings = json.FromJson<CustomLogsSettings>();
+			}
+			catch (Exception ex)
+			{
+				var msg = "Error de-serializing Custom Daily Log Settings JSON: " + ex.Message;
+				cumulus.LogMessage(msg);
+				cumulus.LogDebugMessage("Custom Daily Log Data: " + json);
+				context.Response.StatusCode = 500;
+				return msg;
+			}
+
+			// process the settings
+			try
+			{
+				cumulus.LogMessage("Updating custom daily log settings");
+
+				for (var i = 0; i < 10; i++)
+				{
+					if (i < settings.daily.Count)
+					{
+						cumulus.CustomDailyLogSettings[i].Enabled = settings.daily[i].enabled;
+						cumulus.CustomDailyLogSettings[i].FileName = settings.daily[i].filename ?? null;
+						cumulus.CustomDailyLogSettings[i].ContentString = settings.daily[i].content ?? null;
+
+						if (string.IsNullOrEmpty(cumulus.CustomDailyLogSettings[i].FileName) || string.IsNullOrEmpty(cumulus.CustomDailyLogSettings[i].ContentString))
+							cumulus.CustomDailyLogSettings[i].Enabled = false;
+						else
+							cumulus.CustomDailyLogSettings[i].Enabled = settings.daily[i].enabled;
+					}
+					else
+					{
+						cumulus.CustomDailyLogSettings[i].Enabled = false;
+						cumulus.CustomDailyLogSettings[i].FileName = null;
+						cumulus.CustomDailyLogSettings[i].ContentString = null;
+					}
+				}
+
+				// Save the settings
+				cumulus.WriteIniFile();
+
+				context.Response.StatusCode = 200;
+			}
+			catch (Exception ex)
+			{
+				var msg = "Error processing settings: " + ex.Message;
+				cumulus.LogMessage(msg);
+				context.Response.StatusCode = 500;
+				return msg;
+			}
+			return "success";
+		}
+
+	}
+
+	public class CustomLogsSettings
+	{
+		public bool accessible { get; set; }
+		public List<CustomLogsDailySettings> daily { get; set; }
+		public List<CustomLogsIntervalSettings> interval { get; set; }
+	}
+
+
+	public class CustomLogsDailySettings
+	{
+		public bool enabled { get; set; }
+		public string filename { get; set; }
+		public string content { get; set; }
+	}
+
+
+
+	public class CustomLogsIntervalSettings
+	{
+		public bool enabled { get; set; }
+		public string filename { get; set; }
+		public string content { get; set; }
+		public int intervalidx { get; set; }
+	}
+}

--- a/CumulusMX/CustomLogs.cs
+++ b/CumulusMX/CustomLogs.cs
@@ -107,7 +107,7 @@ namespace CumulusMX
 					if (i < settings.interval.Count)
 					{	
 						cumulus.CustomIntvlLogSettings[i].FileName = settings.interval[i].filename ?? null;
-						cumulus.CustomIntvlLogSettings[i].ContentString = settings.interval[i].content ?? null;
+						cumulus.CustomIntvlLogSettings[i].ContentString = settings.interval[i].content.Replace("\n", "").Replace("\r", "") ?? null;
 						cumulus.CustomIntvlLogSettings[i].IntervalIdx = settings.interval[i].intervalidx;
 						cumulus.CustomIntvlLogSettings[i].Interval = cumulus.FactorsOf60[settings.interval[i].intervalidx];
 
@@ -175,7 +175,7 @@ namespace CumulusMX
 					{
 						cumulus.CustomDailyLogSettings[i].Enabled = settings.daily[i].enabled;
 						cumulus.CustomDailyLogSettings[i].FileName = settings.daily[i].filename ?? null;
-						cumulus.CustomDailyLogSettings[i].ContentString = settings.daily[i].content ?? null;
+						cumulus.CustomDailyLogSettings[i].ContentString = settings.daily[i].content.Replace("\n", "").Replace("\r", "") ?? null;
 
 						if (string.IsNullOrEmpty(cumulus.CustomDailyLogSettings[i].FileName) || string.IsNullOrEmpty(cumulus.CustomDailyLogSettings[i].ContentString))
 							cumulus.CustomDailyLogSettings[i].Enabled = false;

--- a/CumulusMX/CustomLogs.cs
+++ b/CumulusMX/CustomLogs.cs
@@ -122,6 +122,7 @@ namespace CumulusMX
 						cumulus.CustomIntvlLogSettings[i].FileName = null;
 						cumulus.CustomIntvlLogSettings[i].ContentString = null;
 						cumulus.CustomIntvlLogSettings[i].IntervalIdx = cumulus.DataLogInterval;
+						cumulus.CustomIntvlLogSettings[i].Interval = cumulus.FactorsOf60[cumulus.DataLogInterval];
 					}
 				}
 

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -2670,6 +2670,7 @@ namespace CumulusMX
 							cumulus.DoLogFile(timestamp, false);
 							cumulus.LogMessage("GetArchiveData: Log file entry written");
 							cumulus.MySqlRealtimeFile(999, false, timestamp);
+							cumulus.DoCustomIntervalLogs(timestamp);
 
 							if (cumulus.StationOptions.LogExtraSensors)
 							{

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -1835,6 +1835,7 @@ namespace CumulusMX
 					cumulus.DoLogFile(timestamp, false);
 					cumulus.LogMessage("GetWlHistoricData: Log file entry written");
 					cumulus.MySqlRealtimeFile(999, false, timestamp);
+					cumulus.DoCustomIntervalLogs(timestamp);
 
 					if (cumulus.StationOptions.LogExtraSensors)
 					{

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reactive;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
@@ -1224,6 +1225,8 @@ namespace CumulusMX
 				//UpdateDatabase(timestamp.ToUniversalTime(), historydata.interval, false);
 
 				cumulus.DoLogFile(rec.Key, false);
+				cumulus.DoCustomIntervalLogs(rec.Key);
+
 				if (cumulus.StationOptions.LogExtraSensors) cumulus.DoExtraLogFile(rec.Key);
 
 				//AddRecentDataEntry(timestamp, WindAverage, RecentMaxGust, WindLatest, Bearing, AvgBearing,

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -586,6 +586,8 @@ namespace CumulusMX
 				bw.ReportProgress((totalentries - datalist.Count)*100/totalentries, "processing");
 
 				cumulus.DoLogFile(timestamp,false);
+				cumulus.DoCustomIntervalLogs(timestamp);
+
 				if (cumulus.StationOptions.LogExtraSensors)
 				{
 					cumulus.DoExtraLogFile(timestamp);

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Globalization;
 using System.Threading.Tasks;
+using ServiceStack.Text;
 
 namespace CumulusMX
 {
@@ -167,6 +168,12 @@ namespace CumulusMX
 								if ((minute % 20) == 0)
 								{
 									GetSensorIdsNew();
+								}
+
+								// every day dump the clock drift at midday each day
+								if (minute == 0 && DateTime.Now.Hour == 12)
+								{
+									GetSystemInfo(true);
 								}
 							}
 						}
@@ -513,7 +520,7 @@ namespace CumulusMX
 					}
 				}
 
-				GetSystemInfo();
+				GetSystemInfo(false);
 
 				GetSensorIdsNew();
 			}
@@ -909,6 +916,7 @@ namespace CumulusMX
 								idx += 1;
 								break;
 							case 0x18: //Date and time
+								// does not appear to be implemented
 								idx += 7;
 								break;
 							case 0x19: //Day max wind(m/s)
@@ -1277,7 +1285,7 @@ namespace CumulusMX
 			}
 		}
 
-		private void GetSystemInfo()
+		private void GetSystemInfo(bool driftOnly)
 		{
 			cumulus.LogMessage("Reading Ecowitt system info");
 
@@ -1294,6 +1302,8 @@ namespace CumulusMX
 			// 10  - time zone index (?)
 			// 11  - DST 0-1 - false/true
 			// 12  - 0x?? - checksum
+
+			var now = DateTime.Now;
 
 			if (data == null)
 			{
@@ -1324,9 +1334,30 @@ namespace CumulusMX
 
 				var unix = GW1000Api.ConvertBigEndianUInt32(data, 6);
 				var date = Utils.FromUnixTime(unix);
-				var dst = data[11] != 0;
+				var autoDST = data[11] != 0;
 
-				cumulus.LogMessage($"GW1000 Info: frequency: {freq}, main sensor: {mainSensor}, date/time: {date:F}, Automatic DST adjustment: {dst}");
+				// Ecowitt do not understand Unix time and add the DST to it!
+				if (autoDST && TimeZoneInfo.Local.IsDaylightSavingTime(date))
+				{
+					unix -= 3600;
+					date = date.AddHours(-1);
+				}
+
+				var clockdiff = now.ToUnixTime() - unix;
+
+				string slowfast;
+
+				if (clockdiff == 0)
+					slowfast = "off";
+				else if (clockdiff > 0)
+					slowfast = "slow";
+				else
+					slowfast = "fast";
+
+				if (!driftOnly)
+					cumulus.LogMessage($"Gateway Info: frequency: {freq}, main sensor: {mainSensor}, date/time: {date:F}, Automatic DST adjustment: {autoDST}");
+
+				cumulus.LogMessage($"Gateway Info: Gateway clock is {Math.Abs(clockdiff)} secs {slowfast} compared to Cumulus");
 			}
 			catch (Exception ex)
 			{

--- a/CumulusMX/ImetStation.cs
+++ b/CumulusMX/ImetStation.cs
@@ -769,6 +769,7 @@ namespace CumulusMX
 
 							cumulus.DoLogFile(timestamp, false);
 							cumulus.MySqlRealtimeFile(999, false, timestamp);
+							cumulus.DoCustomIntervalLogs(timestamp);
 
 							AddRecentDataEntry(timestamp, WindAverage, RecentMaxGust, WindLatest, Bearing, AvgBearing, OutdoorTemperature, WindChill, OutdoorDewpoint, HeatIndex,
 								OutdoorHumidity, Pressure, RainToday, SolarRad, UV, Raincounter, FeelsLike, Humidex, ApparentTemperature, IndoorTemperature, IndoorHumidity, CurrentSolarMax, RainRate, -1, -1);

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.21.2 - Build 3206")]
+[assembly: AssemblyTitle("Cumulus MX - BETA")]
+[assembly: AssemblyDescription("Version 3.22.0 - Build 3207")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.21.2.3206")]
-[assembly: AssemblyFileVersion("3.21.2.3206")]
+[assembly: AssemblyVersion("3.22.0.3207")]
+[assembly: AssemblyFileVersion("3.22.0.3207")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX - BETA")]
-[assembly: AssemblyDescription("Version 3.22.0 - Build 3208")]
+[assembly: AssemblyDescription("Version 3.22.0 - Build 3209")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.22.0.3208")]
-[assembly: AssemblyFileVersion("3.22.0.3208")]
+[assembly: AssemblyVersion("3.22.0.3209")]
+[assembly: AssemblyFileVersion("3.22.0.3209")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX - BETA")]
-[assembly: AssemblyDescription("Version 3.22.0 - Build 3207")]
+[assembly: AssemblyDescription("Version 3.22.0 - Build 3208")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.22.0.3207")]
-[assembly: AssemblyFileVersion("3.22.0.3207")]
+[assembly: AssemblyVersion("3.22.0.3208")]
+[assembly: AssemblyFileVersion("3.22.0.3208")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Cumulus MX - BETA")]
-[assembly: AssemblyDescription("Version 3.22.0 - Build 3209")]
+[assembly: AssemblyTitle("Cumulus MX")]
+[assembly: AssemblyDescription("Version 3.22.0 - Build 3211")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.22.0.3209")]
-[assembly: AssemblyFileVersion("3.22.0.3209")]
+[assembly: AssemblyVersion("3.22.0.3211")]
+[assembly: AssemblyFileVersion("3.22.0.3211")]

--- a/CumulusMX/TempestStation.cs
+++ b/CumulusMX/TempestStation.cs
@@ -199,6 +199,8 @@ namespace CumulusMX
 				//UpdateDatabase(timestamp.ToUniversalTime(), historydata.interval, false);
 
 				cumulus.DoLogFile(timestamp, false);
+				cumulus.DoCustomIntervalLogs(timestamp);
+
 				if (cumulus.StationOptions.LogExtraSensors) cumulus.DoExtraLogFile(timestamp);
 
 				//AddRecentDataEntry(timestamp, WindAverage, RecentMaxGust, WindLatest, Bearing, AvgBearing,

--- a/CumulusMX/WMR200Station.cs
+++ b/CumulusMX/WMR200Station.cs
@@ -1603,6 +1603,7 @@ namespace CumulusMX
 
 			cumulus.DoLogFile(timestamp,false);
 			cumulus.MySqlRealtimeFile(999, false, timestamp);
+			cumulus.DoCustomIntervalLogs(timestamp);
 
 			if (cumulus.StationOptions.LogExtraSensors)
 			{

--- a/CumulusMX/WS2300Station.cs
+++ b/CumulusMX/WS2300Station.cs
@@ -384,6 +384,8 @@ namespace CumulusMX
 				//UpdateDatabase(timestamp.ToUniversalTime(), historydata.interval, false);
 
 				cumulus.DoLogFile(timestamp, false);
+				cumulus.DoCustomIntervalLogs(timestamp);
+
 				if (cumulus.StationOptions.LogExtraSensors)
 				{
 					cumulus.DoExtraLogFile(timestamp);

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1768,7 +1768,6 @@ namespace CumulusMX
 					if (now.Minute % cumulus.logints[cumulus.DataLogInterval] == 0)
 					{
 						cumulus.DoLogFile(now, true);
-						cumulus.DoCustomIntervalLogs(now);
 
 						if (cumulus.StationOptions.LogExtraSensors)
 						{

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -20,6 +20,8 @@ using ServiceStack.Text;
 using System.Web;
 using System.Threading.Tasks;
 using static System.Collections.Specialized.BitVector32;
+using ServiceStack;
+using System.Reactive;
 
 namespace CumulusMX
 {
@@ -1766,6 +1768,7 @@ namespace CumulusMX
 					if (now.Minute % cumulus.logints[cumulus.DataLogInterval] == 0)
 					{
 						cumulus.DoLogFile(now, true);
+						cumulus.DoCustomIntervalLogs(now);
 
 						if (cumulus.StationOptions.LogExtraSensors)
 						{
@@ -1789,6 +1792,9 @@ namespace CumulusMX
 					{
 						cumulus.CustomHttpMinutesUpdate();
 					}
+
+					// Custom Log files - interval logs
+					cumulus.DoCustomIntervalLogs(now);
 
 					if (cumulus.WebIntervalEnabled && cumulus.SynchronisedWebUpdate && (now.Minute % cumulus.UpdateInterval == 0))
 					{
@@ -4746,6 +4752,8 @@ namespace CumulusMX
 				{
 					cumulus.CustomHttpRolloverUpdate();
 				}
+
+				cumulus.DoCustomDailyLogs(timestamp);
 
 				// First save today"s extremes
 				DoDayfile(timestamp);

--- a/CumulusMX/packages.config
+++ b/CumulusMX/packages.config
@@ -2,9 +2,9 @@
 <packages>
   <package id="EmbedIO" version="3.5.0" targetFramework="net48" />
   <package id="HidSharp" version="2.1.0" targetFramework="net452" />
-  <package id="MailKit" version="3.3.0" targetFramework="net48" />
+  <package id="MailKit" version="3.4.1" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net452" />
-  <package id="MimeKit" version="3.4.0" targetFramework="net48" />
+  <package id="MimeKit" version="3.4.1" targetFramework="net48" />
   <package id="MQTTnet" version="4.1.0.247" targetFramework="net48" />
   <package id="MySqlConnector" version="2.1.13" targetFramework="net48" />
   <package id="Portable.BouncyCastle" version="1.9.0" targetFramework="net48" />

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Web;
+using FluentFTP.Helpers;
 using Swan;
 
 namespace CumulusMX
@@ -586,12 +587,12 @@ namespace CumulusMX
 
 		private static string TagTimeJavascript(Dictionary<string, string> tagParams)
 		{
-			return ((ulong)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds).ToString();
+			return (DateTime.Now.ToUnixEpochDate() * 1000).ToString();
 		}
 
 		private static string TagTimeUnix(Dictionary<string, string> tagParams)
 		{
-			return DateTime.UtcNow.ToUnixEpochDate().ToString();
+			return DateTime.Now.ToUnixEpochDate().ToString();
 		}
 
 		private string TagDate(Dictionary<string,string> tagParams)

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,11 +1,13 @@
-3.22.0 - b3208
+3.22.0 - b3209
 ——————————————
 New
 - Adds the ability to create custom data log files, both interval and daily
+- Ecowitt local API station now dumps the station clock drift to the log file at start-up and every day at noon
 
 Changed
 - MailKit and MimeKit updated to latest versions
-- The web tag <#timeJavaScript> now provides a value truncated to the current second
+- The web tag <#TimeJavaScript> now provides a value truncated to the current second
+
 
 
 3.21.2 - b3206

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,12 @@
+3.22.0 - b3207
+——————————————
+New
+- Adds the ability to create custom data log files, both interval and daily
+
+Changed
+- MailKit and MimeKit updated to latest versions
+
+
 3.21.2 - b3206
 ——————————————
 Fixed

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.22.0 - b3207
+3.22.0 - b3208
 ——————————————
 New
 - Adds the ability to create custom data log files, both interval and daily

--- a/Updates.txt
+++ b/Updates.txt
@@ -5,6 +5,7 @@ New
 
 Changed
 - MailKit and MimeKit updated to latest versions
+- The web tag <#timeJavaScript> now provides a value truncated to the current second
 
 
 3.21.2 - b3206

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.22.0 - b3209
+3.22.0 - b3210
 ——————————————
 New
 - Adds the ability to create custom data log files, both interval and daily

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.22.0 - b3210
+3.22.0 - b3211
 ——————————————
 New
 - Adds the ability to create custom data log files, both interval and daily


### PR DESCRIPTION
New
- Adds the ability to create custom data log files, both interval and daily
- Ecowitt local API station now dumps the station clock drift to the log file at start-up and every day at noon

Changed
- MailKit and MimeKit updated to latest versions
- The web tag <#TimeJavaScript> now provides a value truncated to the current second