### PR TITLE
v3.23.1 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ FakesAssemblies/
 ToDo.txt
 /CumulusMX/DataEditor-byDay.cs
 /CumulusMX/WeatherStation-byDay.cs
+/Updates.md

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -427,6 +427,9 @@ namespace CumulusMX
 							case "extrahum.json":
 								await writer.WriteAsync(Station.GetExtraHumGraphData(DateTime.Now));
 								break;
+							case "extradew.json":
+								await writer.WriteAsync(Station.GetExtraDewpointGraphData(DateTime.Now));
+								break;
 							case "soiltemp.json":
 								await writer.WriteAsync(Station.GetSoilTempGraphData(DateTime.Now));
 								break;

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4346,6 +4346,7 @@ namespace CumulusMX
 			WllApiSecret = ini.GetValue("WLL", "WLv2ApiSecret", "");
 			WllStationId = ini.GetValue("WLL", "WLStationId", -1);
 			//if (WllStationId == "-1") WllStationId = "";
+			WllTriggerDataStoppedOnBroadcast = ini.GetValue("WLL", "DataStoppedOnBroadcast", true);
 			WLLAutoUpdateIpAddress = ini.GetValue("WLL", "AutoUpdateIpAddress", true);
 			WllBroadcastDuration = ini.GetValue("WLL", "BroadcastDuration", WllBroadcastDuration);
 			WllBroadcastPort = ini.GetValue("WLL", "BroadcastPort", WllBroadcastPort);
@@ -5665,6 +5666,7 @@ namespace CumulusMX
 			ini.SetValue("WLL", "WLv2ApiKey", WllApiKey);
 			ini.SetValue("WLL", "WLv2ApiSecret", WllApiSecret);
 			ini.SetValue("WLL", "WLStationId", WllStationId);
+			ini.SetValue("WLL", "DataStoppedOnBroadcast", WllTriggerDataStoppedOnBroadcast);
 			ini.SetValue("WLL", "PrimaryRainTxId", WllPrimaryRain);
 			ini.SetValue("WLL", "PrimaryTempHumTxId", WllPrimaryTempHum);
 			ini.SetValue("WLL", "PrimaryWindTxId", WllPrimaryWind);
@@ -6888,7 +6890,7 @@ namespace CumulusMX
 		public string WllApiSecret;
 		public int WllStationId;
 		public int WllParentId;
-
+		public bool WllTriggerDataStoppedOnBroadcast; // trigger a data stopped state if broadcasts stop being received but current data is OK
 		/// <value>Read-only setting, default 20 minutes (1200 sec)</value>
 		public int WllBroadcastDuration = 1200;
 		/// <value>Read-only setting, default 22222</value>

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -7849,7 +7849,7 @@ namespace CumulusMX
 							if (CustomIntvlLogSettings[i].Enabled)
 							{
 								var filename = GetCustomIntvlLogFileName(i, timestamp.AddDays(-1));
-								CopyBackupFile(filename, filename.Replace(logFilePath, ""), true);
+								CopyBackupFile(filename, foldername + filename.Replace(logFilePath, ""), true);
 							}
 						}
 					}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -2499,6 +2499,7 @@ namespace CumulusMX
 						LogMessage($"AWEKAS: ERROR - Response code = {response.StatusCode}, body = {responseBodyAsText}");
 						HttpUploadAlarm.LastError = $"AWEKAS: HTTP Response code = {response.StatusCode}, body = {responseBodyAsText}";
 						HttpUploadAlarm.Triggered = true;
+						return;
 					}
 					else
 					{

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4660,6 +4660,7 @@ namespace CumulusMX
 			GraphOptions.TempSumVisible2 = ini.GetValue("Graphs", "TempSumVisible2", true);
 			GraphOptions.ExtraTempVisible = ini.GetValue("Graphs", "ExtraTempVisible", new bool[10]);
 			GraphOptions.ExtraHumVisible = ini.GetValue("Graphs", "ExtraHumVisible", new bool[10]);
+			GraphOptions.ExtraDewPointVisible = ini.GetValue("Graphs", "ExtraDewPointVisible", new bool[10]);
 			GraphOptions.SoilTempVisible = ini.GetValue("Graphs", "SoilTempVisible", new bool[16]);
 			GraphOptions.SoilMoistVisible = ini.GetValue("Graphs", "SoilMoistVisible", new bool[16]);
 			GraphOptions.UserTempVisible = ini.GetValue("Graphs", "UserTempVisible", new bool[8]);
@@ -6320,6 +6321,7 @@ namespace CumulusMX
 			ini.SetValue("Graphs", "TempSumVisible2", GraphOptions.TempSumVisible2);
 			ini.SetValue("Graphs", "ExtraTempVisible", GraphOptions.ExtraTempVisible);
 			ini.SetValue("Graphs", "ExtraHumVisible", GraphOptions.ExtraHumVisible);
+			ini.SetValue("Graphs", "ExtraDewPointVisible", GraphOptions.ExtraDewPointVisible);
 			ini.SetValue("Graphs", "SoilTempVisible", GraphOptions.SoilTempVisible);
 			ini.SetValue("Graphs", "SoilMoistVisible", GraphOptions.SoilMoistVisible);
 			ini.SetValue("Graphs", "UserTempVisible", GraphOptions.UserTempVisible);
@@ -11432,6 +11434,7 @@ namespace CumulusMX
 		public bool TempSumVisible2 { get; set; }
 		public bool[] ExtraTempVisible = new bool[10];
 		public bool[] ExtraHumVisible = new bool[10];
+		public bool[] ExtraDewPointVisible = new bool[10];
 		public bool[] SoilTempVisible = new bool[16];
 		public bool[] SoilMoistVisible = new bool[16];
 		public bool[] UserTempVisible = new bool[8];

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -3568,7 +3568,7 @@ namespace CumulusMX
 			var InvC = new CultureInfo("");
 			var lastMonth = -1;
 			var lines = new List<string>();
-			var logfile = "";
+			var logfile = string.Empty;
 
 			using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
 			{
@@ -3579,6 +3579,17 @@ namespace CumulusMX
 
 			if (newData.action == "Edit")
 			{
+				// Get the log file date
+				var ts = Utils.ddmmyyStrToDate(newData.data[0][0]);
+				var fileDate = new DateTime(ts.Year, ts.Month, 15);
+
+				logfile = (newData.extra ? cumulus.GetExtraLogFileName(ts) : cumulus.GetLogFileName(ts));
+
+				// read the log file into a List
+				lines.Clear();
+				lines = File.ReadAllLines(logfile).ToList();
+
+
 				var lineNum = newData.lines[0] - 1; // our List is zero relative
 
 				// replace the edited line

--- a/CumulusMX/DataStruct.cs
+++ b/CumulusMX/DataStruct.cs
@@ -717,7 +717,7 @@ namespace CumulusMX
 		[DataMember(Name = "TempTrend")]
 		public string TempTrendRounded
 		{
-			get => TempTrend.ToString(cumulus.TempFormat);
+			get => TempTrend.ToString("+0.0;-0.0;0.0");
 			set { }
 		}
 
@@ -727,7 +727,11 @@ namespace CumulusMX
 		[DataMember(Name = "PressTrend")]
 		public string PressTrendRounded
 		{
-			get => PressTrend.ToString(cumulus.PressFormat);
+			get {
+				var dps = new string('0', cumulus.PressDPlaces);
+				var format = $"+0.{dps};-0.{dps};0.{dps}";
+				return PressTrend.ToString(format);
+			}
 			set { }
 		}
 

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.23.0 - Build 3220")]
+[assembly: AssemblyDescription("Version 3.23.1 - Build 3221")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
-[assembly: AssemblyCopyright("Copyright ©  2015-2022 Cumulus MX")]
+[assembly: AssemblyCopyright("Copyright ©  2015-2023 Cumulus MX")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.23.0.3220")]
-[assembly: AssemblyFileVersion("3.23.0.3220")]
+[assembly: AssemblyVersion("3.23.1.3221")]
+[assembly: AssemblyFileVersion("3.23.1.3221")]

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -413,7 +413,8 @@ namespace CumulusMX
 			var wllAdvanced = new JsonStationSettingsWLLAdvanced()
 			{
 				raingaugetype = cumulus.DavisOptions.RainGaugeType,
-				tcpport = cumulus.DavisOptions.TCPPort
+				tcpport = cumulus.DavisOptions.TCPPort,
+				datastopped = cumulus.WllTriggerDataStoppedOnBroadcast
 			};
 
 			var wllApi = new JsonStationSettingsWLLApi()
@@ -985,6 +986,8 @@ namespace CumulusMX
 
 						cumulus.DavisOptions.RainGaugeType = settings.daviswll.advanced.raingaugetype;
 						cumulus.DavisOptions.TCPPort = settings.daviswll.advanced.tcpport;
+						cumulus.WllTriggerDataStoppedOnBroadcast = settings.daviswll.advanced.datastopped;
+
 
 						// Automatically enable extra logging?
 						// Should we auto disable it too?
@@ -1850,6 +1853,7 @@ namespace CumulusMX
 	{
 		public int raingaugetype { get; set; }
 		public int tcpport { get; set; }
+		public bool datastopped { get; set; }
 	}
 
 	internal class JsonStationSettingsWLLNetwork

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -350,6 +350,11 @@ namespace CumulusMX
 				sensors = cumulus.GraphOptions.ExtraHumVisible
 			};
 
+			var graphDataExtraDP= new JsonStationSettingsGraphDataExtraSensors()
+			{
+				sensors = cumulus.GraphOptions.ExtraDewPointVisible
+			};
+
 			var graphDataSoilTemp = new JsonStationSettingsGraphDataExtraSensors()
 			{
 				sensors = cumulus.GraphOptions.SoilTempVisible
@@ -385,6 +390,7 @@ namespace CumulusMX
 				degreedays = graphDataDegreeDays,
 				extratemp = graphDataExtraTemp,
 				extrahum = graphDataExtraHum,
+				extradew = graphDataExtraDP,
 				soiltemp = graphDataSoilTemp,
 				soilmoist = graphDataSoilMoist,
 				usertemp = graphDataUserTemp,
@@ -641,6 +647,7 @@ namespace CumulusMX
 					cumulus.GraphOptions.GrowingDegreeDaysVisible2 = settings.Graphs.datavisibility.degreedays.graphGrowingDegreeDaysVis2;
 					cumulus.GraphOptions.ExtraTempVisible = settings.Graphs.datavisibility.extratemp.sensors;
 					cumulus.GraphOptions.ExtraHumVisible = settings.Graphs.datavisibility.extrahum.sensors;
+					cumulus.GraphOptions.ExtraDewPointVisible = settings.Graphs.datavisibility.extradew.sensors;
 					cumulus.GraphOptions.SoilTempVisible = settings.Graphs.datavisibility.soiltemp.sensors;
 					cumulus.GraphOptions.SoilMoistVisible = settings.Graphs.datavisibility.soilmoist.sensors;
 					cumulus.GraphOptions.UserTempVisible = settings.Graphs.datavisibility.usertemp.sensors;
@@ -1963,6 +1970,7 @@ namespace CumulusMX
 		public JsonStationSettingsGraphDataDegreeDays degreedays { get; set; }
 		public JsonStationSettingsGraphDataExtraSensors extratemp { get; set; }
 		public JsonStationSettingsGraphDataExtraSensors extrahum { get; set; }
+		public JsonStationSettingsGraphDataExtraSensors extradew { get; set; }
 		public JsonStationSettingsGraphDataExtraSensors soiltemp { get; set; }
 		public JsonStationSettingsGraphDataExtraSensors soilmoist { get; set; }
 		public JsonStationSettingsGraphDataExtraSensors usertemp { get; set; }

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2715,14 +2715,14 @@ namespace CumulusMX
 					sbExt[i] = new StringBuilder($"\"{cumulus.ExtraTempCaptions[i+1]}\":[");
 			}
 
-			var datefrom = ts.AddHours(-cumulus.GraphHours);
-
-			// get the log file name to start
-			var logFile = cumulus.GetExtraLogFileName(datefrom);
-
 			var finished = false;
 			var entrydate = new DateTime();
 			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] +1));
+			var datefrom = ts.AddHours(-cumulus.GraphHours);
+			var fileDate = datefrom;
+
+			// get the log file name to start
+			var logFile = cumulus.GetExtraLogFileName(fileDate);
 
 			// 0  Date in the form dd/mm/yy (the slash may be replaced by a dash in some cases)
 			// 1  Current time - hh:mm
@@ -2797,20 +2797,144 @@ namespace CumulusMX
 					}
 				}
 
-				if (entrydate >= dateto || datefrom > dateto.AddMonths(1))
+				if (entrydate >= dateto || fileDate > dateto)
 				{
 					finished = true;
 				}
 				else
 				{
-					datefrom = datefrom.AddMonths(1);
-					logFile = cumulus.GetExtraLogFileName(datefrom);
+					fileDate = fileDate.AddMonths(1);
+					logFile = cumulus.GetExtraLogFileName(fileDate);
 				}
 			}
 
 			for (var i = 0; i < cumulus.GraphOptions.ExtraTempVisible.Length; i++)
 			{
 				if (cumulus.GraphOptions.ExtraTempVisible[i])
+				{
+					if (sbExt[i][sbExt[i].Length - 1] == ',')
+						sbExt[i].Length--;
+
+					sbExt[i].Append(']');
+					sb.Append((append ? "," : "") + sbExt[i]);
+					append = true;
+				}
+			}
+
+			sb.Append('}');
+			return sb.ToString();
+		}
+
+		public string GetExtraDewpointGraphData(DateTime ts)
+		{
+			bool append = false;
+			var InvC = new CultureInfo("");
+			var sb = new StringBuilder("{", 10240);
+
+			StringBuilder[] sbExt = new StringBuilder[cumulus.GraphOptions.ExtraDewPointVisible.Length];
+
+			for (var i = 0; i < cumulus.GraphOptions.ExtraDewPointVisible.Length; i++)
+			{
+				if (cumulus.GraphOptions.ExtraDewPointVisible[i])
+					sbExt[i] = new StringBuilder($"\"{cumulus.ExtraDPCaptions[i + 1]}\":[");
+			}
+
+			var finished = false;
+			var entrydate = new DateTime();
+			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var datefrom = ts.AddHours(-cumulus.GraphHours);
+			var fileDate = datefrom;
+
+			// get the log file name to start
+			var logFile = cumulus.GetExtraLogFileName(fileDate);
+
+			// 0  Date in the form dd/mm/yy (the slash may be replaced by a dash in some cases)
+			// 1  Current time - hh:mm
+			// 2-11  Temperature 1-10
+			// 12-21 Humidity 1-10
+			// 22-31 Dew point 1-10
+			// 32-35 Soil temp 1-4
+			// 36-39 Soil moisture 1-4
+			// 40-41 Leaf temp 1-2
+			// 42-43 Leaf wetness 1-2
+			// 44-55 Soil temp 5-16
+			// 56-67 Soil moisture 5-16
+			// 68-71 Air quality 1-4
+			// 72-75 Air quality avg 1-4
+			// 76-83 User temperature 1-8
+			// 84  CO2
+			// 85  CO2 avg
+			// 86  CO2 pm2.5
+			// 87  CO2 pm2.5 avg
+			// 88  CO2 pm10
+			// 89  CO2 pm10 avg
+			// 90  CO2 temp
+			// 91  CO2 hum
+
+			while (!finished)
+			{
+				if (File.Exists(logFile))
+				{
+					int linenum = 0;
+					int errorCount = 0;
+
+					try
+					{
+						var lines = File.ReadAllLines(logFile);
+
+						foreach (var line in lines)
+						{
+							try
+							{
+								// process each record in the file
+								linenum++;
+								var st = new List<string>(Regex.Split(line, CultureInfo.CurrentCulture.TextInfo.ListSeparator));
+								entrydate = Utils.ddmmyyhhmmStrToDate(st[0], st[1]);
+
+								if (entrydate >= datefrom)
+								{
+									// entry is from required period
+									var temp = 0.0;
+									for (var i = 0; i < cumulus.GraphOptions.ExtraDewPointVisible.Length; i++)
+									{
+										if (cumulus.GraphOptions.ExtraDewPointVisible[i] && double.TryParse(st[i + 22], out temp))
+											sbExt[i].Append($"[{DateTimeToUnix(entrydate) * 1000},{temp.ToString(cumulus.TempFormat, InvC)}],");
+									}
+								}
+							}
+							catch (Exception ex)
+							{
+								errorCount++;
+								cumulus.LogErrorMessage($"GetExtraDewpointGraphData: Error at line {linenum} of {logFile}. Error - {ex.Message}");
+								if (errorCount > 10)
+								{
+									cumulus.LogMessage($"GetExtraDewpointGraphData: More than 10 errors in the file {logFile}, aborting processing");
+									finished = true;
+									break;
+								}
+							}
+						}
+					}
+					catch (Exception ex)
+					{
+						cumulus.LogErrorMessage($"GetExtraDewpointGraphData: Error reading {logFile}. Error - {ex.Message}");
+					}
+				}
+
+				if (entrydate >= dateto || fileDate > dateto)
+				{
+					finished = true;
+				}
+				else
+				{
+					fileDate = fileDate.AddMonths(1);
+					logFile = cumulus.GetExtraLogFileName(fileDate);
+				}
+			}
+
+			for (var i = 0; i < cumulus.GraphOptions.ExtraDewPointVisible.Length; i++)
+			{
+				if (cumulus.GraphOptions.ExtraDewPointVisible[i])
 				{
 					if (sbExt[i][sbExt[i].Length - 1] == ',')
 						sbExt[i].Length--;
@@ -2839,14 +2963,15 @@ namespace CumulusMX
 					sbExt[i] = new StringBuilder($"\"{cumulus.ExtraHumCaptions[i + 1]}\":[");
 			}
 
-			var datefrom = ts.AddHours(-cumulus.GraphHours);
-
-			// get the log file name to start
-			var logFile = cumulus.GetExtraLogFileName(datefrom);
 
 			var finished = false;
 			var entrydate = new DateTime();
 			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var datefrom = ts.AddHours(-cumulus.GraphHours);
+			var fileDate = datefrom;
+
+			// get the log file name to start
+			var logFile = cumulus.GetExtraLogFileName(datefrom);
 
 			// 0  Date in the form dd/mm/yy (the slash may be replaced by a dash in some cases)
 			// 1  Current time - hh:mm
@@ -2921,14 +3046,14 @@ namespace CumulusMX
 					}
 				}
 
-				if (entrydate >= dateto || datefrom > dateto.AddMonths(1))
+				if (entrydate >= dateto || fileDate > dateto)
 				{
 					finished = true;
 				}
 				else
 				{
-					datefrom = datefrom.AddMonths(1);
-					logFile = cumulus.GetExtraLogFileName(datefrom);
+					fileDate = fileDate.AddMonths(1);
+					logFile = cumulus.GetExtraLogFileName(fileDate);
 				}
 			}
 
@@ -2963,14 +3088,14 @@ namespace CumulusMX
 					sbExt[i] = new StringBuilder($"\"{cumulus.SoilTempCaptions[i + 1]}\":[");
 			}
 
-			var datefrom = ts.AddHours(-cumulus.GraphHours);
-
-			// get the log file name to start
-			var logFile = cumulus.GetExtraLogFileName(datefrom);
-
 			var finished = false;
 			var entrydate = new DateTime();
 			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var datefrom = ts.AddHours(-cumulus.GraphHours);
+			var fileDate = datefrom;
+
+			// get the log file name to start
+			var logFile = cumulus.GetExtraLogFileName(datefrom);
 
 			// 0  Date in the form dd/mm/yy (the slash may be replaced by a dash in some cases)
 			// 1  Current time - hh:mm
@@ -3050,14 +3175,14 @@ namespace CumulusMX
 					}
 				}
 
-				if (entrydate >= dateto || datefrom > dateto.AddMonths(1))
+				if (entrydate >= dateto || fileDate > dateto)
 				{
 					finished = true;
 				}
 				else
 				{
-					datefrom = datefrom.AddMonths(1);
-					logFile = cumulus.GetExtraLogFileName(datefrom);
+					fileDate = fileDate.AddMonths(1);
+					logFile = cumulus.GetExtraLogFileName(fileDate);
 				}
 			}
 
@@ -3092,14 +3217,14 @@ namespace CumulusMX
 					sbExt[i] = new StringBuilder($"\"{cumulus.SoilMoistureCaptions[i + 1]}\":[");
 			}
 
-			var datefrom = ts.AddHours(-cumulus.GraphHours);
-
-			// get the log file name to start
-			var logFile = cumulus.GetExtraLogFileName(datefrom);
-
 			var finished = false;
 			var entrydate = new DateTime();
 			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var datefrom = ts.AddHours(-cumulus.GraphHours);
+			var fileDate = datefrom;
+
+			// get the log file name to start
+			var logFile = cumulus.GetExtraLogFileName(datefrom);
 
 			// 0  Date in the form dd/mm/yy (the slash may be replaced by a dash in some cases)
 			// 1  Current time - hh:mm
@@ -3179,14 +3304,14 @@ namespace CumulusMX
 					}
 				}
 
-				if (entrydate >= dateto || datefrom > dateto.AddMonths(1))
+				if (entrydate >= dateto || fileDate > dateto)
 				{
 					finished = true;
 				}
 				else
 				{
-					datefrom = datefrom.AddMonths(1);
-					logFile = cumulus.GetExtraLogFileName(datefrom);
+					fileDate = fileDate.AddMonths(1);
+					logFile = cumulus.GetExtraLogFileName(fileDate);
 				}
 			}
 
@@ -3221,14 +3346,14 @@ namespace CumulusMX
 					sbExt[i] = new StringBuilder($"\"{cumulus.UserTempCaptions[i + 1]}\":[");
 			}
 
-			var datefrom = ts.AddHours(-cumulus.GraphHours);
-
-			// get the log file name to start
-			var logFile = cumulus.GetExtraLogFileName(datefrom);
-
 			var finished = false;
 			var entrydate = new DateTime();
 			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var datefrom = ts.AddHours(-cumulus.GraphHours);
+			var fileDate = datefrom;
+
+			// get the log file name to start
+			var logFile = cumulus.GetExtraLogFileName(datefrom);
 
 			// 0  Date in the form dd/mm/yy (the slash may be replaced by a dash in some cases)
 			// 1  Current time - hh:mm
@@ -3303,14 +3428,14 @@ namespace CumulusMX
 					}
 				}
 
-				if (entrydate >= dateto || datefrom > dateto.AddMonths(1))
+				if (entrydate >= dateto || fileDate > dateto)
 				{
 					finished = true;
 				}
 				else
 				{
-					datefrom = datefrom.AddMonths(1);
-					logFile = cumulus.GetExtraLogFileName(datefrom);
+					fileDate = fileDate.AddMonths(1);
+					logFile = cumulus.GetExtraLogFileName(fileDate);
 				}
 			}
 
@@ -3347,14 +3472,15 @@ namespace CumulusMX
 			var sbHum = new StringBuilder("\"Humidity\":[");
 
 
+			var finished = false;
+			var entrydate = new DateTime();
+			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
 			var datefrom = ts.AddHours(-cumulus.GraphHours);
+			var fileDate = datefrom;
 
 			// get the log file name to start
 			var logFile = cumulus.GetExtraLogFileName(datefrom);
 
-			var finished = false;
-			var entrydate = new DateTime();
-			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
 
 			// 0  Date in the form dd/mm/yy (the slash may be replaced by a dash in some cases)
 			// 1  Current time - hh:mm
@@ -3447,14 +3573,14 @@ namespace CumulusMX
 					}
 				}
 
-				if (entrydate >= dateto || datefrom > dateto.AddMonths(1))
+				if (entrydate >= dateto || fileDate > dateto)
 				{
 					finished = true;
 				}
 				else
 				{
-					datefrom = datefrom.AddMonths(1);
-					logFile = cumulus.GetExtraLogFileName(datefrom);
+					fileDate = fileDate.AddMonths(1);
+					logFile = cumulus.GetExtraLogFileName(fileDate);
 				}
 			}
 
@@ -12078,7 +12204,7 @@ namespace CumulusMX
 				for (var i = 0; i < cumulus.GraphOptions.ExtraTempVisible.Length; i++)
 				{
 					if (cumulus.GraphOptions.ExtraTempVisible[i])
-						json.Append($"\"{cumulus.ExtraTempCaptions[i+1]}\",");
+						json.Append($"\"{cumulus.ExtraTempCaptions[i + 1]}\",");
 				}
 				if (json[json.Length - 1] == ',')
 					json.Length--;
@@ -12100,6 +12226,22 @@ namespace CumulusMX
 
 				json.Append(']');
 			}
+
+			// Extra dew point
+			if (cumulus.GraphOptions.ExtraDewPointVisible.Contains(true))
+			{
+				json.Append(",\"ExtraDewPoint\":[");
+				for (var i = 0; i < cumulus.GraphOptions.ExtraDewPointVisible.Length; i++)
+				{
+					if (cumulus.GraphOptions.ExtraDewPointVisible[i])
+						json.Append($"\"{cumulus.ExtraDPCaptions[i + 1]}\",");
+				}
+				if (json[json.Length - 1] == ',')
+					json.Length--;
+
+				json.Append(']');
+			}
+
 
 			// Soil Temp
 			if (cumulus.GraphOptions.SoilTempVisible.Contains(true))

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -9969,9 +9969,9 @@ namespace CumulusMX
 
 			if (cumulus.AWEKAS.SendSoilTemp)
 			{
-				if (started) sb.Append('&'); else started = true;
 				for (var i = 1; i <= 4; i++)
 				{
+					if (started) sb.Append('&'); else started = true;
 					sb.Append($"soiltemp{i}=" + ConvertUserTempToC(SoilTemp[i]).ToString("F1", InvC));
 				}
 			}

--- a/Updates.txt
+++ b/Updates.txt
@@ -15,6 +15,9 @@ Fixed
 - Extra sensor graphs stopping at month end
 - Start-up/rollover backups were copying Custom logs to the CMX root folder rather than the backup folder
 - Davis WLL not updating the gust value if broadcast data stops being received
+- AWEKAS:
+	- Missing "&" on soil temperatures
+	- producing an exception message when it has already logged the response as invalid
 
 
 3.23.0 - b3220

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,7 +7,7 @@ New
 Changed
 - Davis WLL now fully falls back to the local API current conditions for rain and wind data if broadcasts stop being received for 30 seconds
 	- There is now a new Advanced setting for the WLL: Trigger DataStopped on Broadcast stop
-		Previously if broadcast stopped being received, a full DataStopped condition and alarm was triggered
+		Previously if broadcasts stopped being received, a full DataStopped condition and alarm was triggered
 		Now CMX falls back to using the local API for all data
 		This new configuration setting allows you set the DataStopped only when both broadcasts AND local API responses stop being received
 
@@ -19,6 +19,7 @@ Fixed
 	- Missing "&" on soil temperatures
 	- producing an exception message when it has already logged the response as invalid
 - Log file editor broken in v3.23.0
+
 
 3.23.0 - b3220
 ——————————————

--- a/Updates.txt
+++ b/Updates.txt
@@ -18,7 +18,7 @@ Fixed
 - AWEKAS:
 	- Missing "&" on soil temperatures
 	- producing an exception message when it has already logged the response as invalid
-
+- Log file editor broken in v3.23.0
 
 3.23.0 - b3220
 ——————————————

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,6 +6,7 @@ New
 
 Fixed
 - Extra sensor graphs stopping at month end
+- Start-up/rollover backups were copying Custom logs to the CMX root folder rather than the backup folder
 
 
 3.23.0 - b3220

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,11 +2,19 @@
 ——————————————
 New
 - Adds dew point to extra sensor graphing
-- Add extra sensors to the dashboard selecta-a-chart
+- Add extra sensors to the dashboard select-a-chart
+
+Changed
+- Davis WLL now fully falls back to the local API current conditions for rain and wind data if broadcasts stop being received for 30 seconds
+	- There is now a new Advanced setting for the WLL: Trigger DataStopped on Broadcast stop
+		Previously if broadcast stopped being received, a full DataStopped condition and alarm was triggered
+		Now CMX falls back to using the local API for all data
+		This new configuration setting allows you set the DataStopped only when both broadcasts AND local API responses stop being received
 
 Fixed
 - Extra sensor graphs stopping at month end
 - Start-up/rollover backups were copying Custom logs to the CMX root folder rather than the backup folder
+- Davis WLL not updating the gust value if broadcast data stops being received
 
 
 3.23.0 - b3220

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,13 @@
+3.23.1 - b3221
+——————————————
+New
+- Adds dew point to extra sensor graphing
+- Add extra sensors to the dashboard selecta-a-chart
+
+Fixed
+- Extra sensor graphs stopping at month end
+
+
 3.23.0 - b3220
 ——————————————
 New


### PR DESCRIPTION
New
- Adds dew point to extra sensor graphing
- Add extra sensors to the dashboard select-a-chart

Changed
- Davis WLL now fully falls back to the local API current conditions for rain and wind data if broadcasts stop being received for 30 seconds
	- There is now a new Advanced setting for the WLL: Trigger DataStopped on Broadcast stop
		Previously if broadcasts stopped being received, a full DataStopped condition and alarm was triggered
		Now CMX falls back to using the local API for all data
		This new configuration setting allows you set the DataStopped only when both broadcasts AND local API responses stop being received

Fixed
- Extra sensor graphs stopping at month end
- Start-up/rollover backups were copying Custom logs to the CMX root folder rather than the backup folder
- Davis WLL not updating the gust value if broadcast data stops being received
- AWEKAS:
	- Missing "&" on soil temperatures
	- producing an exception message when it has already logged the response as invalid
- Log file editor broken in v3.23.0