### PR TITLE
b3215

### DIFF
--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -89,15 +89,7 @@ namespace CumulusMX
 							{
 								cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {ActionParams}");
 								// Prepare the process to run
-								ProcessStartInfo start = new ProcessStartInfo();
-								// Enter in the command line arguments
-								start.Arguments = ActionParams;
-								// Enter the executable to run, including the complete path
-								start.FileName = Action;
-								// Don"t show a console window
-								start.CreateNoWindow = true;
-								// Run the external process
-								Process.Start(start);
+								Utils.RunExternalTask(Action, ActionParams, false);
 							}
 							catch (Exception ex)
 							{
@@ -219,15 +211,7 @@ namespace CumulusMX
 						{
 							cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {ActionParams}");
 							// Prepare the process to run
-							ProcessStartInfo start = new ProcessStartInfo();
-							// Enter in the command line arguments
-							start.Arguments = ActionParams;
-							// Enter the executable to run, including the complete path
-							start.FileName = Action;
-							// Don"t show a console window
-							start.CreateNoWindow = true;
-							// Run the external process
-							Process.Start(start);
+							Utils.RunExternalTask(Action, ActionParams, false);
 						}
 						catch (Exception ex)
 						{
@@ -284,15 +268,7 @@ namespace CumulusMX
 						{
 							cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {ActionParams}");
 							// Prepare the process to run
-							ProcessStartInfo start = new ProcessStartInfo();
-							// Enter in the command line arguments
-							start.Arguments = ActionParams;
-							// Enter the executable to run, including the complete path
-							start.FileName = Action;
-							// Don"t show a console window
-							start.CreateNoWindow = true;
-							// Run the external process
-							Process.Start(start);
+							Utils.RunExternalTask(Action, ActionParams, false);
 						}
 						catch (Exception ex)
 						{

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -284,6 +284,9 @@
     <Content Include="sqlite3.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Updates.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -31,6 +31,7 @@ namespace CumulusMX
 		private const int TcpWaitTimeMs = 2500;
 		private int maxArchiveRuns = 2;
 		private bool stop;
+		private int loggerInterval;
 
 		private readonly Stopwatch awakeStopWatch = new Stopwatch();
 
@@ -329,6 +330,9 @@ namespace CumulusMX
 			var bytesRead = 0;
 			byte[] readBuffer = new byte[40];
 
+			// default the logger interval to the CMX interval - change it later if we find different
+			loggerInterval = cumulus.logints[cumulus.DataLogInterval];
+
 			// response should be (5 mins):
 			// ACK  VAL CKS1 CKS2
 			// 0x06-05-50-3F
@@ -421,7 +425,9 @@ namespace CumulusMX
 
 			if (bytesRead > 0 && readBuffer[0] != cumulus.logints[cumulus.DataLogInterval])
 			{
-				var msg = $"** WARNING: Your station logger interval {readBuffer[0]} mins does not match your Cumulus MX logging interval {cumulus.logints[cumulus.DataLogInterval]} mins";
+				// change the logger interval to the value we just discovered
+				loggerInterval = readBuffer[0];
+				var msg = $"** WARNING: Your station logger interval {loggerInterval} mins does not match your Cumulus MX logging interval {cumulus.logints[cumulus.DataLogInterval]} mins";
 				cumulus.LogConsoleMessage(msg);
 				cumulus.LogMessage("CheckLoggerInterval: " + msg);
 
@@ -452,6 +458,8 @@ namespace CumulusMX
 							return;
 						}
 
+						// logger updated OK, so change our internal tracking value too
+						loggerInterval = interval;
 						cumulus.LogMessage("SetLoggerInterval: Logger interval changed OK");
 					}
 					catch (TimeoutException)
@@ -484,6 +492,8 @@ namespace CumulusMX
 							return;
 						}
 
+						// logger updated OK, so change our internal tracking value too
+						loggerInterval = interval;
 						cumulus.LogMessage("SetLoggerInterval: Logger interval changed OK");
 					}
 					catch (System.IO.IOException ex)
@@ -2075,11 +2085,14 @@ namespace CumulusMX
 
 			bool midnightraindone = luhour == 0;
 
-			// construct date and time of last record read
-			int vantageDateStamp = cumulus.LastUpdateTime.Day + cumulus.LastUpdateTime.Month*32 + (cumulus.LastUpdateTime.Year - 2000)*512;
-			int vantageTimeStamp = (100*cumulus.LastUpdateTime.Hour + cumulus.LastUpdateTime.Minute);
+			// work out the next logger interval after the last CMX update
+			var nextLoggerTime = Utils.RoundTimeUpToInterval(cumulus.LastUpdateTime, TimeSpan.FromMinutes(loggerInterval));
 
-			cumulus.LogMessage($"GetArchiveData: Last Archive Date: {cumulus.LastUpdateTime}");
+			// construct date and time of last record read
+			int vantageDateStamp = nextLoggerTime.Day + nextLoggerTime.Month*32 + (nextLoggerTime.Year - 2000) * 512;
+			int vantageTimeStamp = (100 * nextLoggerTime.Hour + nextLoggerTime.Minute);
+
+			cumulus.LogMessage($"GetArchiveData: Last Archive Date: {nextLoggerTime}");
 			cumulus.LogDebugMessage("GetArchiveData: Date: " + vantageDateStamp);
 			cumulus.LogDebugMessage("GetArchiveData: Time: " + vantageTimeStamp);
 

--- a/CumulusMX/ProgramSettings.cs
+++ b/CumulusMX/ProgramSettings.cs
@@ -20,18 +20,34 @@ namespace CumulusMX
 		public string GetAlpacaFormData()
 		{
 			// Build the settings data, convert to JSON, and return it
+
+			var startuptask = new JsonProgramSettingsTask()
+			{
+				task = cumulus.ProgramOptions.StartupTask,
+				taskparams = cumulus.ProgramOptions.StartupTaskParams,
+				wait = cumulus.ProgramOptions.StartupTaskWait
+			};
+
 			var startup = new JsonProgramSettingsStartupOptions()
 			{
 				startuphostping = cumulus.ProgramOptions.StartupPingHost,
 				startuppingescape = cumulus.ProgramOptions.StartupPingEscapeTime,
 				startupdelay = cumulus.ProgramOptions.StartupDelaySecs,
-				startupdelaymaxuptime = cumulus.ProgramOptions.StartupDelayMaxUptime
+				startupdelaymaxuptime = cumulus.ProgramOptions.StartupDelayMaxUptime,
+				startuptask = startuptask
+			};
+
+			var shutdowntask = new JsonProgramSettingsTask()
+			{
+				task = cumulus.ProgramOptions.ShutdownTask,
+				taskparams = cumulus.ProgramOptions.ShutdownTaskParams
 			};
 
 			var shutdown = new JsonProgramSettingsShutdownOptions()
 			{
 				datastoppedexit = cumulus.ProgramOptions.DataStoppedExit,
-				datastoppedmins = cumulus.ProgramOptions.DataStoppedMins
+				datastoppedmins = cumulus.ProgramOptions.DataStoppedMins,
+				shutdowntask = shutdowntask
 			};
 
 			var logging = new JsonProgramSettingsLoggingOptions()
@@ -106,6 +122,13 @@ namespace CumulusMX
 				cumulus.ProgramOptions.StartupDelaySecs = settings.startup.startupdelay;
 				cumulus.ProgramOptions.StartupDelayMaxUptime = settings.startup.startupdelaymaxuptime;
 
+				cumulus.ProgramOptions.StartupTask = settings.startup.startuptask.task;
+				cumulus.ProgramOptions.StartupTaskParams = settings.startup.startuptask.taskparams;
+				cumulus.ProgramOptions.StartupTaskWait = settings.startup.startuptask.wait;
+
+				cumulus.ProgramOptions.ShutdownTask = settings.shutdown.shutdowntask.task;
+				cumulus.ProgramOptions.ShutdownTaskParams = settings.shutdown.shutdowntask.taskparams;
+
 				cumulus.ProgramOptions.DataStoppedExit = settings.shutdown.datastoppedexit;
 				cumulus.ProgramOptions.DataStoppedMins = settings.shutdown.datastoppedmins;
 
@@ -179,6 +202,14 @@ namespace CumulusMX
 		public int startuppingescape { get; set; }
 		public int startupdelay { get; set; }
 		public int startupdelaymaxuptime { get; set; }
+		public JsonProgramSettingsTask startuptask {get; set;}
+	}
+
+	public class JsonProgramSettingsTask
+	{
+		public string task { get; set; }
+		public string taskparams { get; set; }
+		public bool wait { get; set; }
 	}
 
 	public class JsonProgramSettingsLoggingOptions
@@ -202,5 +233,6 @@ namespace CumulusMX
 	{
 		public bool datastoppedexit { get; set; }
 		public int datastoppedmins { get; set; }
+		public JsonProgramSettingsTask shutdowntask { get; set; }
 	}
 }

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.22.3.3214")]
-[assembly: AssemblyFileVersion("3.22.3.3214")]
+[assembly: AssemblyVersion("3.22.4.3215")]
+[assembly: AssemblyFileVersion("3.22.4.3215")]

--- a/CumulusMX/ThirdPartySettings.cs
+++ b/CumulusMX/ThirdPartySettings.cs
@@ -272,8 +272,7 @@ namespace CumulusMX
 					cumulus.CustomHttpSecondsTimer.Enabled = cumulus.CustomHttpSecondsEnabled;
 					if (cumulus.CustomHttpSecondsEnabled)
 					{
-						cumulus.CustomHttpSecondsStrings[0] = settings.customhttp.customseconds.url[0] ?? string.Empty;
-						for (var i = 1; i < 10; i++)
+						for (var i = 0; i < 10; i++)
 						{
 							if (i < settings.customhttp.customseconds.url.Length)
 								cumulus.CustomHttpSecondsStrings[i] = settings.customhttp.customseconds.url[i] ?? null;
@@ -288,10 +287,9 @@ namespace CumulusMX
 					cumulus.CustomHttpMinutesEnabled = settings.customhttp.customminutes.enabled;
 					if (cumulus.CustomHttpMinutesEnabled)
 					{
-						cumulus.CustomHttpMinutesStrings[0] = settings.customhttp.customminutes.url[0] ?? string.Empty;
-						for (var i = 1; i < 10; i++)
+						for (var i = 0; i < 10; i++)
 						{
-							if (i < settings.customhttp.customseconds.url.Length)
+							if (i < settings.customhttp.customminutes.url.Length)
 								cumulus.CustomHttpMinutesStrings[i] = settings.customhttp.customminutes.url[i] ?? null;
 							else
 								cumulus.CustomHttpMinutesStrings[i] = null;
@@ -311,8 +309,7 @@ namespace CumulusMX
 					cumulus.CustomHttpRolloverEnabled = settings.customhttp.customrollover.enabled;
 					if (cumulus.CustomHttpRolloverEnabled)
 					{
-						cumulus.CustomHttpRolloverStrings[0] = settings.customhttp.customrollover.url[0] ?? string.Empty;
-						for (var i = 1; i < 10; i++)
+						for (var i = 0; i < 10; i++)
 						{
 							if (i < settings.customhttp.customrollover.url.Length)
 								cumulus.CustomHttpMinutesStrings[i] = settings.customhttp.customrollover.url[i] ?? null;

--- a/CumulusMX/Updates.txt
+++ b/CumulusMX/Updates.txt
@@ -1,0 +1,2444 @@
+3.22.4 - b3215
+——————————————
+Fixed
+- Removing last entry from Third Party custom HTTP lists
+- Disallow negative solar rad values
+- Ecowitt piezo rain sensor (WS90) now supports storm event
+- Davis Vantage VP2/Vue stations no longer download the entire logger contents on start-up when the station logging interval does not match the CMX interval
+- Catch errors in La Crosse WS2300 data handling - specifically fixes reported crashes in forecast data
+
+New
+- Adds start-up and shutdown tasks - see Program Settings
+
+
+3.22.3 - b3214
+——————————————
+Fixed
+- Updates and fixes to the MQTT library
+- Crash in the WLL station fetching Available Sensors from wl.com when it is unreachable
+- Recent data graph JSON files may contain differing numbers of records
+
+Changed
+- The records editors now cope with blank fields (above field 15 - Current Gust) in the monthly log files
+
+
+3.22.2 - b3213
+——————————————
+Fixed
+- Broken 24hr rain and rain rate in v3.22.1
+
+
+3.22.1 - b3212
+——————————————
+Fixed
+- NOAA Reports pages not working in all locales
+- RainRate sometimes giving wild values on start-up when CMX calculates rate
+- Amusing typo in default web site today/yesterday page
+
+
+3.22.0 - b3211
+——————————————
+New
+- Adds the ability to create custom data log files, both interval and daily
+- Ecowitt local API station now dumps the station clock drift to the log file at start-up and every day at noon
+
+Changed
+- MailKit and MimeKit updated to latest versions
+- The web tag <#TimeJavaScript> now provides a value truncated to the current second
+
+
+3.21.2 - b3206
+——————————————
+Fixed
+- Pressure/Temperature trend alarms triggering before the first data has been received
+
+
+3.21.1 - b3205
+——————————————
+Fixed
+- Custom MySQL settings
+
+
+3.21.0 - b3204
+——————————————
+NOTE: When running under Mono, this release REQUIRES Mono version 6.12 or later for email functions
+
+Fixed
+- FTP delete before upload aborting if the initial delete fails due to file not existing
+- Local file copy giving "index out of bounds" error
+
+New
+- Failed MySQL commands are now can now be individually edited/deleted
+
+Changed
+- Failed MySQL commands are now stored in the SQLite database to persist across Cumulus runs
+- Third party components updated
+
+
+
+3.20.1 - b3203
+——————————————
+Fixed
+- Fix crash in Alarms with some station types
+- Change the MySQL table updates to compare column names rather than simple counts
+- Fix the All Time, Monthly, This Year records editors not allowing 24 hour rain values to be changed
+- Fix Dayfile editor not updating ChillHours and 24 hour rainfall values in the MySQL database
+- Fix Dayfile editor inserting 9999/-9999 values into the MySQL database when values are missing
+
+New
+- Adds a new option to the email server settings to ignore certificate errors
+
+Changed
+- The station latitude and longitude are now stored internally as decimal values. This means there will be no loss of precision when storing locations entered as decimal values via the
+  configuration wizard, or directly in the Cumulus.ini file
+
+
+3.20.0 - b3202
+——————————————
+Fixed
+- Buffering of failed MySQL queries
+- MySQL library update to fix crashes with a null reference
+- NOAA Monthly report selector showing two "March"s and no February on the first day of each new month
+- Alarms being triggered during data catch-up. These are now suppressed
+
+New
+- Add custom actions for alarms. Call a script or external exe etc.
+- Add a This Period records display like C1
+- New option to exit Cumulus MX after a data stopped condition - Program Options > Shutdown
+- All DateTime web tags now accept format strings of "Unix" and "JS", if either of these is supplied the datetime will be output as either a Unix or JavaScript timestamp
+- Rain 24 hour:
+	- Added to day file, records 54, 55 (value, time)
+	- Updated dayfile header. Also abbreviated and changed to CSV from PipeSV
+	- Added to all the record editors
+	- Added to MySQL. See new feature below for updating your existing Dayfile table. There is also a MySQL script in the MXutils folder to alter existing table
+	- New web tags:
+		<#rain24hourTH>, <#Train24hourTH>
+		<#rain24hourYH>, <#Train24hourYH>
+	- Default web site updated to show all the relevant records
+- Adds the ability to search in the Dayfile viewer/editor
+- FTP and FTPS now has an option to enable automatic detection of the connection settings
+	- This and another new setting Ignore Certificate Errors are in Internet Settings | Web/TFP Site | Advanced Settings
+	- NOTE: If you use an FTP server without a public certificate, you *MUST* enable the setting. This is a breaking change
+- Custom HTTP calls (seconds, minutes, rollover) can now each have up to 10 URLs
+- Custom MySQL Uploads (seconds, minutes, rollover) can now each have up to 10 commands
+- The MySQL Settings page gets new functions for updating existing tables by adding columns to match the current schema
+- A new "Utils" menu on the Dashboard interface
+	- The FTP Now function has been moved there
+	- New option to reload the Dayfile into CMX from file. CMX holds a copy of the Dayfile in memory, if you edit it externally, use this to refresh the values in CMX without restating
+	- New option to purge the failed MySQL command queue. If you have failed commands (normally custom commands) that will never work, then you can remove them from the failed retry queue without restarting CMX
+
+Changed
+- Alarm latch time hours are now decimal values rather than integer
+- Moon Rise/Set web tags now have the date set to the current day
+- The records editors now work in your locale date/time formats, they also now report any errors setting values
+- The Monthly records editor month tabs have improved accessibility
+- The default web site monthly records page month selection button have improved accessibility
+- Local API, removed BOM from all API responses
+- The date pickers for the log file view/editor pages and the new This Period now display the date in the CMX locale format
+- The Cumulus.ini file now only contains FTP ExtraFiles entries that have either a local or remote filename entered (potentially removes 800 lines from the file!)
+
+
+3.19.3 - b3196
+——————————————
+Fixed
+- Error when sending an Is Raining alarm email
+
+
+3.19.2 - b3195
+——————————————
+Fixed
+- Supress trying to sync solar data on FO stations with solar during night time hours
+- Fix problem processing buffered failed MySQL commands. More query string issues excluded from buffering
+- Default gauges.htm page CSS for the Wind Rose fixed
+
+New
+- Adds the ability to use leaf wetness sensors to trigger the "Is Raining" value and optional alarm. Configure this via Station Settings > Common Options
+- Adds a hash file for the distribution files - hashmd5_<buildno>.txt
+
+
+3.19.1 - b3194
+——————————————
+Fixed
+- Dashboard occasionally showing zero values when using Ecowitt/Ambient extra sensors with the extra HTTP station feature
+- Sunshine Hours graph data had badly formed JSON
+- Fine Offset station getting into a data read synchronisation loop when synchronisation fails. It will now give up after two attempts
+- Potential fix for FTP client locking files on connection error
+
+New
+- Added new midnight temperature range tags for today and yesterday
+	<#tempMidnightRangeT> <#tempMidnightRangeY>
+- Adds new "Is Raining" alarm, triggered either via a Hydreon RG-11 device, or rain rate > 0
+	The alarm has a new associated web tag <#IsRainingAlarm>
+- Adds a new option under Station > Common Options > Advanced Options to use station rainfall (rate > 0 or tip occurred) to trigger IsRaining
+
+
+3.19.0 - b3191
+——————————————
+Fixed
+- Ecowitt Extra Sensors setup error 500
+- Broken NOAA reports in dashboard
+- Occasional web socket disconnection in the Dashboard
+- Default web site pages not always fully loading - updated /js/setpagedata.js
+- Ecowitt Local API station failing to start-up correctly when auto-discovery is enabled and the station fails initial discovery
+- Fine Offset console read synchronisation is fixed/changed
+
+New
+- Added the Today/Yesterday page to the default web site
+
+Changed
+- Migrate the log file viewers to the new date picker
+- Default web site menu system - add accessible sub-menus (setpagedata.js)
+- Date selection in NOAA reports
+- Local API: NOAA reports are now returned as plain text rather than a JSON array of strings
+- Dashboard now populated with data on initial page load (also Now and Gauges pages)
+- Davis WLL: Querying the WLL current conditions now avoids times a broadcast is due to be sent as the WLL cannot do both at once
+
+Removed
+- Twitter be gone! Cumulus MX no longer supports Twitter directly
+
+
+
+3.18.0 - b3190
+——————————————
+- Fix: Adds Ecowitt Wh40 battery state decode
+- Fix: Increase the sensitivity of the rain counter reset and make it "unit aware"
+
+- Change: Lots of third party libraries updated to the latest versions. This should improve SFTP and FTPS connectivity amongst other things
+- Change: Weather Diary editor changed to improve accessibility of the Date Picker
+- Change: Records editors changed to improve accessibility, they now also use pop-up editors
+- Change: Records editors now have the ability to click on the values/timestamps of the log files and have them copied to the record value/timestamp
+
+- New: Additional web tags for today and yesterday high and low temperatures using a midnight rollover. Obviously if you use a midnight rollover
+  for your met day then these tags will return the same values as the existing hi/lo temp web tags.
+	<#tempMidnightTH>, <#TtempMidnightTH>, <#tempMidnightTL>, <#TtempMidnightTL>
+	<#tempMidnightYH>, <#TtempMidnightYH>, <#tempMidnightYL>, <#TtempMidnightYL>
+
+
+3.17.0 - b3184
+——————————————
+- Fix: Cloud base being set to large value at start-up
+- Fix: Reading lightning distance from today.ini
+- Fix: Potential crash obtaining the local IP address
+
+- New: Adds a PWS Simulator station type for testing or trial purposes
+
+- Change: The "live" dashboard screens now refresh whenever new data is received, or every five seconds
+- Change: The "Speed for average calc" station option has been moved from Common Options to Common Options | Advanced Options
+- Change: The Ecowitt stations now force the "Speed for average calc" option to be enabled at start-up
+- Change: Slightly improved solar position calculations
+
+
+3.16.1 - b3183
+——————————————
+- Fix: Error message about Ecowitt sensor mapping when saving the station settings for non-Ecowitt stations
+- Fix: Some Ambient stations are not sending the yearly rainfall total - they send total rain instead
+- Fix: Ecowitt stations with a Blake-Larsen were erroneously adding CMX calculated sunshine during catch-up
+- Fix: Potential issue whereby Ecowitt historic data download could get stuck in a loop downloading the same block
+
+- Change: Ecowitt Local API stations with WS90 sensors now get the update rate set to 8 seconds (previously 4)
+
+
+
+3.16.0 - b3182
+——————————————
+- Fix: Fix mislabelled July solar transmission factors to June
+- Fix: Web tags <#chillhoursToday>, <#chillhoursYest> when chill hours not increasing
+- Fix: Alarm settings could not be saved unless a valid from-email address was entered. Now it is only mandatory if an alert has the email option checked
+- Fix: Ecowitt catch-up not processing rain data - and nobody has noticed!
+- Fix: CPU temp check on Linux?
+- Fix: Start-up PING is now run in a separate thread so if it hangs CMX can continue
+- Fix: Ecowitt Local API station not performing a battery check every 20 minutes
+- Fix: Longest dry/wet web tags from outputting -9999 values, if uninitialised they now output "--"
+
+- New: Ecowitt WN34 sensors can now be mapped from User temp to Soil Temp
+- New: Ecowitt rain sensor is now selectable between tipping bucket and piezo sensors - both Local API and HTTP Ecowitt protocols
+- New: Adds ability for CMX to configure Ecowitt custom server when using it for Extra Sensors
+- New: HTTP Ecowitt stations, Cumulus MX will now configure the custom server config for you - optional
+- New: Ecowitt stations (Local API and HTTP), adds the ability to override the default outdoor temp/humidity values by specifying an extra T/H sensor channel
+- New: Adds last 24 hours rain to the dashboard "Now" page
+- New: Adds records for 24 hour rainfall - This Month, This Year, Monthly, and All Time
+	- New web tags:
+		<#HighRain24HourRecordSet>
+		<#ByMonthRain24HourH>, <#ByMonthRain24HourHT>
+		<#MonthRain24HourH>, <#MonthRain24HourHT>, <#MonthRain24HourHD>
+		<#YearRain24HourH>, <#YearRain24HourHT>, <#YearRain24HourHD>
+		<#r24hourH>, <#Tr24hourH>
+	- Existing web tags updated:
+		<#newrecord>
+		<#RainRecordSet>
+	- Note: It is not currently possible to edit these records via the built-in records editor
+- New: You can now use comment lines that start with a # character within sections in .ini files
+
+
+
+3.15.3 - b3173
+——————————————
+- Fix: Broken start-up ping in 3.15.2 - doh!
+- Fix: Ecowitt historic catch-up when expected data is missing
+- Fix: Disabling the Third Party HTTP Seconds upload no longer requires a restart of CMX
+
+- Change: Ecowitt historic catch-up now applies a 5 minute offset to the received data
+
+
+
+3.15.2 - b3171
+——————————————
+- Fix: Broken start-up ping in 3.15.1
+
+
+3.15.1 - b3170
+——————————————
+- Fix: Changes to the initial ping delay
+- Fix: Remove duplicated Records Set Timeout setting in Station Settings/General/Advanced
+- Fix: Some HTTP Ecowitt stations not sending yearlyrainin - try and use totalrainin for these
+
+- Change: Tweak to the ET calculation
+- Change: Improved WeatherLink.com status message logging
+- Change: The Ecowitt GW1000 station has been renamed to "Ecowitt Local API" to better reflect the applicability to a range of devices
+	- The Ecowitt local API remains the preferred method of connection over HTTP (Ecowitt)
+
+
+
+3.15.0 - b3169
+——————————————
+- Fix: Prevent real time processing occurring before first data has been received
+- Fix: Davis WLL: Add missing decode of THSW from current data
+- Fix: Daily high humidex time being logged as high apparent temp time
+
+- Change: Leaf wetness web tags <#LeafWetness[1-8]> now accept the rc and dp parameters
+- Change: Davis WLL: Now fetches temperature data every 10 seconds instead of 60 seconds
+
+- New: Adds experimental support for Ecowitt stations (GW1000 & HTTP) historic catch-up
+- New: HTTP (Ecowitt) station: adds support for WS990 battery state decoding
+
+- New: Additional web tag for annual ET total <#AnnualET>
+
+
+
+3.14.2 - b3162
+——————————————
+- Fix: Dayfile viewer/editor header for log date changed year format to correct value = "dd/mm/yy"
+- Fix: HTTP stations now ignore any inbound data until any required pre-processing is complete
+- Fix: Removal of old log files from the /MXdiags folder now ignores log files created by other utilities
+- Fix: Davis WLL: Adds missing health data decode for soil/leaf transmitters, and adds SuperCap voltage for Vue transmitters
+- Fix: GW1000 & HTTP Ecowitt: Wind speed handling now consistent across both protocols
+- Fix: Davis VP2: Fix USB/Serial stations stopping polling when connection is temporarily lost
+
+- Change: Davis WLL: Davis leaf wetness sensors now log values as decimals when reporting
+
+- New: Third party uploads to WOW can now include soil temperature from any chosen sensor
+- New: Adds additional units to the JSON data files - "windrun", "soilmoisture", "co2", "leafwet", and "aq"
+
+
+3.14.1 - b3160
+——————————————
+- Fix: Davis WLL stations recording zero values if the WLL sends "null" for a value
+- Fix: Dashboard Alarm settings screen now correctly shows the Sound Enabled flags
+- Fix: Dashboard Historic charts nor correctly removes the Temperature Sum chart
+
+- Change: Ecowitt GW1000 discovery mechanism updated
+
+- New: The Solar calculation now allows you to input different transparency values for July and December. MX uses a cosine interpolation between the two values
+	There are changes to cumulus.ini to accommodate this.
+	[Solar]
+	RStransfactor=0.8		Removed
+	BrasTurbidity=2.0		Removed
+	RStransfactorJul=0.8	New
+	RStransfactorDec=0.8	New
+	BrasTurbidityJul=2.0	New
+	BrasTurbidityDec=2.0	New
+
+
+
+3.14.0 - b3159
+——————————————
+- Fix: Uncaught exception in SFTP Interval uploads
+- Fix: Endless loop during end of day processing if temperature sensor is missing
+- Fix: GW1000, HTTP Ecowitt and HTTP Ambient stations are no longer forced to disable the "Use Speed for Avg" setting
+- Fix: WMR928 Station: Crash opening invalid COM port now handled correctly
+
+- Change: Cumulus MX now uses .Net Framework 4.8 (previously 4.5.2)
+- Change: Now supports TLS1.3 for HTTPS/FTPS/MQTT/Email - dependent on OS support and enabled
+- Change: MySQL server connection check amended to attempt to work around issues with some servers
+- Change: The data stopped, and sensor contact lost alarms are now enabled by default for new installs (both with 1 hour latch, and 2 event trigger)
+- Change: The records editors and records pages in the dashboard now display dashes for records yet to be set
+- Change: The monthly log file and extra log file file editors now accept a date range rather than showing a whole month at a time
+	The date range can span a month end
+	These editors now also have a search field which you can use to search for specific values or times. Only matching lines will be displayed
+	- It is up to you to be sensible on restricting the date range to the performance of your CMX computer
+	- A fast machine with SSD drives will cope with much larger ranges than a Raspberry Pi zero for instance!
+
+
+3.13.8 - b3154
+——————————————
+- Fix: Error in GW1000 LiveData decoding
+
+
+3.13.7 - b3153
+——————————————
+- Fix: Davis stations not retrieving 10 min Gust values from LOOP2 packets
+- Fix: HTTP Ecowitt stations not decoding user temp sensors (HTTP Ecowitt Extra did)
+- Fix: Culture Option to remove spaces from dates
+
+- Change: Writes to log files are now retried twice if they fail the first time
+
+- New: adds support for Ecowitt WH90 sensor battery status
+
+
+
+3.13.6 - b3152
+——————————————
+- Fix: HTTP Ecowitt decode of leaf wetness sensors again
+- Fix: HTTP Ecowitt/Ambient - Remove soil temperature from extra sensor settings
+- Fix: Davis VP2 station sending zero values for soil temp instead of 255 when no sensor present
+- Fix: Long standing bug in Davis VP2/Vue & WLL stations where the day rollover during catch-up was performed after the monthly log entry rather than before
+- Fix: Small tweaks to the ET calculation
+- Fix: Davis VP2 console uses 16 bit signed value for Total Packets Received - compensate for it overflowing in CMX
+
+- New: Program Settings now allows you to over-ride the default date separator string for your locale. This will be useful for those locales that under
+	Mono now use a date separator such as ". " and you want it to use "."
+
+- Change: Cumulus will now still parse the dates/times in dayfile.txt and monthly logs even if the locale changes
+- Change: FO Station will now ignore UV-I values greater than 16
+
+- Updated libraries
+	MailKit
+	MimeKit
+	MySqlConnector
+
+
+
+3.13.5 - b3151
+——————————————
+WITHDRWAN due to issues with FluentFTP and Mono when connecting to FTP servers that allow newer EC encryption algorithms
+
+
+3.13.4 - b3149
+——————————————
+- Fix: Dayfile editor MySQL update statement failing and knock on effects
+- Fix: Davis AirLink sensors now honours the disabling of auto-discovery, and improve auto-discovery logic
+- Fix: Davis WLL station now honours the disabling of auto-discovery
+- Fix: HTTP Extra sensors were over-riding the station manufacturer causing various side effects
+- Fix: Extra sensor logging is now only automatically enabled for HTTP sensors if the selected sensors are actually logged
+- Fix: HTTP Ecowitt station decode of leaf wetness sensors values and battery data
+
+- New: Adds an estimated evapotranspiration value (ET) for stations that have a solar irradiation sensor and do not already supply this value
+	The only currently supported station provides an ET value are Davis VP2/WLL stations with solar sensors
+	The Cumulus calculation uses the standard grass reference crop
+
+- Change: Instead of 'Cumulus pressure names' being implicitly set internally for Davis stations and having to be explicitly set for some other stations
+	Davis VP2/WLL and some! other stations will now explicitly set this option for you
+
+
+
+3.13.3 - b3148
+——————————————
+- Fix: FineOffset station historic catch-up is now aligned to the correct logger intervals
+- Fix: Rain counter reset incorrectly detected if a day has had more than 50 mm of rainfall
+- Fix: Realtime FTP would not recover after a connection failure
+
+
+3.13.2 - b3147
+——————————————
+- Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly, again!
+
+- Change: The CumulusMX distribution zip no longer contains the required empty folders /backup, /data
+	These folders will now be created on start-up if they are missing
+
+
+3.13.1 - b3146
+——————————————
+- Fix: HTTP Station Ecowitt - not decoding all CO₂ sensor values correctly
+- Fix: AirLink crash when used as a standalone station
+- Fix: NOAA settings normal precipitation value for July being saved as June's value
+
+- New: Ecowitt, adds support for WN34S/WN34L soil/water temperature sensors as User Temps as per GW1000
+- New: The default web site index page now shows the Moon illumination percentage
+
+- Change: On start-up Cumulus now always checks for other running instances and reports if one is found, but only aborts if 'Stop second instance' is enabled
+
+- Summary of Cumulus.ini changes:
+	>> NEW >>
+		[GW1000]
+		ExtraSensorUseUserTemp=1
+
+
+3.13.0 - b3145
+——————————————
+- Fix: Realtime FTP, now correctly clears the RT FTP in progress flag
+- Fix: Station Settings, Units, Advanced not being saved correctly
+- Fix: The Log editors (dayfile, data, extradata), now handle returned errors correctly
+- Fix: Rain not being counted with really small bucket sizes
+
+- New: Adds support the WeatherFlow Tempest weather stations (contributed by Doug Summersgill)
+- New: HTTP Ecowitt: Adds GW1000 Firmware Version extraction to both main station and extra sensors
+
+- Change: Davis WLL, low battery warning for WLL device changed from 5.2 to 5.4V (1.35V per cell)
+- Change: Ecowitt battery decoding nightmare continues and evolves as we discover what they really send as opposed to what they say they send!
+- Change: Monthly NOAA reports now stop at the first day with an error in either the dayfile, or the monthly log file. Previously it only stopped at the first dayfile error
+- Change: Internet Settings now works better when enabling/disabling FTP globally and in the interval settings
+- Change: Ecowitt GW1000 now detects WS80 ultrasonic wind sensors and changes the update rate to 4 seconds (WS80 updates every 4.75 secs)
+
+- Updated libraries
+	- MailKit
+	- MimeKit
+	- ServiceStack.Text
+
+
+3.12.1 - b3143
+——————————————
+- Fix: Issues with the temperatures on the Gauges page (and adds Feels like)
+- Fix: Hourly rain value when the rain counter is reset
+- Fix: Limit real time MySQL inserts to 1 minute was not saving correctly
+- Fix: Alarm threshold counts not being saved to Cumulus.ini
+- Fix: Trend values being set to invalid values on new installs
+- Fix: GW1000 station, incorrect decoding of WH51 battery status
+- Fix: Davis WLL ET value for the day being reset to zero on MX restart
+
+- New: Experimental - Add HTTP Station type for Ambient consoles or WH2600/Observer IP
+	- Set-up your Customized Server in the AWnet app to:
+		Protocol	: Ambient Weather
+		Server 		: <hostname_or_ip_of_CMX>
+		Path		: /station/ambient?
+		Port		: 8998 (or whatever you have configured CMX for)
+		Interval	: 20 (seconds)
+- New: Experimental - You can now add extra sensors to your existing station using an Ambient console or WH2600/Observer IP.
+	- Set-up your Customized Server in the AWnet app to:
+		Protocol	: Ambient Weather
+		Server 		: <hostname_or_ip_of_CMX>
+		Path		: /station/ambientextra?
+		Port		: 8998 (or whatever you have configured CMX for)
+		Interval	: 20 (seconds)
+- New: Adds configuration help for the HTTP Upload stations (Ecowitt, Ambient, Wunderground) to the Wizard, Station Settings, and Extra Sensors dashboard pages
+- New: Implements Alarm threshold counts for Sensor Contact Lost, Data Connection Lost, Low Batteries
+
+- Change: Removes the restriction that you could not add Ecowitt Extra sensors to an Ecowitt main station
+- Change: The Calibration Settings page has been re-organised
+- Change: Settings screen more compact for mobile screens, added Aria screen reader attributes to Internet Settings
+
+- Summary of Cumulus.ini changes:
+	>> NEW >>
+		[Ambient]
+		ExtraSensorDataEnabled=0
+		ExtraSensorUseSolar=1
+		ExtraSensorUseUv=1
+		ExtraSensorUseTempHum=1
+		ExtraSensorUseSoilTemp=1
+		ExtraSensorUseSoilMoist=1
+		ExtraSensorUseAQI=1
+		ExtraSensorUseCo2=1
+		ExtraSensorUseLightning=1
+		ExtraSensorUseLeak=1
+
+
+3.12.0 - b3141
+——————————————
+- Fix: The Realtime FTP - particularly SFTP - reconnection code has been rewritten to make it more robust
+- Fix: SteelSeries gauges data mouseovers not working on the dashboard interface
+- Fix: Davis WLL, bug in Chill Hours calculation during archive data catch-up. Each interval increment was 60x larger than it should be
+- Fix: Davis WLL, add missing Sunshine hours calculation to historic catch-up
+- Fix: Davis WLL, now correctly handles null values in historic data during catch-up
+- Fix: GW1000 station, 0.1mm rain tippers would take 3 tips in an interval to register "last rained" when using Inches as the rain unit
+- Fix: GW1000 station, adds missing low battery alarm
+- Fix: GW1000 station, user temperatures above channel 1 were not being assigned to the correct channel
+- Fix: Instromet Increment Logger Pointer was not saving correctly from the Station Settings screen
+- Fix: LowTempAlarmSoundFile being written to incorrect Cumulus.ini entry
+- Fix: Start-up PING now attempts to catch 'hung' responses and terminates them
+- Fix: Start-up delay is now applied before the start-up PING as originally intended
+- Fix: Broken 'Stop second instance' code
+
+
+- New: Adds a First Time Setup Wizard to the settings menu. First time users (i.e. no pre-existing Cumulus.ini) are asked to run this from prompts in the console.
+- New: Adds a HTTP upload station type using WUnderground protocol
+	- Set-up your Customized Server in WSView to:
+		Protocol	: Wunderground
+		Server 		: <hostname_or_ip_of_CMX>
+		Path		: /station/wunderground?
+		Station Id	: 1 (can be anything)
+		Key			: 1 (can be anything)
+		Port		: 8998 (or whatever you have configured CMX for)
+		Interval	: 20 (seconds)
+- New: Adds a HTTP upload station type using Ecowitt protocol
+	- Set-up your Customized Server in WSView to:
+		Protocol	: Ecowitt
+		Server 		: <hostname_or_ip_of_CMX>
+		Path		: /station/ecowitt
+		Port		: 8998 (or whatever you have configured CMX for)
+		Interval	: 20 (seconds)
+- New: You can now add extra sensors to your existing station using an Ecowitt GW1000 (or compatible console).
+	- Set-up your Customized Server in WSView to:
+		Protocol	: Ecowitt
+		Server 		: <hostname_or_ip_of_CMX>
+		Path		: /station/ecowittextra
+		Port		: 8998 (or whatever you have configured CMX for)
+		Interval	: 20 (seconds)
+- New: Adds more "advanced" options to the GUI configuration:
+	- Max wind speed in Station > Common Options > Advanced options
+	- Record set timeout in Station > Common Options > Advanced options
+	- Snow depth hour in Station > Common Options > Advanced options
+	- Rain day threshold in Station > Common Options > Advanced options
+	- List web tags in Program Settings > Program General Options
+- New: Adds Cloud base unit to Units settings
+- New: Realtime and Web Interval settings changed via the dashboard now have immediate effect, a restart is no longer required.
+- New: Adds Lightning distance and last strike time to Today.ini to preserve the values across CMX runs when the GW-1000 has 'forgotten' them
+	[Lightning]
+	Distance=-1
+	LastStrike=0001-01-01T00:00:00
+- New: Adds a global Enable/Disable switch to Internet FTP settings, the value for this on the first run of this version of CMX will be inferred from the other settings.
+	From this release onwards, this switch can be used to enable/disable all FTP activity. It does not affect the Interval and real time interval settings.
+	Disabling this option also disables all the relevant FTP settings in the following sub-sections on the page
+- New: Adds an option to Internet settings for "Local Copy". This enables the ability to create all the standard web site files, and copy them on the local file
+	system instead (or as well as) FTPing them. Useful for installs that run on the same host as the web server.
+- New: Two new web tags for sunshine hours
+	<#SunshineHoursMonth> <#SunshineHoursYear>
+	- When used without parameters these return the total sunshine hours for this month so far, and this year so far.
+	- The Month tag accepts three parameters:
+		y=nnnn & m=nn - use these to specify a specific month you want the total for. Example - <#SunshineHoursMonth y=2021 m=1> for the January 2021 total
+		r=-nn - use this parameter to specify a relative month, -1 = last month, -2 = month before last etc. Example <#SunshineHoursMonth r=-1> for last month's total
+	- The Year tag accepts two parameters:
+		y=nnnn - specify the year you want the total. Example <#SunshineHoursYear y=2020>
+		r=-nn - specify a relative year, -1 = last year etc. Example <#SunshineHoursYear r=-2> total for the year before last
+	- The tags also accept the usual rc=y and dp=n parameters
+- New: Add New Record timeout value to Station Settings > General > Advanced
+- New: Adds Chill hours to yesterday.ini, and adds a new web tag for chill hours total yesterday
+	<#Ychillhours>
+- New: Adds the Chill Hours configuration values to the Station Settings screen
+- New: Add new web tags for average wind speed today and yesterday
+	<#windAvg>, <#windAvgY>
+- New: Adds the ability to update the corresponding entries in the Dayfile and Monthly MySQL tables when using the log file editors in the dashboard
+	- You can enable/disable this feature via a setting in MySQL settings
+	- It only applies to Edit, Delete does not delete the entry in MySQL
+- New: Catch-up from a station logger with (standard) MySQL enabled, now also adds each archive entry to the Realtime table
+- New: Adds the ability to buffer failed MySQL commands until the MySQL server becomes available again, or Cumulus MX is restarted - when they will be lost
+	- Enabled via an option in MySQL Settings
+	- Note: Whilst Realtime updates are buffered, the uploading of failed queries is only performed by the Log updates
+- New: FineOffset stations now log the progress of archive data loading to the console
+- New: NOAA Reports now have an option to calculate the mean temperatures using the traditional method (max + min) / 2
+	- Note: This does not apply to heating/cooling degree days, they will still use the integrated method
+- New: Adds ET for Davis WLL stations with Pro subscriptions
+	- Note: Your solar sensor MUST be connected to your primary ISS for this to work, otherwise weatherlink.com does not calculate ET
+
+
+- Change: Cumulus MX now uses a persistent database to store the recent 1 minute data
+	- This means that charts, recent webtags, and internal calculations for trends and periodic values will be more accurate after a restart
+	- If Cumulus MX is offline for a prolonged period, data for that offline period will obviously still be at the station logging interval resolution
+- Change: MQTT now allows multiple topics for both Update and Interval data.
+	- The format of the MQTT template files has changed to accommodate this
+	- The template must now be formatted as JSON, however the payload data for each topic can still be in whatever format you like so long as you construct
+	  a valid string - i.e. escape quotation marks
+	- The default interval template (the update template is similar) now looks like this...
+		{"topics": [
+			{
+				"topic": "CumulusMX/Interval",
+				"data": "{\"time\":\"<#timehhmmss>\",\"temp\":<#temp rc=y>,\"humidity\":<#hum>,\"wgust\":<#wgust rc=y>}",
+				"retain": false
+			}
+		]}
+		Where the topic name is "CumulusMX/Interval", and the payload is the string "{\"time\":\"<#timehhmmss>\",\"te...rc=y>}" which is formatted as JSON text
+	- To create a template with multiple topics, use this format...
+		{"topics": [
+			{"topic": "MyName/Topic1", "data": "\"<#timehhmmss>\",<#temp rc=y>", "retain": false},
+			{"topic": "MyName/Topic2", "data": "<data><humidity><val><#hum></val></humidity></data>", "retain": true}
+		]}
+		Where Topic1 is formatted as CSV and is not retained on the server, and Topic2 as XML and is retained
+	- The Dashboard Internet > MQTT settings have been updated to reflect these changes
+- Change: Moves the FTP Rename/Delete/UTF-8 Encode settings from Internet Settings|Web Settings|General, to Internet Settings|Web Site|General
+- Change: Moves the Forum URL and Webcam URL settings from Internet Settings|Web Site to Internet Settings|Miscellaneous
+- Change [Internal]: The Dashboard web pages now all use a common menu.js script to render the menus - it saves me a lot of typing when anything changes!
+- Change: The Dashboard settings pages now load the forms JSON as static files rather than via the API.
+- Change: The console output on start-up has been changed slightly to show actual IP addresses in URLs, and I have added some colour.
+	- You now also get different messages if no Cumulus.ini file is detected, directing users to run the first time setup wizard
+- Change: The default web site NOAA reports page is now accessible and removes the mouse-over month selection
+- Change: When configuring the Davis WLL station, if any extra sensors are enabled, then Extra Logging is also automatically enabled.
+- Change: Default unit values for new installs changed for Wind, Pressure and Altitude...
+	m/s -> km/h
+	mbar -> hPa
+	feet -> metres
+- Change: When reading the Cumulus.ini file at start-up, if settings are migrated, or invalid entries corrected, Cumulus.ini is now re-written.
+	That is re-written as created afresh, not updated in place. Old entries are removed, and the file order resequenced. Thus you cannot then
+	use the new Cumulus.ini on old versions of Cumulus, you will have to use backups.
+- Change: Cosmetic changes to most Settings pages, and Records editors
+- Change: Some libraries updated:
+	- Email:	MailKit
+	- MQTT:		MQTTnet
+	- MySQL:	MySqlConnector
+	- JSON:		ServiceStack.Text
+
+
+- Summary of Cumulus.ini changes:
+	>> NEW >>
+		[FTP site]
+		Enabled=1
+		EnableLocalCopy=0
+		LocalCopyFolder=
+		CopyMoonImage=0
+		RealtimeTxtCopy=0
+		RealtimeGaugesTxtCopy=0
+		Copy-websitedata=0
+		Copy-wxnow=0
+		Copy-graphconfig=0
+		Copy-availabledata=0
+		Copy-tempdata=0
+		Copy-pressdata=0
+		Copy-winddata=0
+		Copy-wdirdata=0
+		Copy-humdata=0
+		Copy-raindata=0
+		Copy-dailyrain=0
+		Copy-dailytemp=0
+		Copy-solardata=0
+		Copy-sunhours=0
+		Copy-airquality=0
+		Copy-alldailytempdata=0
+		Copy-alldailypressdata=0
+		Copy-alldailywinddata=0
+		Copy-alldailyhumdata=0
+		Copy-alldailyraindata=0
+		Copy-alldailysolardata=0
+		Copy-alldailydegdaydata=0
+		Copy-alltempsumdata=0
+
+		[MySQL]
+		UpdateOnEdit=1
+		BufferOnFailure=0
+
+		[GW1000]
+		ExtraSensorDataEnabled=0
+		ExtraSensorUseSolar=1
+		ExtraSensorUseUv=1
+		ExtraSensorUseTempHum=1
+		ExtraSensorUseSoilTemp=1
+		ExtraSensorUseSoilMoist=1
+		ExtraSensorUseLeafWet=1
+		ExtraSensorUseAQI=1
+		ExtraSensorUseCo2=1
+		ExtraSensorUseLightning=1
+		ExtraSensorUseLeak=1
+
+		[Graphs]
+		MoonImageCopyDest=images/moon.png
+
+		[NOAA]
+		AutoCopy=0
+		CopyDirectory=
+		UseMinMaxAvg=0
+
+	>> NO LONGER USED >>
+		[FTP site]
+		AutoUpdate=0   // Deprecated, now read-only for migration purposes
+
+		[MQTT]
+		UpdateTopic=CumulusMX/DataUpdate
+		UpdateRetained=0
+		IntervalTopic=CumulusMX/interval
+		IntervalRetained=0
+
+
+
+3.11.4 - b3133
+——————————————
+- Fix: MySQL crash - "Adding the specified count to the semaphore would cause it to exceed its maximum count"
+
+
+
+3.11.3 - b3132
+——————————————
+- Fix: HTTP Alarm alerting for WUnderground successful uploads
+- Fix: Davis WLL setting dewpoint to zero on processing the first history record if Cumulus Calculates Dewpoint is selected
+- Fix: FTP Now did not always update all the Graph JSON files and flag them for FTP
+
+
+
+3.11.2 - b3131
+——————————————
+- Fix: Send email failing if email logging is not enabled
+- Fix: Solar Rad colour now displays as selected on first load in the Selectachart on the dashboard and default website
+- Fix: Handlebars JS script updated due to severe security risk on previous version
+- Fix: GW1000 for 433, 868, 915 MHz variants
+- Fix: Bug in MySQL catch-up
+
+- Change: Setting of ALL logging options via the GUI is now "sticky" - i.e. preserved across runs of Cumulus MX
+- Change: Many of the main settings screens now alert to to the first invalid settings in a message, and the tree containing
+	the error is highlighted in red:
+	- Program Settings
+	- Station Settings
+	- Internet Settings
+	- Third Party Settings
+	- Extra Sensor Settings
+	- Calibration Settings
+	- NOAA Settings
+	- MySQL Settings
+- Change: If any of the base units (wind, temp, rain, pressure) are changed via Station Settings (for instance during the initial configuration), then all the
+	thresholds and base values associated with that unit are reset to the defaults for the new unit
+- Change: The main dashboard page now only shows alarm indicators for enabled alarms
+- Change: Alarm Settings page now has added screen reader attributes (not visible on the page)
+- Change: All HighCharts based pages (Dashboard and default web site) now use the latest stable release of HighCharts
+
+- New: Implements two new alarms for HTTP uploads failing, and MySQL uploads failing
+	- These plus Data Spike, have an additional setting via Cumulus.ini (for now) to set a trigger threshold.
+	  This defaults to 1, so the alarm will trigger immediately. If set to 5, then it will take 5 trigger events happen within the Latch time to set the alarm.
+	  The idea is to prevent an occasional error from triggering the alarm
+	  Cumulus.ini settings:
+		[Alarms]
+		SpikeAlarmTriggerCount=1
+		HttpUploadAlarmTriggerCount=1
+		MySqlUploadAlarmTriggerCount=1
+- New: Web tags - <#HttpUploadAlarm>, <#MySqlUploadAlarm>
+- New: Data Stopped, Data Spike,HTTP upload, MySQL upload emails now also report the error that triggered the alarm in the email text
+- New: Adds two new variables for Extra Web Files - <noaayearfile> & <noaamonthfile> to upload the last year and month reports. It only really makes sense to use these with the EOD option
+- New: You can now limit the real time MySQL table inserts to once a minute. Useful if you run a short real time interval (say 5 seconds), and do not want to
+	flood your MySQL real time table with many rows that hardly change.
+
+
+
+3.11.1 - b3130
+——————————————
+- Fix: Fix Test email logging "success" on failure
+- Fix: Rollback FluentFTP package to previous 32.3.1 version due to crashes in Mono with newer versions
+
+- New: Pressure change in last 3 hours web tag - <#PressChangeLast3Hours>
+- New: Enable additional Accessibility feature - configured via either Station Settings or Program Settings
+	The following pages now have some enhanced accessibility features:
+	- Program Settings
+	- Station Settings
+	- Internet Settings
+	- Third Party Settings
+	- Extra Sensor Settings
+	- Calibration Settings
+	- NOAA Settings
+	- MySQL Settings
+	Adds a new entry in Cumulus.ini
+
+
+
+3.11.0 - b3129
+——————————————
+- Fix: Remove THW Index in /web/websitedataT.json, and default web site index.htm
+- Fix: OpenWeatherMap - create new station was not forcing the use of dot decimals for lat/long values
+- Fix: WeatherCloud - date/time of reading should be UTC
+- Fix: End of day backup now always runs at rollover
+- Fix: FineOffset stations were not ignoring invalid wind speeds on historic catch up
+- Fix: FineOffset stations historic catch up was failing when it reached a logger memory wrap around
+- Fix: FineOffset stations historic catch up is now limited to the number of logger entries the console says are recorded
+- Fix: FineOffset synchronise reads process improvements (attempt)
+- Fix: Catch some errors that could occur in the start-up PING process
+- Fix: MySQL connections that use encryption should now be supported (MySQL 8.0+ default)
+- Fix: GW1000 System Information now correctly decodes 915 and 920MHz devices
+- Fix: GW1000 occasional crash when an unexpected response was received
+- Fix: All settings screens error handling messages now no longer display "[object object]"
+
+- New: Adds support for a THW Index calculation. This value is now available for all station types via the web tag <#THWindex>
+- New: Adds support for Windguru uploads
+- New: Adds Email support for Alarms
+	- Configured via Internet Settings (email server config), and Alarm Settings (from/to addresses for alarms, and a Test Email function)
+	- Creates a new section in Cumulus.ini:
+		[SMTP]
+		ServerName=
+		Port=587
+		SSLOption=1
+		RequiresAuthentication=0
+		User=
+		Password=
+		Logging=0
+	- Adds to the Alarms section in Cumulus.ini
+		[Alarms]
+		xxxxxAlarmEmail=0
+		FromEmail=
+		DestEmail=
+	- Creates a new section in strings.ini, with email text
+		[AlarmEmails]
+- New: WeatherCloud now supports uploading of Air Quality, Soil Moisture, and Leaf Wetness
+- New: Adds support for two sets of Growing Degree Days data
+	- Configured via Station Settings|Growing Degree Days, visibility via Station Settings|Graphs|Data Series Visibility|Degree Days
+- New: Adds support for Temperature Sum - annual running total of daily average temperatures
+	- Configured via Station Settings|Temperature Sum, visibility via Station Settings|Graphs|Data Series Visibility|Temperature Data
+- New: The graphs pages - both dashboard and default web site - now set a page hash value depending on the graph being shown.
+	Benefit = you can now link directly to a particular graph to show on page load
+- New: FineOffset stations now report a warning if the console logger interval does match the Cumulus MX interval
+- New: FineOffset experimental feature to set the console logger interval to match Cumulus logging interval
+- New: JavaScript encoded web tags. These tags were previously only available as HTML entity encoded strings:
+	<#latitudeJsEnc>, <#longitudeJsEnc>
+	<#locationJsEnc>, <#longlocationJsEnc>
+	<#forecastJsEnc>, <#cumulusforecastJsEnc>, <#wsforecastJsEnc>
+	<#currcondJsEnc>,
+- New: Web tags with no HTML entity encoding:
+	<#tempunitnoenc>, <#altitudenoenc>
+
+- Changed: Moved FTP Logging option from Internet Settings to Program Settings to collect all the logging options in one place
+- Changed: A Data Stopped state now stops all logging, MySQL and web activity
+- Changed: Updates to various library components...
+	- Updated to latest versions:
+		- FTP:		FluentFTP
+		- JSON:		ServiceStack.Text
+		- Pointers:	System.Runtime.CompilerServices.Unsafe
+		- MQTT:		MQTTnet
+	- Removed/Added
+		- MySQL:	Removed Devart, replaced with MySqlConnector
+		- MailKit:	Added along with supporting packages MimeKit, and Portable.BouncyCastle
+- Changed: FineOffset stations now attempt to reconnect the USB after a data stopped event. These stations now also keep retrying to connect to the station at start-up
+- Changed: The MySQL real time table data retention settings reworked.
+- Changed: Moved all third party web uploads from Internet Settings page to their own Third Party Settings page
+- Changed: Internal optimisations
+- Changed: JQuery library updated to v3.6.0 for both the Dashboard interface, and the default web site
+
+
+
+3.10.5 - b3122
+——————————————
+- Fix: Comma decimal issues with OpenWeatherMap and other third party uploads
+- Fix: Occasional GW1000 crash on GetSensorIdsNew response timeout
+- Fix: GW1000, WH40 rain gauge, removed battery status check as it does not send this information
+- Fix: Adds missing WeatherCloud interval setting to Internet Settings
+- Fix: Default web site Monthly NOAA reports before the year 2010
+
+- New: Now determines the Ecowitt GW1000 device main sensor type (WH65/WH24) and prints system information to the log file
+- New: Adds the free text station model to the Station settings page
+- New: Adds a cache buster to default web site webpagedata.json downloads
+- New: Adds optional UV index to Now, Today, Yesterday pages of the default web site
+- New: All decimal web tag values now accept a dp=N and tc=y overrides for the number of decimal places
+- New: Adds option to upload AQ data to WeatherCloud
+
+
+3.10.4 - b3121
+——————————————
+- Fix: Issue introduced in v3.10.3 decoding Ecowitt live data
+- Fix: Catch real time FTP updates that have hung for more than 5 minutes and restart them.
+
+
+
+3.10.3 - b3120
+——————————————
+- Fix: Problem with setpagedata.js in "/legacy-webfiles"
+- Fix: Ecowitt GW1000 and clone auto-discovery extended to WH2650 and Ambient clones
+- Fix: Ecowitt auto-discovery broken after a recent Ecowitt firmware update
+- Fix: Ecowitt WH45 battery status on firmware levels below 1.6.5
+- Fix: Blake-Larsen sunshine recorder, the SRsunshine.dat file was using user locale decode, it should always use dot decimal
+- Fix: MQTT only read the Update template file at start-up or if the filename was changed. It now reads the file at every update
+- Fix: Davis WLL was not calculating chill hours and heating/cooling degree days on catch-up
+- Fix: Add missing COM port setting for OS WM918/WMR928 stations
+
+- New: Adds Records Began Date to - Station Settings|General|Advanced
+- New: Adds support for GW1000 firmware 1.6.6
+- New: Default web site - You can now use the "data-cmxdata" attribute on any HTML element, not just spans. BUT note, ALL the innerHTML will get replaced with the JSON data.
+- New: Two new web tags that HTML encode the station description strings - <#locationenc>, <#longlocationenc>
+- New: Adds a NOAA Reports page to the default web site
+- New: Adds support for the EcoWitt WH35 8 channel leaf wetness sensor
+	- Note that only channels 1-4 will be displayed on the dashboard
+	- Extends the leaf wetness web tags with <#LeafWetness5> to <#LeafWetness8> added
+	- samplestrings.ini adds leaf wetness captions 5-8
+- New: Experimental - Enables Battery Low alarm for WMR100/WMR928 stations
+
+- Changed: The Default web site menu system has been rewritten. It is now all defined in the file menu.js
+
+
+3.10.2 - b3117
+——————————————
+- Fix: Improve the AWEKAS fall back for upload interval to go right back to 5 minutes in two stages
+- Fix: Occasional corrupt files output that have processed web tags in them
+- Fix: Error creating the NOAA Year report for some people
+- Fix: Missing station location on gauges.htm web site page
+
+- New: Default website now removes the "Current Conditions" element if the value is blank
+- New: Default web site now auto updates the index.htm and today.htm pages every minute
+
+- Change: The current conditions is now HTML encoded in case it contains illegal characters
+
+- Updated default web site files
+	\web\websitedataT.json
+	\webfiles\index.htm
+	\webfiles\gauges.htm
+	\webfiles\js\setpagedata.js
+
+
+
+3.10.1 - b3116
+——————————————
+- Fix: Bug in temperature conversions introduced in v3.10.0
+
+
+3.10.0 - b3115
+——————————————
+- Fix: Catch error creating System Uptime counter on Windows
+- Fix: The Local web server is now brought up before initialising the station. This allows you to correct a misconfigured station without resorting to editing the Cumulus.ini file.
+- Fix: Diary Editor creating entries on the wrong day, and revamp the interface a bit
+- Fix: WLL day average temp stats on historic catch-up
+- Fix: GW1000 auto-discovery was triggering an erroneous IP address change
+- Fix: Cumulus MX shutdown when running as a system service is now orderly
+- Fix: The start-up ping now refreshes the DNS cache before every re-try to avoid using null entries cached before the internet comes up
+
+- New: Brand new default web site template courtesy of Neil Thomas. The original "legacy" web site is still included, but it has been moved to the /webfiles-legacy folder.
+	- The new web site is now data file driven as opposed to all pages being processed and uploaded. The legacy web site has also been updated to use this method.
+- New: The previous Console log file is now copied to an "-old" file on start-up
+- New: For Davis WLL stations using weatherlink.com, Cumulus now checks and reports the operational status of weatherlink.com on start-up and if an error occurs accessing the service
+- New: Two web tags <#forumurl> and <#webcamurl>, which just return the respective URLs rather than the pre-canned HTML of <#forum> and <#webcam>
+- New: The start of a Display Options section under Station, which controls what data is displayed on the default web site, implementing some of the Cumulus 1 options
+	- New web tags for this: <#Option_useApparent>, <#Option_showSolar>, <#Option_showUV>
+
+- Change: All the settings screens revamped, reorganised and extended.
+	- Many of the settings are now context sensitive, only showing items relevant to your station and configuration.
+	- Most of the previously config file "read-only" settings are now available in an Advanced section relevant to the configuration item. These settings are now read/write.
+	- Many new Cumulus.ini configuration entries, and some now depreciated.
+	- Virtually all the standard files that can be generated can now be controlled for enabling/disabling generation and FTP transfer independently.
+	- Added more graph data series controls.
+- Change: The two graph config files availabledata.json and graphconfig.json are now only uploaded on program start-up and when the station config is changed.
+- Change: Dayfile, Monthly Log, and Extra log file editors now have a selectable page length, and a goto-page feature
+- Change: The default web site is now driven by a single data file (plus realtimegauges.txt), rather than every page being updated and uploaded each interval.
+- Change: The various charting pages now hide buttons for graphs that do not contain any data - both on the dashboard and default web site.
+- Change: Creation of the wxnow.txt file is now disabled by default for new installs
+- Change: Clock sync (Davis VP2 & Instromet) now occurs at 2 minutes past the hour selected
+- Change: Davis VP/VP2/Vue ReadReceptionStats now defaults to enabled for new installs
+- Change: The default output file format is now UTF-8 for new installs
+
+
+3.9.7 - b3107
+—————————————
+- Fix: Unhandled exception in ProcessTemplateFile if cumulus cannot write to the output file
+- Fix: Davis IP logger prevents Cumulus exiting if no station is found on the network
+- Fix: Ecowitt AQ sensors not loading graph data from the log files on start-up
+- Fix: Bug in dayfile parser that was using the time of highest wind speed as time of lowest humidity.
+	- The dayfile parser now outputs the first field number in a line that has failed to parse along with the field contents
+- Fix: The GW1000 retains the previous lightning time/distance if the station resets the values to defaults
+- Fix: Now opens the Davis WLL multi-cast listening port in shared mode to allow multiple copies of Cumulus to run on the same computer.
+       Only tested on Windows, may not work on macOS.
+
+- New: Adds a Select-a-Chart to the dashboard for recent data so you can plot different data on the same chart
+- New: Adds a Select-a-Chart to the default web site for recent data
+	- Creates a new json data file - availabledata.json - that is uploaded to the remote site
+- New: Adds a hot link to the Upgrade alarm on the dashboard
+- New: Adds a start-up host ping escape time. Allows Cumulus to continue loading even if no ping response is received for the specified time
+
+- Change: The default web site gets a CSS change that dynamically alters the "content" width depending on the screen size. On smaller screens the white space either side will reduce in size.
+- Change: The graph JSON data files are now always created locally, regardless of the Include Graph Data Files setting. That now setting only controls FTP like the standard files.
+
+
+3.9.6 - b3101
+—————————————
+- Fix: NOAA monthly report min temp/rain not formatting in dot decimal correctly
+- Fix: Windows console log no longer being created
+- Fix: Fix for exit handlers being called before cumulus instance is initialised causing an unhandled exception
+- Fix: Airlink auto-discovery/update when you have more than one Airlink device
+- Fix: Upgrade & Spike alarm latch hours not being saved/read correctly. You will need to check the values after installing this release.
+- Fix: Rework both the interface graphs and default web site graphs JavaScript files
+- Fix: SampleStrings.ini changes/fixes. The following entries should not longer be quoted - Davis Forecast strings and CO₂ captions
+
+- Change: Recent graph hours now defaults for new installs to 72 hours instead of 24
+- Change: All alarm latch hours now default to 24 hours
+
+
+3.9.5 - b3100
+—————————————
+- Fix: Alarms being cleared after their defined latch time even if latching was disabled
+- Fix: Adds missing dew point calculation for GW1000 extra T/H sensors 1-8
+- Fix: Potential Object reference not set to an instance of an object fault on initial configuration [Goran Devic]
+- Fix: Failed connections to some SFTP servers - Renchi.SshNet library reverted to older version
+- Fix: Improved accessibility of the "Extra web files" page
+- Fix: Tweak to Sunshine hours counter reset logic (primarily for Imet stations during a power cycle)
+- Fix: Davis Console battery low threshold changed from 4.0 V to 3.5 V
+- Fix: Rework station rain counter reset logic. Cope with Davis station start-up on the first day of new rain season which is not January
+
+- New: More comprehensive support for the Ecowitt WH45 CO₂ sensor...
+	- Added to Extra Sensors page
+	- Added to Strings.ini
+	- Can be selected as the primary AQ sensor
+	- New web tags:
+		<#CO2-pm2p5>, <#CO2-pm2p5-24h>, <#CO2-pm10>, <#CO2-pm10-24h>, <#CO2-temp>, <#CO2-hum>
+	- Added to ExtraLog file, columns for: CO2, CO2Avg, pm2.5, pm2.5Avg, pm10, pm10Avg, Temp, Hum
+- New: Improved GW-1000 device auto-discovery, after initial discovery or user input of the IP address it locks onto the MAC address for further changes in IP
+       If multiple potential devices are found they are now listed and the user must add the appropriate IP into the config and restart Cumulus.
+       Discovery is now run whenever a Data Stopped condition is detected (and periodically thereafter until the data resumes)
+	New Cumulus.ini setting:
+	[GW1000]
+	MACAddress=
+- New: Adds a browser cache time limit of 5 minutes to the Admin interface static files
+- New: NOAA reports settings now have an option to force "dot" decimal points, this overrides your locale setting
+	New Cumulus.ini setting:
+	[NOAA]
+	UseDotDecimal=0
+- Tweaks the charts for both the admin interface and the default web site
+- Rework of Airlink sensor implementation - no functional changes
+
+
+3.9.4 - b3099
+—————————————
+- Fix: WMR100 stations generated empty daily graph data files on start-up
+- Fix: System uptime web tag for Linux systems - maybe!
+- Fix: Historic charts wind run tooltip suffix
+- Fix: High Min Temp and Low Max Temp records editors were not displaying and allowing input of the time
+- Fix: This Month/This Year records editors were showing records for the entire day file rather than the specific period
+- Fix: GW1000 station dewpoint calculation incorrect on first packet read at start-up
+
+- New: Settings page: Program Settings. Moved Debug/Data logging options and Prevent Second Instance to here from Station Settings.
+	Note: These settings still remain in the [Station] section of the Cumulus.ini file for backwards compatibility
+- New: Two settings to delay the start-up of Cumulus MX. Both added to the new Program Settings page.
+	Start-up Host PING:        Specify a remote hostname or IP address, Cumulus will wait for a successful PING from this address before continuing
+	Start-up Delay:            Specify a fixed time in seconds to delay the start-up. The delay will be executed after the PING check is one is specified
+	Start-up Delay Max Uptime: Specify a maximum system uptime in seconds after which the delay will no longer be applied. Set to zero to always delay
+	New section in Cumulus.ini:
+	[Program]
+	StartupPingHost=            // Default is no remote host - enter a host name or IP address
+	StartupDelaySecs=0          // Default is no delay = 0
+	StartupDelayMaxUptime=300   // Default is 300 seconds (5 minutes)
+- New: FTP Now - Adds a new option to regenerate the daily graph data files (if enabled), and include them in the manually invoked FTP session
+- New: Adds support for OpenWeatherMap uploads (and catch-up). Using an existing station if the id is supplied, or your API key only has one station defined.
+	If no stations are defined CMX automatically creates a new one using your station details and starts uploading to it.
+
+
+
+3.9.3 - b3098
+—————————————
+- Fix: Records check was triggering for very small value changes in derived values such as feels like temps
+- Fix: Catch uncaught exception on SFTP disconnect
+- Fix: FTP was inconsistent in empty remote server folder handling for real-time and interval files
+- Fix: AirLink was not using the local vs WLL API data correctly
+- Fix: EU CAQI AQI index calculations (based on the City/Urban scale)
+- Fix: US EPA AQI calculation error of values between 51 and 100
+- Fix: Removes redundant alldailywdirdata.json file from daily uploads
+- Fix: Corrects incorrect/invalid JSON being created in the alldailytempdata.json file when the dayfile contains blank entry's for dew point
+- Fix: Attempted FTP uploads of files that do not exist caused the FTP session to become non-functional
+- Fix: The monthly data log file editor erroring with 404
+
+- New: You can now use "<airlinklogfile>" in the extra files local filename to copy/upload the latest AirLink data log file
+- New: You can now define your Indoor AirLink as the primary AQ sensor. Note this only applies to the admin interface, its data will not be
+       uploaded to the default web site
+- New: Adds Cumulus MX update available alarm to the dashboard - enabled by default. This also has an associated web tag <#UpgradeAlarm>
+- New: If enabled, the daily graph data files are now created at start-up and uploaded at first interval FTP.
+       Previously you had to wait for the first EOD rollover.
+- New: If a FineOffset station is not found, MX now dumps a list of all the USB devices it can see to the MXdiags log
+
+
+
+3.9.2 - b3097
+—————————————
+- Fix: Change log messages for number of SQL rows affected to Debug only messages
+- Fix: AirLink web tags no longer error if the sensor is not enabled - all now return "--"
+- Fix: Australia NEPM AQIs to allow values greater than 101
+- Fix: Canada AQHI - still based on PM2.5 3 hour values only
+- Fix: Dutch and Belgian AQI calculations
+- Fix: Default web site temperature Trends graph yAxis issue
+- Fix: Broken logfile, extralogfile, and dayfile editors in b3096
+- Fix: Improve Instromet stations error handling of out of sequence responses
+- Fix: Extra files without the EOD flag were not being transferred during the EOD upload period (first after rollover)
+
+
+- Adds Notifications to Alarms
+	Note: Cumulus notifications only work by default if you run the browser on the same machine as Cumulus and connect using the
+	url: http://localhost:8998
+	In order to get them working on a remote machine you will have to change an advanced flag in your browser.
+	This is at your own risk as advanced flags are unsupported features in Chrome and Edge.
+	In Chrome or Edge, open the url - "about:flags"
+	Find the entry "Insecure origins treated as secure" and enable it
+	The add the url you use to remotely access the Cumulus dashboard - eg. http://192.168.1.23:8998
+	Then click the button to restart your browser. Notifications should now work.
+- Adds Latch times to Alarms. You can now specify a period in hours that an alarm will remain active after the event that tripped it has reset.
+- The default value for "DavisIncrementPressureDP" is changed from true to false
+  ** The effect of this is that for Davis VP/VP2 stations, the default number of decimal places used for pressure values changes
+     from 2 dp (hPa/mb) and 3 dp (kPa, inHg) to 1 dp (hPa/mb) and 2 dp (kPa, inHg)
+  ** If you wish to retain the previous behaviour, then you MUST add the setting "DavisIncrementPressureDP=1" to your Cumulus.ini file
+- Wind Rose is now populated from data files at start-up (last 24 hours)
+- New graphs option to show/hide sunshine hours data
+- New admin interface historic graphs (and associated API)
+- New default web site page to show historic graphs
+- Adds Air Quality to Recent Graphs in Admin Interface and default web site - configure a primary AQ sensor in Station.Options
+- Adds Air Quality upload to WeatherUnderground. Enable in WeatherUnderGround settings, and configure a primary AQ sensor in Station.Options
+- Adds Air Quality upload to AWEKAS. Enable in AWEKAS settings, and configure a primary AQ sensor in Station.Options
+- Adds ability to define the number of decimal places used for various weather units via read-only settings in Cumulus.ini.
+  The full list of existing and new values is:
+	[Station]
+	WindSpeedDecimals=1         // Existing entry
+	WindSpeedAvgDecimals=1      // Existing entry
+	WindRunDecimals=1           // NEW
+	SunshineHrsDecimals=1       // Existing entry
+	PressDecimals=              // NEW [hPa/mb=1, inHg=2]
+	RainDecimals=               // NEW [mm=1, in=2]
+	TempDecimals=1              // NEW
+	UVDecimals=1                // NEW
+	AirQualityDecimals=1        // NEW - affects AQI values only, not PM values
+- Lots of internal code fettling
+- New Cumulus.ini read-only entry to control the data read rate for Instromet stations. The value is in milliseconds, default is 500.
+	[Station]
+	ImetReadDelay=500
+- Admin interface tweaks
+- Change WUnderground Password field name to Station Key in settings
+
+
+3.9.1 - b3096
+—————————————
+- Fix: AirLink - Limit the number of decimal places in the AirLink log file
+- Fix: AirLink - The web tags for 1hr average AQI values were picking up the latest reading value in error
+- Fix: Send rounded wind speed to Weather Underground/Windy/PWS/WoW if Cumulus "Round Wind Speeds" is set
+- Fix: Replaces a bad copy of trendsT.htm that crept into b3095
+- Fix: Bug in wind spike removal that prevented it working
+- Fix: Airlink caused premature day rollover processing during catch-up
+- Workaround for the Chromium browser CSS bug that adds scroll bars to the settings screens
+- Adds a new AirLink Sensors page to the admin interface
+- Adds Netherlands LKI, and Belgian BelAQI AQI scales [6=Netherlands=LKI, 7=Belgium-BelAQI] to AirLink devices
+- All AirLink AQI web tags now support the tc=y parameter, to properly truncate the AQI to an integer value
+- Adds the ability to "latch" all alarms for a user configured number of hours
+- Adds a new web tag <#CPUTemp> - only works on Linux, updates once a minute
+- Change of JSON library from Newtonsoft to ServiceStack.Text
+- Dashboard now updates every 2.5 seconds to match Davis stations (was 3 seconds)
+
+- Updated files
+	\AirLinkFileHeader.txt                      - NEW
+	\CumulusMX.exe
+	\MQTTnet.dll
+	\Newtonsoft.Json.dll                        - REMOVED
+	\ServiceStack.Text.dll                      - NEW
+	\System.Buffers.dll                         - NEW
+	\System.Memory.dll                          - NEW
+	\System.Runtime.CompilerServices.Unsafe.dll - NEW
+	\interface\*.html                           - ALL html files
+	\interface\css\cumulus.css
+	\interface\json\ExtraSensorOptions.json     - NEW
+	\interface\json\ExtraSensorSchema.json      - NEW
+	\interface\json\InternetSchema.json
+	\interface\json\InternetOptions.json
+	\interface\js\airlink.js
+	\interface\js\extrasensorsettings.js        - NEW
+	\interface\alarmsettings.js
+	\interface\lib\alpaca\alpaca.css
+	\web\trendsT.htm
+
+
+
+
+3.9.0 - b3095
+—————————————
+- Fix: Running as a Windows service, now correctly reads command line parameters from the registry "ImagePath" field
+- Fix: Cumulus forecast would sometimes start with a comma
+- Fix: trendsT.htm location formatting
+- Adds support for the Davis AirLink air quality monitor.
+	- Like the WLL it supports auto-discovery of the AirLink IP address, this can be disabled via config
+	- A new Settings page has been created for "Extra sensors", this is where you can configure the AirLink.
+	- Logs AirLink data to a new CSV data file "AirLink<yyyyMM>log.txt" - see AirLinkFileHeader.txt for field information
+	- Historic catch-up is supported if the main station is a Davis WLL and the AirLink has been added as node to this station
+	- Historic catch-up for other stations will be a later release
+	- Creates a new Cumulus.ini file section
+		[AirLink]
+		WLv2ApiKey=
+		WLv2ApiSecret=
+		AutoUpdateIpAddress=1
+		In-Enabled=0
+		In-IPAddress=0.0.0.0
+		In-IsNode=0
+		In-WLStationId=
+		Out-Enabled=0
+		Out-IPAddress=0.0.0.0
+		Out-IsNode=0
+		Out-WLStationId=
+		AQIformula=0      [0=US-EPA, 1=UK-COMEAP, 2=EU-AQI, 3=EU-CAQI, 4=Canada-AQHI, 5=Australia-NEMP]
+	- Adds new web tags for Davis AirLink
+		<#AirLinkFirmwareVersionIn>,<#AirLinkWifiRssiIn>	- Requires Davis WeatherLink Live Pro subscription
+		<#AirLinkFirmwareVersionOut>,<#AirLinkWifiRssiOut>	- Requires Davis WeatherLink Live Pro subscription
+		<#AirLinkTempIn>,<#AirLinkHumIn>
+		<#AirLinkTempOut>,<#AirLinkHumOut>
+		<#AirLinkPm1In>,<#AirLinkPm1Out>
+		<#AirLinkPm2p5In>,<#AirLinkPm2p5_1hrIn>,<#AirLinkPm2p5_3hrIn>,<#AirLinkPm2p5_24hrIn>,<#AirLinkPm2p5_NowcastIn>
+		<#AirLinkPm2p5Out>,<#AirLinkPm2p5_1hrOut>,<#AirLinkPm2p5_3hrOut>,<#AirLinkPm2p5_24hrOut>,<#AirLinkPm2p5_NowcastOut>
+		<#AirLinkPm10In>,<#AirLinkPm10_1hrIn>,<#AirLinkPm10_3hrIn>,<#AirLinkPm10_24hrIn>,<#AirLinkPm10_NowcastIn>
+		<#AirLinkPm10Out>,<#AirLinkPm10_1hrOut>,<#AirLinkPm10_3hrOut>,<#AirLinkPm10_24hrOut>,<#AirLinkPm10_NowcastOut>
+		<#AirLinkAqiPm2p5In>,<#AirLinkAqiPm2p5_1hrIn>,<#AirLinkAqiPm2p5_3hrIn>,<#AirLinkAqiPm2p5_24hrIn>,<#AirLinkAqiPm2p5_NowcastIn>
+		<#AirLinkAqiPm2p5Out>,<#AirLinkAqiPm2p5_1hrOut>,<#AirLinkAqiPm2p5_3hrOut>,<#AirLinkAqiPm2p5_24hrOut>,<#AirLinkAqiPm2p5_NowcastOut>
+		<#AirLinkAqiPm10In>,<#AirLinkAqiPm10_1hrIn>,<#AirLinkAqiPm10_3hrIn>,<#AirLinkAqiPm10_24hrIn>,<#AirLinkAqiPm10_NowcastIn>
+		<#AirLinkAqiPm10Out>,<#AirLinkAqiPm10_1hrOut>,<#AirLinkAqiPm10_3hrOut>,<#AirLinkAqiPm10_24hrOut>,<#AirLinkAqiPm10_NowcastOut>
+		<#AirLinkPct_1hrIn>,<#AirLinkPct_3hrIn>,<#AirLinkPct_24hrIn><#AirLinkPct_NowcastIn>
+		<#AirLinkPct_1hrOut>,<#AirLinkPct_3hrOut>,<#AirLinkPct_24hrOut><#AirLinkPct_NowcastOut>
+- The Blake-Larsen sunshine recorder, and Hydreon RG-11 rain device configuration options can now be set on the new Extra Sensors page.
+	There are two new settings for RG-11 devices, if you use these devices you must set these via the configuration page as they will default to disabled.
+		[Station]
+		RG11Enabled=0
+		RG11Enabled2=0
+- Adds new graph option - Solar Visible. Setting both Solar and UV to hidden means the solar graph data files will be empty.
+- CumulusMX no longer re-writes the Cumulus.ini file on shutdown
+- Adds the option to set the retained flag for the MQTT feeds
+	- New Cumulus.ini file settings
+		[MQTT]
+		UpdateRetained=0
+		IntervalRetained=0
+
+- Updated files
+	\CumulusMX.exe
+	\AirLinkFileHeader.txt
+	\interface				- lots of changes, all *.html files, /scripts, and /json
+	\web\trendsT.htm
+
+
+3.8.4 - b3094
+—————————————
+- Fix: Unhandled exception in MySQL during the start-up catch-up process
+- Fix: Graph buttons not wrapping on default web site trends page
+- Fix: Calculating the trend rain rate when a rainfall multiplier is used
+- Fix: Program Uptime when running under Mono and uptime > 24 days
+- Fix: When running as a Windows service, the service was stopped unintentionally on non-critical system power events
+- Fix: Davis VP receptions stats - ReceptionStats, FirmwareVersion and BaroRead functions rewritten
+- Adds Ecowitt GW1000 decoding of WH34 battery status
+- Adds Ecowitt GW1000 support for CO₂ sensor, no logging yet, but the decoding is there for when these sensors are released.
+	- New web tags <#CO2>, <#CO2-24h>
+- Adds new Linux cumulusmx.service configuration file (thanks to @freddie), this allows you run Cumulus MX as a service under Linux using the
+  newer systemd control rather than the original init.d script supplied with v3.8.0
+	- Edit the cumulusmx.service configuration file and change the path to match your Cumulus MX installation folder
+	- Copy cumulusmx.service to your /etc/systemd/system/ folder
+	- Cumulus can then be started and stopped with the following commands:
+		> systemctl start cumulusmx
+		> systemctl stop cumulusmx
+	- Status and restart are available too:
+		> systemctl restart cumulusmx
+		> systemctl status cumulusmx
+	- If you make a change to the unit file, you need to run the following command so that systemd re-reads your file:
+		> systemctl daemon-reload
+	- To have Cumulus start on reboot, issue the following command:
+		> systemctl enable cumulusmx
+	- Finally, to stop the service running on reboot, use the following:
+		> systemctl disable cumulusmx
+- Adds a new web tag <#ProgramUpTimeMs> that returns the Cumulus run time in milliseconds
+
+- Updated files
+	\CumulusMX.exe
+	\web\trendsT.htm
+
+- New files
+	\MXutils\linux\cumulusmx.service
+
+
+3.8.3 - b3093
+—————————————
+- Fix: The dew point threshold limit (default value 40C) was incorrectly being applied to installations configured to use Fahrenheit
+  as if the value were in Fahrenheit.
+- Fix: Davis VP/VP2 force 1 minute barometer updates no longer working correctly after v3.8.2 protocol changes.
+	Note: this setting should only be used for VP stations, or VP2 stations with very old firmware.
+- Fix: Last rain date not updating for Davis stations (fixes the mixed unit/bucket size update in 3.8.2)
+- Adds two new Cumulus.ini file settings to control the number of decimal places used for wind speeds. These override the built-in defaults.
+  These settings are read-only, they can to be manually added ONLY if you need to use them. Add either or both settings as required.
+	[Station]
+	WindSpeedDecimals=[0|1|2]
+	WindSpeedAvgDecimals=[0|1|2]
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.8.2 - b3092
+—————————————
+- Fix: Davis VP2 stations - LastRainTip not being updated correctly with mixed metric/imperial gauges/units
+- Fix: Davis VP2 stations - Bug that prevented the seconds being read from the console clock
+- Fix: Dashboard temp/press trend arrows not working in locales with comma decimals
+- MXdiags log files are now rotated if they exceed 20MB in size, 15 log files are now retained
+- For Davis VP2 stations, setting the console clock now checks the console time and only sets it if it
+  differs from the current time by greater than 60 seconds
+- Davis VP2 stations protocols have been extensively rewritten to make them more efficient and less timing sensitive
+  Third party IP loggers such as meteobridge and WiFi logger should now work more reliably
+- Enables PSK authentication when using SFTP. Options are now Password, PSK, PSK with Password fall-back
+	New Cumulus.ini entries...
+	[FTP site]
+	SshFtpAuthentication=password      [password (default), psk, password_psk]
+	SshFtpPskFile=                     [PSK filename, must include the full path is the file is not in the CumulusMX folder]
+- CMX calculated dew point is automatically enabled for GW1000 stations
+
+- Updated files
+	\CumulusMX.exe
+	\interface\js\dashboard.js
+	\interface\json\InternetOptions.json
+	\interface\json\InternetSchema.json
+
+
+3.8.1 - b3091
+—————————————
+- Fix: Davis TCP loggers failing to connect correctly
+- Fix: NOAA reports not viewable in Admin interface when Cumulus started as a service
+- Fix: Prevents an Exception on shutdown when running as a service
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.8.0 - b3090
+—————————————
+- Fix: Malformed API JSON returned by api/tags/process.json if no data output is generated
+- Fix: Crash on start-up on the 1st of the month between 00:00 and rollover hour when using 9am rollover
+- Fix: AWEKAS Sunshine hours were being truncated to integer hours
+- New feature: Cumulus MX now supports running as a system service
+	- When running as a service the normal console output is logged to a file: \MXdiags\ServiceConsoleLog.txt
+	- On Windows
+		- To set Cumulus up as a service run it as an Administrator using the command line parameter -install
+		- To remove the Cumulus system service run it as an Administrator using the command line parameter -uninstall
+		- The service will stop itself if it detects that the computer is going into standby
+		- To add parameters to the service when it starts automatically you will have to edit the registry
+			HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\CumulusMX\ImagePath
+			Add the parameters after the quoted executable string. Eg.
+				"C:\CumulusMX\CumulusMX.exe" -port 9000
+		- The service can be stopped/started using the usual utilities:
+			The Services applet:- services.msc (You can pass parameters using this tool, but they are not saved for future use)
+			The service command line tool:- sc start|stop|query CumulusMX [optional parameters for start-up here]
+	- On Linux
+		- Run Cumulus using the mono-service command instead of mono. You also need to add the command line parameter -service
+		  > mono-service -l:/var/run/cmx.pid CumulusMX.exe -service                              (if pathed to CumulusMX folder)
+		 or
+		  > mono-service -l:/var/run/cmx.pid -d:<</path/to/cumulusmx>> CumulusMX.exe -service    (from any location)
+		- To stop the service you use kill, which will perform an orderly shutdown of MX
+		  > kill `cat /var/run/cmx.pid`
+- New feature:
+	- When running on Linux there is now an init.d script to start/stop the service.
+	- The script can be found in the \MXutils\linux folder
+		- Copy it to your /etc/init.d folder
+		- Change the permissions to 0755
+		  > chmod 0755 /etc/init.d/cumulusmx.sh
+	- The script supports the following commands: start, stop, restart, status, removelock
+		- start: Starts MX as a service and creates a lock file to prevent it running again
+		- stop: Stops MX as a service and removes the lock file
+		- restart: Stops, then starts MX
+		- status: Reports if MX is running (only by checking the lock file at present), and dumps the latest console output to screen
+		- removelock: Removes a stray lock file if one gets left behind
+	- The command line would be: /etc/init.d/cumulusmx.sh start|stop|restart|status|removelock
+	- Script name: \MXutils\linux\cumulusmx.sh
+- New feature:
+	- When running on Windows as a service, the service will stop if the computer goes to standby/hibernate mode. A script to set up
+		a Scheduled Task that will restart the service on resume from standby/hibernate is provided in the \MXutils\windows folder.
+		The script MUST be run with Administrator privileges.
+	- Script name: \MXutils\windows\CreateCmxResumeFromStandbyTask.ps1
+- Adds a new web tags for the Davis WLL device.
+	<#ConsoleSupplyV>   - The WLL external supply voltage
+	<#MulticastBadCnt>  - Count of multicast packets missed or have bad a CRC
+	<#MulticastGoodCnt> - Count of good multicast packets received
+	<#MulticastGoodPct> - Percentage of good multicast packets received
+- On new installs of Cumulus MX, changes the default value of "WarnMultiple" from false to true
+- Adds a download history limit of 50 bad packets for WMR200 station types. Previously it could get stuck in a loop downloading bad data.
+- Adds Show UV-I to the graph hide/show options
+- Updates ExportMySQL to include the new Humidex values from b3089
+- AWEKAS uploads updated to API v4 - now can include indoor data, soil temp/moisture 1-4, and leaf wetness 1-2. And it supports rapid
+	updates - minimum 15 seconds if you have a Stationsweb subscription, min 60 secs for Pro accounts, and 300 seconds for normal accounts
+	- IMPORTANT NOTE: THe AWEKAS interval has changed from being set in minutes, to being set in seconds.
+	  You MUST update the AWEKAS interval in the Internet settings/Cumulus.ini file to reflect this change.
+	- New Cumulus.ini entries
+		[Awekas]
+		Language=en
+		SendIndoor=0
+		SendSoilMoisture=0
+		SendLeafWetness=0
+- Enabling/disabling and changing intervals for Twitter, WUnderground, Windy, PWS Weather, WOW, APRS, AWEKAS, Weather Cloud, MQTT from
+  Internet Settings now takes immediate effect and does not require a Cumulus restart.
+- Adds a new Cumulus.ini file only, read-only setting
+	[Station]
+	SunshineHrsDecimals=1
+- Adds a new folder in Dist zip file: /MXutils
+	In here I will add the various scripts etc that are provided with the releases to update MySQL or aid moving from one release to the next.
+	See above for new Windows and Linux scripts when running as a service
+
+
+- Updated files
+	\CumulusMX.exe
+	\ExportMySQL.exe
+	\interface\js\charts.js
+	\interface\json\InternetOptions.json
+	\interface\json\InternetSchema.json
+	\interface\json\StationOptions.json
+	\interface\json\StationSchema.json
+	\webfiles\js\cumuluscharts.js
+
+-New files
+	\MXutils
+
+
+3.7.0 - b3089
+—————————————
+- Fix: Humidex was treated by MX as a temperature and incorrectly converted using the Celsius to Fahrenheit
+  conversion (if that was the user selected temperature unit).
+  Humidex is a dimensionless scale that should not be converted to retain meaning
+- Fix: Thread unsafe graph data access
+- Fix: Real time SFTP not recovering from some reconnection situations
+- Fix: Add missing "rc" function from <#battery> web tag
+- Fix: Remove units from Humidex value on the chart tooltip
+- Fix: Station Settings page menu
+- Fix: Davis WLL devices were flagging sensor contact lost for lost packets, now it only flags contact lost
+		when resynchronising with a transmitter
+- Fix: Monthly records editor not functioning correctly on Humidex in beta1
+- Adds a logger interval check for Davis VP2 stations - prints warning to console and log file if there is a mismatch
+- Now supports some of the Cumulus 1 Graph plotting options, configured via Station Settings
+	- Cumulus.ini file settings
+		[Graphs]
+		TempVisible=1
+		InTempVisible=1		*new?
+		HIVisible=1
+		DPVisible=1
+		WCVisible=1
+		AppTempVisible=1
+		FeelsLikeVisible=1
+		HumidexVisible=1	*new
+		InHumVisible=1
+		OutHumVisible=1
+- Remove defunct WeatherBug upload from Cumulus MX
+- Humidex is now a fully fledged variable...
+	- Daily, monthly, yearly highs
+	- Recent data
+	- Graph data - added to MX interface
+	- Records
+	- New Humidex web tags:
+		<#HighHumidexRecordSet>
+		<#humidexTH>, <#ThumidexTH>
+		<#humidexYH>, <#ThumidexYH>
+		<#MonthHumidexH>, <#MonthHumidexHT>, <#MonthHumidexHD>
+		<#YearHumidexH>, <#YearHumidexHT>, <#YearHumidexHD>
+		<#humidexH>, <#ThumidexH>
+		<#ByMonthHumidexH>, <#ByMonthHumidexHT>
+		<#RecentHumidex>
+- Add Humidex to default web site trend graphs
+- Now only calculates Humidex above 10C
+- Day file updated with four additional fields or Humidex high, high time
+- Monthly log file has an additional field for Humidex
+- Daily SQL table has four additional columns for Humidex high, high time
+- Monthly SQL table has an additional column for Humidex
+- Add new web tag <#timeUnix> = provides current date/time as a Unix timestamp (like <#timeJavaScript>)
+- The web tags <#SunshineHours> and <#YSunshineHours> now accept the decimal place parameter "dp=n"
+- Adds a new web token processor API - details available separately
+- Spike removal settings are now active for all station types - TAKE CARE! Use with caution
+- Spike/limit logging is now enabled by default for new installs
+- Adds a new alarm - Spike removal triggered - it stays active for 12 hours, or it is cleared if you save the calibration settings
+	- New web tag <#DataSpikeAlarm>
+	- New Cumulus.ini file settings...
+		[Alarms]
+		DataSpikeAlarmSet=0
+		DataSpikeAlarmSound=0
+		DataSpikeAlarmSoundFile=alarm.mp3
+- New "Limits" implemented. Now MX ignores temperature, dew point, pressure, and wind values outside sensible value ranges from any station type (these also trigger a spike alarm)
+	- Set via the Calibration settings screen
+	- New Cumulus.ini file settings...
+		[Limits]
+		TempHighC=60
+		TempLowC=-60
+		DewHighC=40
+		PressHighMB=1090
+		PressLowMB=870
+		WindHighMS=90
+- New web tags for latest build notification - these require internet access to be meaningful
+	<#NewBuildAvailable> - returns "1" or "0"
+	<#NewBuildNumber> - returns the latest available Cumulus MX build number
+
+
+- Updated files
+	\CumulusMX.exe
+	\dayfileheader.txt
+	\monthlyfileheader.txt
+	\interface\alarmsettings.html
+	\interface\alltimerecseditor.html
+	\interface\index.html
+	\interface\monthlyrecseditor.html
+	\interface\stationsettings.html
+	\interface\thismonthrecseditor.html
+	\interface\thisyearrecseditor.html
+	\interface\js\alarmsettings.js
+	\interface\js\alltimerecseditor.js
+	\interface\js\charts.js
+	\interface\js\dashboard.js
+	\interface\js\datalogs.js
+	\interface\js\dayfileeditor.js
+	\interface\js\monthlyrecseditor.js
+	\interface\js\thismonthrecseditor.js
+	\interface\js\thisyearrecseditor.js
+	\interface\json\CalibrationOptions.json
+	\interface\json\CalibrationSchema.json
+	\interface\json\InternetOptions.json
+	\interface\json\InternetSchema.json
+	\webfiles\js\cumuluscharts.js
+
+
+3.6.12 - b3088
+——————————————
+- Fix Davis stations not downloading historic logger data (in b3087)
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.6.11 - b3087
+——————————————
+- Fix Davis TCP logger connections not timing out occasionally
+- Fix heading on interface Now page, remove units from Humidex
+- Fix FTP log file handling in Extra Files, with EOD option on the first of the month
+- Add Feels Like to the default web site trends temperature graph
+- Add Extra Sensors log file to the backup routine
+- Add previous months log files (monthly and extra) to the backup on the first of the month
+- Add "<currentextralogfile>" tag to Extra Web Files to specify the variable extra log file name
+- Improve web tag token parser performance
+- Cumulus (Zambretti) forecast now works with localised compass points
+- Internal optimisations (watch out for new issues!)
+- Uplift the SFTP component from a 2016 version to new beta version - supports more encryption methods and key file formats
+- Further additions to shutdown code for all stations
+- Adds new web tag <#RecentFeelsLike>
+
+- Updated files
+	\CumulusMX.exe
+	\Renchi.SshNet.dll
+	\interface\now.html
+	\webfiles\js\cumuluscharts.js
+
+
+3.6.10 - b3086
+——————————————
+- Fix for Feels Like calculation broken in previous release
+- Fix for Davis WLL wind values when using units other than mph
+- Fix for poor performance of wind direction charts on the MX interface and base web site
+- Make end of day SQL inserts asynchronous
+- Use a fixed timestamp for all EOD operations
+
+- Updated files
+	\CumulusMX.exe
+	\interface\charts.html
+	\interface\js\charts.js
+	\web\trendsT.htm
+	\webfiles\js\cumuluscharts.js
+
+3.6.9 - b3085
+—————————————
+- RELEASE WITHDRAWN
+
+
+3.6.8 - b3084
+—————————————
+- Simplify realtime SFTP error detection and recovery
+- Change the default web site Gauges page to not show pop-up graphs by default
+- Fix for Ecowitt GW1000 stations when sensors go offline/online (wind and rain values)
+- Fix for GW1000 stations wind gust values when using units other than "mph"
+- Fix for GW1000 stations with WH34 type sensors and firmware 1.6.0 or later. You *must* now use firmware 1.6.0+ with WH34 devices
+- Fix crash when creating the graph JSON files when file in use by FTP
+- Fix for rc=y parameter not working with the <#intemp> web tag
+- Fix low contrast menus on admin interface
+- Fix HighCharts theme on admin interface Charts page, and default web site Trends page
+- Fix for web tags <#daylength> and <#daylightlength> to display "24:00" if they last all day (they still allow custom formats)
+
+- Updated files
+	\CumulusmX.exe
+	\interface\charts.html
+	\interface\css\cumulus.css
+	\web\trendsT.htm
+	\webfiles\lib\steelseries\scripts\gauges.js
+
+
+3.6.7 - b3083
+—————————————
+- Add catches for real time MySQL updates and all real time file failures
+- Adds Station (Absolute) and Altimeter pressure values for Davis WLL stations
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.6.6 - b3082
+—————————————
+- Change ini files to use 17 significant figures for decimal values (up from 15)
+- Fix for Davis WLL health data decoding when the WLL is LAN attached
+- Fix for real time SFTP not reconnecting after failure
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.6.5 - b3081
+—————————————
+- Fix for sun rise/set and dawn/dusk calculations when there is one event but not the other in a single day
+- Fix for realtime FTP timeout/recovery issues
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.6.4 - b3080
+—————————————
+- Fix for Ctrl-C not being handled when running under Linux/mono. Now handles SIGTERM and console Ctrl-C
+- Fix for realtime FTP getting stuck on "already in progress"
+- Adds support for Ecowitt GW1000 WH34 8 channel "User" (soil and water) temperature sensors
+	New web tags <#UserTemp1> - <#UserTemp8>
+	ExtraLog file has eight new fields appended - UserTemp1-8
+
+- Updated files
+	\CumulusMX.exe
+	\Extrafileheader.txt
+	\SampleStrings.ini
+	\interface\extra.html
+	\interface\js\extradatalogs.js
+	\interface\js\extrasensors.js
+
+
+3.6.3 - b3079
+—————————————
+- Reverts b3077 FluentFTP update
+- Fix for the long standing random Cumulus.ini/today.ini corruption when shutting down on Windows
+- Another fix for Oregon WMR928 extra temperature only sensors
+
+
+- Updated files
+	\CumulusMX.exe
+	\FluentFTP.dll
+
+
+3.6.2 - b3078
+—————————————
+- Fix for badly formed realtime.txt in b3077
+
+
+- Updated files
+	\CumulusMX.exe
+
+
+
+3.6.1 - b3077
+—————————————
+- Fix for Oregon WMR928 extra temperature only sensors
+- Fix for yesterdays Feels Like values in Admin interface Today/Yesterday screen
+- Adds Feels Like to realtime.txt file as field 59
+- Changes GW1000 default Lightning distance to 999 (all user units), and time to 1900-01-01 00:00:00
+	The corresponding Webtags will output "--" and "---" respectively
+- Adds a new web tag <#LastRainTip>, which unlike <#LastRainTipISO> will accept a date/time format string
+
+
+- Updated files
+	\CumulusMX.exe
+	\FluentFTP.dll
+
+
+
+3.6.0 - b3076
+—————————————
+- Fix for records editors failing to read log files from Cumulus 1 versions
+- Fix for Ecowitt GW-1000 devices to bypass the auto-discovery mechanism if it is disabled in the config
+- NOAA reports now include degree, minutes, seconds symbols
+- Slightly enhanced program termination logging
+- Implements highs/low/records for Feels like
+	- Changes to ini files to add Feels Like - Adds [FeelsLike] section to
+		today.ini, yesterday.ini, month.ini, year.ini, alltime.ini, monthlyalltime.ini
+	- Changes to log files
+		monthlog.txt - adds field 27, feels like
+		dayfile.txt - adds fields 47-50, high feels like, high time, low, low time
+	- Changes to the MYSQL database tables are required
+		Adds column FeelsLike to the Monthly table
+		Adds columns MaxFeelsLike, TMaxFeelsLike, MinFeelsLike, TMinFeelsLike to the Dayfile table
+	- New web tags
+		<#HighFeelsLikeRecordSet>
+		<#LowFeelsLikeRecordSet>
+		<#ByMonthFeelsLikeHT>
+		<#ByMonthFeelsLikeLT>
+		<#ByMonthFeelsLikeL>
+		<#ByMonthFeelsLikeH>
+		<#YearFeelsLikeHD>
+		<#YearFeelsLikeLD>
+		<#YearFeelsLikeHT>
+		<#YearFeelsLikeLT>
+		<#YearFeelsLikeH>
+		<#YearFeelsLikeL>
+		<#MonthFeelsLikeHD>
+		<#MonthFeelsLikeLD>
+		<#MonthFeelsLikeHT>
+		<#MonthFeelsLikeLT>
+		<#MonthFeelsLikeH>
+		<#MonthFeelsLikeL>
+		<#feelslikeH>
+		<#TfeelslikeH>
+		<#feelslikeL>
+		<#TfeelslikeL>
+		<#feelslikeYH>
+		<#TfeelslikeYH>
+		<#feelslikeYL>
+		<#TfeelslikeYL>
+		<#feelslikeTH>
+		<#TfeelslikeTH>
+		<#feelslikeTL>
+		<#TfeelslikeTL>
+	- Updated record editors
+	- Updated log file viewers/editors
+- Adds battery and reception data for Davis WLL. It now logs battery and input voltages to the MXdiags.
+  These are updated every 15 minutes and require you to have a WeatherLink Pro subscription.
+  The WLL unlike the VP2 console provides individual data for each transmitter
+	- The following web tags have been updated to accept a "tx=n" parameter, where n=1-8 and equals the desired transmitter id.
+	  Omitting the tx= parameter or using tx=0 makes the tag function as before for Davis VP2 systems
+		<#DavisTotalPacketsMissed tx=n>
+		<#DavisNumberOfResynchs tx=n>
+		<#DavisMaxInARow tx=n>
+		<#DavisNumCRCerrors tx=n>
+	- New web tags for WLL transmitter reception percentage and RSSI figure, these must be used with the tx=n parameter
+		<#DavisReceptionPercent tx=n>   - defaults to tx=1, tx=0 is unused
+		<#DavisTxRssi tx=n>             - defaults to tx=1, use tx=0 to get the WLL WiFi RSSI
+- Updated ExportMySQL.exe to version 1.1.0
+	- Incorporates the new Feels Like data
+	- Uses compass point "-" for Calm
+	- Reads customised compass points from strings.ini if set
+
+
+- Updated files
+	\CumulusMX.exe
+	\dayfileheader.txt
+	\ExportMySQL.exe
+	\Extrafileheader.txt
+	\monthlyfileheader.txt
+	\interface\alltimerecseditor.html
+	\interface\extrawebfiles.html
+	\interface\index.html
+	\interface\monthlyrecseditor.html
+	\interface\now.html
+	\interface\thismonthrecseditor.html
+	\interface\thisyearrecseditor.html
+	\interface\todayest.html
+	\interface\js\alltimerecseditor.js
+	\interface\js\charts.js
+	\interface\js\datalogs.js
+	\interface\js\dayfileeditor.js
+	\interface\js\monthlyrecseditor.js
+	\interface\js\thismonthrecseditor.js
+	\interface\js\thisyearrecseditor.js
+	\interface\json\StationOptions.json
+
+
+
+3.5.4 - b3075
+—————————————
+- Fix for bearing zero on the interface "Now" page
+- Fix for admin interface charts popup
+- Fix for "normal" Extra files not being FTP'd at rollover interval, only those flagged as EOD were being transferred
+- Another attempt to rationalise the Moon Phase messages - each quarter (new, 1st, full, 3rd) should now show for approximately 12 hours either side of the event
+- All web tags that produce decimal number output now support the "rc=y" option
+- Additional Davis WLL health info dumped in the MXdiags log on start-up and every 10 minutes if debug logging is on (voltages, uptimes, WiFi RSSI etc)
+    Logs warnings to the command line console and log file if voltages are too low
+- Adds BatteryLow Alarm for WLL (Console [if you have an API key] & Tx), VP2 (Console & Tx), GW1000 (Tx), and adds a new web tag <#BatteryLowAlarm>
+- Adds new web tag <#feelslike> - calculated using the JAG/TI formula used in the UK, USA, Canada etc. Currently there are no stats for this value
+
+- Updated files
+	\CumulusMX.exe
+	\interface\alarmsettings.html
+	\interface\alltimerecseditor.html
+	\interface\index.html
+	\interface\now.html
+	\interface\todayest.html
+	\interface\js\alarmsettings.js
+	\interface\js\charts.js
+	\interface\js\dashboard.js
+	\interface\js\now.js
+	\mqtt\DataUpdateTemplate.txt
+	\mqtt\IntervalUpdate.txt
+	\webfiles\js\cumuluscharts.js
+
+
+
+3.5.3 - b3074
+—————————————
+- Fix: Backs out changes that created bad file paths in b3073
+
+
+- Updated files
+	\CumulusMX.exe
+	\web\webfiles\lib\steelseries\scripts\gauges.js
+
+
+
+3.5.2 - b3073
+—————————————
+- Fixes and improvements to MQTT processing
+- Adds new Cumulus.ini setting for MQTT to force IPv4/IPv6 connectivity (default is System decides which to use)
+	[MQTT]
+	IPversion=0   (0=default, 4=IPv4, 6=IPv6)
+- Adds Sensor Contact lost flag/alarm for Davis WLL devices
+- GW1000 raw Lux value is now available via the <#Light> web tag like other Fine Offset stations
+- Adds three new web tags...
+	<#timeJavaScript> - returns the current date/time in JavaScript milliseconds. Example use = "var dt = Date(<#timeJavaScript>)"
+	<#directionTM> - returns todays max wind gust direction as a compass point
+	<#directionYM> - returns yesterdays max wind gust direction as a compass point
+
+
+- Updated files
+	\CumulusMX.exe
+	\MQTTnet.dll
+
+
+
+3.5.1 - b3072
+—————————————
+- Fix for the "Stop second instance" option now working a bit too well, you could not disable it!
+- Implements the "record set" web tags. These will be set from the time of the record until a timeout value (default 24 hours).
+  You can change the default timeout by adding a entry to Cumulus.ini
+	[Station]
+	RecordSetTimeoutHrs=24
+
+  The web tags enabled are: TempRecordSet, WindRecordSet, RainRecordSet, HumidityRecordSet, PressureRecordSet, HighTempRecordSet,
+  LowTempRecordSet, HighAppTempRecordSet, LowAppTempRecordSet, HighHeatIndexRecordSet, LowWindChillRecordSet, HighMinTempRecordSet,
+  LowMaxTempRecordSet, HighDewPointRecordSet, LowDewPointRecordSet, HighWindGustRecordSet, HighWindSpeedRecordSet, HighRainRateRecordSet,
+  HighHourlyRainRecordSet, HighDailyRainRecordSet, HighMonthlyRainRecordSet, HighHumidityRecordSet, HighWindrunRecordSet, LowHumidityRecordSet,
+  HighPressureRecordSet, LowPressureRecordSet, LongestDryPeriodRecordSet, LongestWetPeriodRecordSet, HighTempRangeRecordSet, LowTempRangeRecordSet
+
+
+- Updated files
+	\CumulusMX.exe
+
+
+
+3.5.0 - b3071
+—————————————
+- Fix to "Stop second instance" of Cumulus running
+- Fix for hung update interval (S)FTP sessions getting hung
+- Fix to <#moonage> web tag to improve accuracy
+- Adds support for MQTT output
+  Two options, send an MQTT message whenever new data is received, or send a message at a fixed interval
+  The message format is defined in template files, using web tags, located in the \mqtt folder
+- Tidy up of /interface folder to remove unused files
+- Removal of Highcharts scripts from the distribution
+- Add support for generating a Moon Phase image. This is disabled by default. The output image will be generated and
+  optionally FTP'd once an hour. The generated local image file is always \web\moon.png
+	[FTP site]
+	IncludeMoonImage=1
+
+	[Graphs]
+	MoonImageEnabled=1
+	MoonImageSize=100
+	MoonImageFtpDest=images/moon.png
+
+
+- New files
+	\Licences-Additional.txt
+	\MQTTnet.dll
+	\mqtt\DataUpdateTemplate.txt
+	\mqtt\IntervalTemplate.txt
+	\web\MoonBaseImage.png
+
+- Updated files
+	\CumulusMX.exe
+	\FluentFTP.dll
+	\Newtonsoft.Json.dll
+	\interface\  - [Many changes, delete and replace]
+	\web\indexT.htm
+	\webfiles\js\cumuluscharts.js
+
+
+
+3.4.6 - b3070
+—————————————
+- Fix for station wind chill on Davis WLL devices
+- Fix for auto-discovered Davis WLL Station-Ids not being saved to the config file
+- More robust failure handling for realtime FTP connections
+- Additional diagnostics output in the console and log file for badly formed web tags
+
+- Updated files
+	\CumulusMX.exe
+
+
+
+3.4.5 - b3069
+—————————————
+- Adds Editors for: Dayfile, Monthly Logs, Extra Logs
+- Adds line numbers to the log file viewer/editors
+- Widens the time windows for the Moons phase names
+- Fix for <#MoonPercent> and <#MoonPercentAbs> always showing integer values even with the dp=n option
+
+
+- Updated files
+	\CumulusMX.exe
+	\interface\<too much to list>
+
+
+
+3.4.4 - b3068
+—————————————
+- Fix for incorrect NOAA yearly report, annual averages for temperature and wind were calculated incorrectly
+- Now detects invalid CumulusMX.exe command line parameters
+- Adds a new command line parameter -debug. This switches on debug and data logging from the start-up of Cumulus MX. You no
+  longer have to edit Cumulus.ini to gather these diagnostics.
+
+- Updated files
+	\CumulusMX.exe
+
+
+
+3.4.3 - b3067
+—————————————
+- Adds a new option to Davis WLL and Ecowitt GW1000 station settings to disable IP address auto-discovery. Use this option
+  if you have more than one of these devices on your network, then enter the IP address manually.
+
+- Updated files
+	\CumulusMX.exe
+	\interface\json\StationOptions.json
+	\interface\json\StationSchema.json
+
+
+
+3.4.2 - b3066
+—————————————
+- Improved error handing for invalid Davis WLL Station Ids
+- Improved error handling when the network connection to a Davis WLL is lost (and restored)
+- Adds missing Data Stopped alarm to the Dashboard and Alarm Settings screens
+- Adds auto-discovery for Ecowitt GW1000 devices IP addresses
+- Adds DataStopped handling to Ecowitt GW1000 devices
+
+- Updated files
+	\CumulusMX.exe
+	\interface\alarmsettings.html
+	\interface\index.html
+	\interface\js\alarmsettings.js
+	\interface\js\dashboard.js
+
+
+
+3.4.1 - b3065
+—————————————
+- Fix for WLL if you change the WL.com logging interval around a catch-up period
+- Fix for gust values from WLL devices
+- Add WLL broadcast data watchdog and warning, implements DataStopped flag
+- Adds WLL Cumulus.ini readonly setting, AutoUpdateIpAddress, use this to switch off the WLL autodetection of IP
+  address. This is a workaround for a WLL firmware bug that does not update the IP address when it changes using DHCP.
+	AutoUpdateIpAddress=0  #default = 1
+
+- Updated files
+	\CumulusMX.exe
+
+
+
+3.4.0 - b3064
+—————————————
+- Adds the option for Davis WLL users who have a WL.com Pro subscription to use WL.com as a "logger" to catch up
+  missing data on Cumulus MX start-up.
+- Adds to option to truncate the <#MoonAge> tag value to an integer value instead of rounding it.
+  Use <#MoonAge tc=y> - ideal if you use the tag for image selection
+- Updates FTP Now so that it does a full file process and FTP cycle, previously it just ran the FTP process
+- Adds a Cumulus MX version check at startup - if online - and logs a message in the console and diags when a newer
+  build is available
+- Fixes the Monthly Records editor for dry/wet periods that end on the last day of a month being incorrectly recorded
+  against the following month.
+- Fixes the Beaufort calculations - there were some rounding errors in edge cases.
+- Fixes Davis VP2 and WLL that were not using peak speeds from LOOP2 (VP2) and live/historic data (WLL) when the Cumulus logging
+  interval is set to 10 minutes or more.
+- Fix for FTPS on realtime FTP updates
+- Adds new ini file only option to disable Explicit FTPS - ie use Implicit mode
+	DisableFtpsExplicit=1
+
+- Updated files
+	\CumulusMX.exe
+	\interface\json\StationOptions.json
+	\interface\json\StationSchema.json
+
+
+3.3.0 - b3063
+—————————————
+- Adds support for SFTP (SSH FTP)
+	- Moves the FTP SSL option to the web server settings
+	- Adds SFTP to existing FTP, FTPS options
+- Fixes Ecowitt Soil Temperature/Moisture/Leak detector channel numbering
+- Fix for an occasional error in station logger data handling of today's rainfall during CMX start-up
+- Fix for Ecowitt GW1000 Lightning data decode
+- Fix for incorrect date on <#Snow*> web tags
+- Now automatically fixes two Cumulus.ini changes from Cumulus 1 generated files
+	- Changes the [FTP Site] section name to [FTP site]
+	- Changes NOAA default monthly name (if still set) from "NOAAMO'mmyy'.txt" to "NOAAMO'MMyy'.txt"
+- Additional diagnostic logging info for Lacrosse WS2300 stations
+
+- Updated files
+	\CumulusMX.exe
+	\FluentFTP.dll
+	\interface\json\InternetOptions.json
+	\interface\json\InternetSchema.json
+
+- New files
+	\Renci.SshNet.dll
+
+
+3.2.6 - b3062
+—————————————
+- Fixes monthly records editor for stations with a met day starting at 9am
+- Adds range checks for latitude and longitude values
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.2.5 - b3061
+—————————————
+- Adds This Month and This Year records editors
+- Adds FTP Now function
+- Fix to MonthlyAlltimeLog.txt to add line feeds
+- Fix missing WLL station description from APRS data
+
+- Updated files
+	\CumulusMX.exe
+	\interface\<allfiles>.html
+
+- New files
+	\interface\ftpnow.html
+	\interface\thismonthrecseditor.html
+	\interface\thisyearrecseditor.html
+	\interface\js\thismonthrecseditor.js
+	\interface\js\thisyearrecseditor.js
+
+
+3.2.4 - b3060
+—————————————
+- Fix uncaught Web exceptions in Davis WLL
+- Fix Monthly Records editor not saving updated date/time stamps
+- Adds a log file for MonthlyAlltime.ini file changes
+
+- Updated files
+	\CumulusMX.exe
+
+
+3.2.3 - b3059
+—————————————
+- Adds the Cumulus.ini file to the files automatically backed up each day/program start
+- Fixes to the Monthly Records editor monthly rainfall figures
+
+- Updated files
+	\CumulusMX.exe
+	\interface\alltimerecseditor.html
+	\interface\monthlyrecseditor.html
+	\interface\js\alltimerecseditor.js
+	\interface\js\monthlyrecseditor.js
+
+
+3.2.2 - b3058
+—————————————
+- Implements the missing <#txbattery> web tag for WLL devices
+- Fix default website pages header not wrapping on small screens
+- Adds Monthly Records editor
+- Fixes and improvements to the All Time Records editor
+
+- Updated files
+	\CumulusMX.exe
+	\interface\<allfiles>.html
+	\web\<allfiles>T.htm
+
+- New files
+	\interface\monthlyrecseditor.html
+	\interface\js\monthlyrecseditor.js
+
+
+3.2.1 - b3057
+—————————————
+- Fix for WMR200 stations writing a zero value Apparent Temperature to the log files when retrieving logger data
+- Fix the dashboard for Internet Explorer
+- Fix default website index page header not wrapping on small screens
+- Fix for Davis stations connected via TCP/IP to detect failures and reopen the connection more quickly during loop data processing
+- Adds Solar calibration settings offset and multiplier
+- Updates the SampleStrings.ini file with the extra captions added in b3056
+
+- Updated files
+	\CumulusMX.exe
+	\SampleStrings.ini
+	\HidSharp.dll
+	\interface\js\dashboard.js
+	\interface\json\CalibrationSchema.json
+	\web\indexT.htm
+
+
+3.2.0 - b3056
+—————————————
+- Adds support for Ecowitt GW1000 WiFi gateway
+- New web tag <#GW1000FirmwareVersion>
+- Added extra soil temp sensors 5-16 for GW1000 stations
+	- New web tags <#SoilTemp5-16>
+	- Value are logged to extra log file
+	- Added custom captions available in Cumulus.ini [SoilTempCaptions] : Sensor5-16
+- Added extra soil moisture sensors 5-16 for GW1000 stations
+	- New web tags <#SoilMoisture5-16>
+	- Values are logged to extra log file
+	- Added custom captions available in Cumulus.ini [SoilMoistureCaptions] : Sensors5-16
+	- Units now change between cb for Davis and % for GW1000 sensors
+- Added extra air quality sensors 1-4 for GW1000 stations
+	- New web tags <#AirQuality1-4> and <#AirQualityAvg1-4>
+	- Values are logged to extra log file
+	- Added custom captions available in Cumulus.ini [AirQualityCaptions] : Sensor1-4 and SensorAvg1-4
+- Added new web tags for <#LeakSensor1-4> to support GW1000 leak sensors
+	- No display or logging of these values is done
+- Added new web tags for Lightning sensors on GW1000 stations
+	- <#LightningDistance> Distance to last strike (same units as wind run - miles/km/nm)
+	- <#LightningTime> Time of last strike (format customisable)
+	- <#LightningStrikesToday> Number of strikes since midnight
+	- Currently there is no logging or display of these values
+- Enables alarms as per Cumulus 1
+	- New Alarm page under Settings
+	- Alarms are shown visually on the dashboard
+	- Due to browser restrictions, alarm sounds on the browser page may require you to click a button on the first alarm in order to hear it.
+           - You can add the MX admin site to your browsers list of sites allowed to play sound automatically
+	   - Your browser should "learn" that you want to allow sounds to play automatically
+	- Alarm sound files should be placed in the /interface/sounds folder, they must be a browser compatible format (mp3 are good)
+	- The alarm settings for the sound file should be just the filename without any path
+- Add pressure multiplier calibration
+	- New ini file setting [Offsets] PressMult = 1.0 (default)
+- Fix for the All Time Records editor hourly rain total from the monthly log file month
+- Fixes missing Cumulus multipliers for Wind and Rain values on Davis WLL stations
+- Changes All Time Records editor to only load data from the Day File by default. Monthly log file
+  processing is now optional as it can take a very long time on a slow machine e.g. Raspberry Pi
+- Fix to catch badly formed Davis WLL broadcast messages
+- Fix for Davis WLL edge cases producing an initial zero value wind chill on startup
+
+- Updated files
+	\CumulusMX.exe
+	\interface\json\StationOptions.json
+	\interface\json\StationSchema.json
+	\interface\<AllFiles>.html
+	\interface\js\extrasensors.js
+	\interface\js\alltimerecseditor.js
+	\interface\js\dashboard.js
+	\interface\css\main.css
+	\interface\json\CalibrationSchema.json
+
+- New files
+	\interface\alarmsettings.html
+	\interface\js\alarmsettings.js
+	\interface\sounds\alarm.mp3
+
+
+3.1.2 - b3055
+—————————————
+- Fix for the All Time Records editor monthly rain total from the monthly log file month
+- Fix for some long timeouts in All Time Records editor
+
+- Updated files
+	\CumulusMX.exe
+
+
+
+3.1.1 - b3054
+—————————————
+- Fixes WLL timestamps always being in UTC, now uses local time
+- Adds web tags <#snowlying>, <#snowfalling>, both provide 1|0 responses
+- Adds Current Conditions editor to admin interface
+- Adds All Time Records editor to admin interface
+
+
+- Updated files
+	\CumulusMX.exe
+	\interface\<allexistingfiles>.html
+
+-New files
+	\interface\currentcondeditor.html
+	\interface\alltimerecseditor.html
+	\interface\js\alltimerecseditor.js
+	\interface\lib\x-editable\ <all files>
+	\interface\img\loading.gif
+
+
+3.1.0 - b3053
+—————————————
+- Adds support for Davis WeatherLink Live device
+	- Supports Zero-Config, it should discover your WLL on the network (router support required)
+- Adds support for Cumulus.ini file setting EWpressureoffset for Fine Offset stations as used in Cumulus1.
+	- This provides a manual override for the calculated absolute to relative pressure offset
+- Adds reading of the interval Hi/Lo temperature readings when processing Davis logger archive records during catch-up
+- Adds display and generation of NOAA Monthly and Yearly reports
+- Reduces the Instromet live data read intervals to 1 second
+- Applies "fix" for Mono 5.x generating short month names ending with "." as used for log file names
+
+
+- Updated files
+	\CumulusMX.exe
+	\CumulusMX.exe.config
+	\interface\<allfiles>.html
+	\interface\json\StationOptions.json
+	\interface\json\StationSchema.json
+
+- New files
+	\Tmds.MDns.dll
+
+
+3.0.2 - b3052
+—————————————
+- Fixes Davis archive downloads from the the logger when the day rollover processing takes longer than 10 seconds.
+  This can happen on slow processors - Pi Zero for example - or if lengthy procedures are included
+  An extra archive processing run is scheduled for each day rollover that takes longer than 10 seconds
+
+- Updated files
+	\CumulusMX.exe
+	\CumulusMX.exe.config
+
+
+3.0.1 - b3051
+—————————————
+- Increases Davis DMPAFT Date/Time command timeout
+- Much improved Davis serial port throughput (for USB and Serial loggers), should decrease the historic logger download time
+- Adds Davis archive data processing progress indication
+- Fixes firmware check for LOOP2 support
+- Fixes a race condition on start-up of Davis VP2 stations without a logger. This could cause a crash in AstroLib.SolarMax()
+- Fixes reading the Davis console clock after setting the time
+
+- Updated files
+	\CumulusMX.exe
+
+
+3050
+————
+- Fixes MX not working with locales that use two character date separators
+  Eg. Croatia "29. 04. 19"
+
+- Updated files
+	\CumulusMX.exe
+
+3049
+————
+- Adds the ability to upload data to Windy.com
+
+- Updated files
+	\CumulusMX.exe
+	\interface\json\InternetOptions.json
+	\interface\json\InternetSchema.json
+
+3048
+————
+- You can now first time enable/disable Realtime FTP without having to restart CMX
+
+- Instromet stations now record and report rainfall (mm) and sunshine hours to 2 decimal places
+
+- Improved realtime FTP error handling
+
+- Improved Davis protocol handling
+
+- Fix Davis protocol mixing up LOOP1 and LOOP2 packets and consequently providing invalid rain and wind data.
+
+- Fix web tag <#YearLowDailyTempRangeD> broken in b3047
+
+- Bug fixes to FTP Component, and internal changes to FTP transfer mechanism
+
+- Updated files
+	\CumulusMX.exe
+	\FluentFTP.dll
+
+
+
+3047
+————
+- Web token parser updated to cope with html tag characters "<>" in the format string.
+	- You can now do things like...
+		<#TapptempH format="dd'&nbsp;'MMM'&nbsp;'yyyy'<span class=\'xx\'> at 'HH:mm'</span>'">
+		which gives...
+		04&nbsp;Dec&nbsp;2018<span class='xx'> at 10:12</span>
+
+		Note: that you have to use single quotes for HTML entity names, and they have to be escaped "\'"
+
+- New Davis Baud Rate setting
+	- Allows you to alter the speed of the serial connection to Davis loggers
+	- Configured manually in Cumulus.ini [Station] section
+		DavisBaudRate=19200 (default) Permitted values are 1200, 2400, 4800, 9600, 14400, 19200
+
+- Added new option for the "Extra files" - End of Day
+	- Enabling this means that file will only be processed/copied/FTPed once a day during the end of day roll-over.
+	- There is a new Cumulus.ini file setting for each "extra" file associated with this setting
+		ExtraEOD[nn]
+	- Note there is currently no check between Realtime and End of Day settings, you could check both options and the file
+	  will be processed at both the realtime interval AND end of day - which would not make much sense!
+
+- Improvement to Instromet logger protocol handling
+
+- Change the Fine Offset Synchronised Reads option to default to enabled
+
+- Change VP2 automatic disabling of LOOP2 to an advisory message, as the firmware version is not always detected.
+
+- Consistency: All record Value tags should now return '---' and Date tags '----' until they are first set.
+
+- The following web tags now support the "dp=N" "rc=y" parameters for the number of decimal places, and replace decimal commas with points.
+	#MoonPercent
+	#MoonPercentAbs
+	#MoonAge
+
+- Fix for Fine Offset & WMR100/200 stations on Mac operating systems (introduced in b3044)
+
+- Fix for invalid (extremely high) pressure readings from Fine Offset stations (thanks to 79669weather)
+
+- Fix to not updating the Instromet loggers memory pointer correctly
+
+- Fixed Weather Diary Time Zone issues
+
+- Bug fixes and performance improvements to the FTP component
+
+- Updated files
+	\CumulusMX.exe
+	\CumulusMX.exe.config
+	\FluentFTP.dll
+	\HidSharp.dll
+	\interface\js\diaryeditor.js
+	\interface\json\StationOptions.json
+
+- Removed files
+	\fastJSON.dll
+
+
+
+3046
+————
+- Weather Diary
+	- Added Weather Diary page to management interface
+	- Added diary.db file to daily backup files
+	- Removed diary.db from distribution (it is created on first use to avoid overwriting the file on CMX distro updates)
+
+- Web Tags
+	- Added <#snowdepth> tag processing
+
+- ET annual roll-over fix
+
+- Fix to TLS 1.2 FTPS of the 'periodic' files
+
+
+
+3045
+————
+- Internal Stuff
+	- Update the targeted .Net version to 4.5.2 (4.5 and 4.5.1 are no longer supported by Microsoft)
+	- Upgrade System.Net.FtpClient to replacement FluentFTP package
+	- Update Microsoft.Net.Http package to latest stable version
+	- Update fastJSON package to latest stable version
+	- Update embedIO package to latest stable version
+	- Remove Alchemy WS package from build
+
+- Davis TCP connections.
+	- Added additional error handling, should now be much more robust and attempt to reconnect on failure.
+
+- Astro calcs for Solar
+	- Added refraction correction.
+	- updated to add some extra terms.
+
+- Removed URL encode Twitter messages added in b3044
+
+- Added second order humidity correction factor, works the same as the temperature. It has to be set manually in Cumulus.ini.
+	- Cumulus.ini
+		[Offsets]
+		HumMult2=0.0
+
+- FTP Updates
+	- Now supports FTPS over TLS1.1 and 1.2
+	- In Passive FTP, you can disable Enhanced Passive (EPSV) mode if it causes problems with your host. Some hosts are reporting they support it, but a firewall along the route cannot handle the connections.
+	  Requires manually adding a new Cumulus.ini entry...
+		[FTP site]
+		DisableEPSV=1
+	- RealtimeGaugesTxt is no longer automatically enabled for FTP.
+
+- Web Sockets are no longer on a separate port, it shares the same port as HTTP.
+	- The wsport command line switch is still recognised for backwards compatibility, but it is no longer used.
+
+- Fix Fine Offset with solar logger reading, now limited to the reduced number of logger entries available on solar stations.
+
+- Fix for Slovenian locale (and any other with a two character date separator)
+
+
+
+3044
+————
+- Added new solar calculation method "Bras"
+	- New Cumulus.ini entries...
+		SolarCalc=0    		(0=Ryan-Stolzenbach, 1=Bras, default=0)
+		BrasTurbidity=2   	(atmospheric turbidity factor (2=clear, 5=smoggy, default=2)
+	- Updated the Interface web files to reflect the new settings.
+
+- Updated HidSharp to ver 2.0.5
+	- Now uses libudev1 for Fine Offset and WMR200 stations
+
+- Fixed corrupt/missing MySQL port causing CumulusMX to crash on start-up
+
+- Attempt to reconnect to Davis IP logger on connection failure (only a possible fix)
+
+- Updated the default forum URL to it's new home
+
+- Updated included website files to new URL
+
+- URL encode Twitter messages (I know Twitter is largely broken)
+
+- Davis VP2 - (Steve Loft) Added sanity checks for invalid wind speed/direction values
+
+- Davis VP2 - Added automatic disabling of the use of LOOP2 packets on firmware versions < 1.90
+
+- Change RG11 devices to use a new Cumulus.ini file entry. The previous MX builds would not work on Linux.
+  For example:
+	RG11port=2   (depreciated)
+	RG11port2=3
+		now use
+	RG11portName=COM2   (for Windows or /dev/ttyUSB2 for Linux)
+	RG11portName2=COM3   (for Windows or /dev/ttyUSB3 for Linux)
+
+- The default Comm port values are now set to either COM1 or /dev/ttyUSB0 depending on the platform. Hopefully this will prevent some of the confusion of new users.

--- a/CumulusMX/Utils.cs
+++ b/CumulusMX/Utils.cs
@@ -25,6 +25,11 @@ namespace CumulusMX
 		}
 
 
+		public static DateTime RoundTimeUpToInterval(DateTime dateTime, TimeSpan intvl)
+		{
+			return new DateTime((dateTime.Ticks + intvl.Ticks - 1) / intvl.Ticks * intvl.Ticks, dateTime.Kind);
+		}
+
 		public static string ByteArrayToHexString(byte[] ba)
 		{
 			System.Text.StringBuilder hex = new System.Text.StringBuilder(ba.Length * 2);

--- a/CumulusMX/Utils.cs
+++ b/CumulusMX/Utils.cs
@@ -164,5 +164,23 @@ namespace CumulusMX
 			// finally, give up and just return a 0.0.0.0 IP!
 			return IPAddress.Any;
 		}
+
+		public static void RunExternalTask(string task, string parameters, bool wait)
+		{
+			var process = new System.Diagnostics.Process();
+			process.StartInfo.FileName = task;
+			process.StartInfo.Arguments = parameters;
+			process.StartInfo.UseShellExecute = false;
+			//process.StartInfo.RedirectStandardOutput = true;
+			//process.StartInfo.RedirectStandardError = true;
+			process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
+			process.StartInfo.CreateNoWindow = true;
+			process.Start();
+
+			if (wait)
+			{
+				process.WaitForExit();
+			}
+		}
 	}
 }

--- a/CumulusMX/WS2300Station.cs
+++ b/CumulusMX/WS2300Station.cs
@@ -749,9 +749,17 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10.0F + (data[0] & 0xF) / 100.0F) - 30.0;
-			cumulus.LogDataMessage("Indoor temp = " + val);
-			return val;
+			try
+			{
+				var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10.0F + (data[0] & 0xF) / 100.0F) - 30.0;
+				cumulus.LogDataMessage("Indoor temp = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
+
 		}
 
 		/// <summary>
@@ -768,9 +776,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10.0F + (data[0] & 0xF) / 100.0F) - 30.0;
-			cumulus.LogDataMessage("Outdoor temp = " + val);
-			return val;
+			try
+			{
+				var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10.0F + (data[0] & 0xF) / 100.0F) - 30.0;
+				cumulus.LogDataMessage("Outdoor temp = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -788,9 +803,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10.0F + (data[0] & 0xF) / 100.0F) - 30.0;
-			cumulus.LogDataMessage("Dewpoint = " + val);
-			return val;
+			try
+			{
+				var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10.0F + (data[0] & 0xF) / 100.0F) - 30.0;
+				cumulus.LogDataMessage("Dewpoint = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -808,9 +830,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = (data[0] >> 4) * 10 + (data[0] & 0xF);
-			cumulus.LogDataMessage("Indoor humidity = " + val);
-			return val;
+			try
+			{
+				var val = (data[0] >> 4) * 10 + (data[0] & 0xF);
+				cumulus.LogDataMessage("Indoor humidity = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -828,9 +857,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = (data[0] >> 4) * 10 + (data[0] & 0xF);
-			cumulus.LogDataMessage("Outdoor humidity = " + val);
-			return val;
+			try
+			{
+				var val = (data[0] >> 4) * 10 + (data[0] & 0xF);
+				cumulus.LogDataMessage("Outdoor humidity = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -859,17 +895,24 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			if (((data[0] & 0xF7) != 0x00) || //Invalid wind data
-				((data[1] == 0xFF) && (((data[2] & 0xF) == 0) || ((data[2] & 0xF) == 1))))
+			try
+			{
+				if (((data[0] & 0xF7) != 0x00) || //Invalid wind data
+					((data[1] == 0xFF) && (((data[2] & 0xF) == 0) || ((data[2] & 0xF) == 1))))
+					return ERROR;
+
+				//Calculate wind direction
+				direction = (data[2] >> 4) * 22.5;
+
+				//Calculate wind speed
+				var val = (((data[2] & 0xF) << 8) + (data[1])) / 10.0;
+				cumulus.LogDataMessage($"Wind data: Speed = {val}, Direction = {direction}");
+				return val;
+			}
+			catch
+			{
 				return ERROR;
-
-			//Calculate wind direction
-			direction = (data[2] >> 4) * 22.5;
-
-			//Calculate wind speed
-			var val = (((data[2] & 0xF) << 8) + (data[1])) / 10.0;
-			cumulus.LogDataMessage($"Wind data: Speed = {val}, Direction = {direction}");
-			return val;
+			}
 		}
 
 		/// <summary>
@@ -887,9 +930,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10F + (data[0] & 0xF) / 100F) - 30;
-			cumulus.LogDataMessage("Wind chill = " + val);
-			return val;
+			try
+			{
+				var val = ((data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10F + (data[0] & 0xF) / 100F) - 30;
+				cumulus.LogDataMessage("Wind chill = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -908,9 +958,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = (data[2] >> 4) * 1000 + (data[2] & 0xF) * 100 + (data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10F + (data[0] & 0xF) / 100.0;
-			cumulus.LogDataMessage("Rain total = " + val);
-			return val;
+			try
+			{
+				var val = (data[2] >> 4) * 1000 + (data[2] & 0xF) * 100 + (data[1] >> 4) * 10 + (data[1] & 0xF) + (data[0] >> 4) / 10F + (data[0] & 0xF) / 100.0;
+				cumulus.LogDataMessage("Rain total = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -928,9 +985,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = (data[2] & 0xF) * 1000 + (data[1] >> 4) * 100 + (data[1] & 0xF) * 10 + (data[0] >> 4) + (data[0] & 0xF) / 10.0;
-			cumulus.LogDataMessage("Rel pressure = " + val);
-			return val;
+			try
+			{
+				var val = (data[2] & 0xF) * 1000 + (data[1] >> 4) * 100 + (data[1] & 0xF) * 10 + (data[0] >> 4) + (data[0] & 0xF) / 10.0;
+				cumulus.LogDataMessage("Rel pressure = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -948,9 +1012,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = (data[2] & 0xF) * 1000 + (data[1] >> 4) * 100 + (data[1] & 0xF) * 10 + (data[0] >> 4) + (data[0] & 0xF) / 10.0;
-			cumulus.LogDataMessage("Abs pressure = " + val);
-			return val;
+			try
+			{
+				var val = (data[2] & 0xF) * 1000 + (data[1] >> 4) * 100 + (data[1] & 0xF) * 10 + (data[0] >> 4) + (data[0] & 0xF) / 10.0;
+				cumulus.LogDataMessage("Abs pressure = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -969,9 +1040,16 @@ namespace CumulusMX
 			if (Ws2300ReadWithRetries(address, bytes, data, command) != bytes)
 				return ERROR;
 
-			var val = (data[2] & 0xF) * 1000 + (data[1] >> 4) * 100 + (data[1] & 0xF) * 10 + (data[0] >> 4) + (data[0] & 0xF) / 10.0 - 1000;
-			cumulus.LogDataMessage("Pressure offset = " + val);
-			return val;
+			try
+			{
+				var val = (data[2] & 0xF) * 1000 + (data[1] >> 4) * 100 + (data[1] & 0xF) * 10 + (data[0] >> 4) + (data[0] & 0xF) / 10.0 - 1000;
+				cumulus.LogDataMessage("Pressure offset = " + val);
+				return val;
+			}
+			catch
+			{
+				return ERROR;
+			}
 		}
 
 		/// <summary>
@@ -998,11 +1076,19 @@ namespace CumulusMX
 				return ERROR;
 			}
 
-			pressuretrend = presstrendstrings[data[0] >> 4];
-			forecast = forecaststrings[data[0] & 0xF];
-
-			cumulus.LogDataMessage($"Pressure trend = {pressuretrend}, forecast = {forecast}");
-			return 0;
+			try
+			{
+				pressuretrend = presstrendstrings[data[0] >> 4];
+				forecast = forecaststrings[data[0] & 0xF];
+				cumulus.LogDataMessage($"Pressure trend = {pressuretrend}, forecast = {forecast}");
+				return 0;
+			}
+			catch
+			{
+				pressuretrend = "";
+				forecast = "";
+				return ERROR;
+			}
 		}
 
 		/*

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1695,7 +1695,7 @@ namespace CumulusMX
 			CheckForDataStopped();
 
 			CurrentSolarMax = AstroLib.SolarMax(now, (double) cumulus.Longitude, (double) cumulus.Latitude, AltitudeM(cumulus.Altitude), out SolarElevation, cumulus.SolarOptions);
-			
+
 			if (!DataStopped)
 			{
 				if (((Pressure > 0) && TempReadyToPlot && WindReadyToPlot) || cumulus.StationOptions.NoSensorCheck)
@@ -4347,6 +4347,8 @@ namespace CumulusMX
 		public void DoSolarRad(int value, DateTime timestamp)
 		{
 			SolarRad = (value * cumulus.Calib.Solar.Mult) + cumulus.Calib.Solar.Offset;
+			if (SolarRad < 0)
+				SolarRad = 0;
 
 			if (SolarRad > HiLoToday.HighSolar)
 			{
@@ -6317,7 +6319,7 @@ namespace CumulusMX
 			}
 
 			try
-			{ 
+			{
 				// Do 1 hour trends
 				retVals = RecentDataDb.Query<RecentData>("select OutsideTemp, raincounter from RecentData where Timestamp >=? order by Timestamp limit 1", ts.AddHours(-1));
 
@@ -11180,7 +11182,7 @@ namespace CumulusMX
 			// remove trailing comma
 			if (sb[sb.Length - 1] == ',')
 				sb.Length--;
-			
+
 			sb.Append("]}");
 			return sb.ToString();
 		}

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -5438,15 +5438,7 @@ namespace CumulusMX
 					try
 					{
 						// Prepare the process to run
-						ProcessStartInfo start = new ProcessStartInfo();
-						// Enter in the command line arguments
-						start.Arguments = cumulus.DailyParams;
-						// Enter the executable to run, including the complete path
-						start.FileName = cumulus.DailyProgram;
-						// Don"t show a console window
-						start.CreateNoWindow = true;
-						// Run the external process
-						Process.Start(start);
+						Utils.RunExternalTask(cumulus.DailyProgram, cumulus.DailyParams, false);
 					}
 					catch (Exception ex)
 					{

--- a/Updates.txt
+++ b/Updates.txt
@@ -5,6 +5,7 @@ Fixed
 - Disallow negative solar rad values
 - Ecowitt piezo rain sensor (WS90) now supports storm event
 - Davis Vantage VP2/Vue stations no longer download the entire logger contents on start-up when the station logging interval does not match the CMX interval
+- Catch errors in La Crosse WS2300 data handling - specifically fixes reported crashes in forecast data
 
 
 3.22.3 - b3214

--- a/Updates.txt
+++ b/Updates.txt
@@ -4,6 +4,7 @@ Fixed
 - Removing last entry from Third Party custom HTTP lists
 - Disallow negative solar rad values
 - Ecowitt piezo rain sensor (WS90) now supports storm event
+- Davis Vantage VP2/Vue stations no longer download the entire logger contents on start-up when the station logging interval does not match the CMX interval
 
 
 3.22.3 - b3214
@@ -15,7 +16,6 @@ Fixed
 
 Changed
 - The records editors now cope with blank fields (above field 15 - Current Gust) in the monthly log files
-
 
 
 3.22.2 - b3213

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,6 +2,8 @@
 ——————————————
 Fixed
 - Removing last entry from Third Party custom HTTP lists
+- Disallow negative solar rad values
+- Ecowitt piezo rain sensor (WS90) now supports storm event
 
 
 3.22.3 - b3214

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,9 @@
+3.22.4 - b3215
+——————————————
+Fixed
+- Removing last entry from Third Party custom HTTP lists
+
+
 3.22.3 - b3214
 ——————————————
 Fixed

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,6 +6,10 @@ Fixed
 - Ecowitt piezo rain sensor (WS90) now supports storm event
 - Davis Vantage VP2/Vue stations no longer download the entire logger contents on start-up when the station logging interval does not match the CMX interval
 - Catch errors in La Crosse WS2300 data handling - specifically fixes reported crashes in forecast data
+- Added a cache-buster to the default website index page - just upload the new index.htm file
+
+New
+- Adds start-up and shutdown tasks - see Program Settings
 
 
 3.22.3 - b3214


### PR DESCRIPTION
Fixed
- Removing last entry from Third Party custom HTTP lists
- Disallow negative solar rad values
- Ecowitt piezo rain sensor (WS90) now supports storm event
- Davis Vantage VP2/Vue stations no longer download the entire logger contents on start-up when the station logging interval does not match the CMX interval
- Catch errors in La Crosse WS2300 data handling - specifically fixes reported crashes in forecast data
- Added a cache-buster to the default website index page - just upload the new index.htm file

New
- Adds start-up and shutdown tasks - see Program Settings