### PR TITLE
v3.24.2

### DIFF
--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -57,6 +57,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowedReferenceRelatedFileExtensions>".pdb"=""</AllowedReferenceRelatedFileExtensions>
     <DebugSymbols>false</DebugSymbols>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup>

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -2078,7 +2078,7 @@ namespace CumulusMX
 			bool midnightraindone = luhour == 0;
 
 			// work out the next logger interval after the last CMX update
-			var nextLoggerTime = Utils.RoundTimeUpToInterval(cumulus.LastUpdateTime, TimeSpan.FromMinutes(loggerInterval));
+			var nextLoggerTime = Utils.RoundTimeUpToInterval(cumulus.LastUpdateTime.AddMinutes(-1), TimeSpan.FromMinutes(loggerInterval));
 
 			// check if the calculated logger time is later than now!
 			if (nextLoggerTime > DateTime.Now)

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -259,7 +259,7 @@ namespace CumulusMX
 				// Create a current conditions thread to poll readings every 10 seconds as temperature updates every 10 seconds
 				GetWllCurrent(null, null);
 				tmrCurrent.Elapsed += GetWllCurrent;
-				tmrCurrent.Interval = 10 * 1000;  // Every 10 seconds
+				tmrCurrent.Interval = 20 * 1000;  // Every 10 seconds
 				tmrCurrent.AutoReset = true;
 				tmrCurrent.Start();
 
@@ -910,15 +910,20 @@ namespace CumulusMX
 												WindRecent[nextwind].Timestamp = dateTime;
 												nextwind = (nextwind + 1) % MaxWindRecent;
 
-												RecentMaxGust = gustCal;
+												if (broadcastStopped)
+												{
+													// if we are not receiving live broadcasts, then use current gust value)
+													RecentMaxGust = gustCal;
+												}
 											}
 										}
 									}
 									else if (!CalcRecentMaxGust)
 									{
 										// Check for spikes, and set highs
-										if (CheckHighGust(gustCal, gustDir, dateTime))
+										if (CheckHighGust(gustCal, gustDir, dateTime) && broadcastStopped)
 										{
+											// if we are not receiving live broadcasts, then use current gust value
 											RecentMaxGust = gustCal;
 										}
 									}

--- a/CumulusMX/ProgramSettings.cs
+++ b/CumulusMX/ProgramSettings.cs
@@ -143,6 +143,13 @@ namespace CumulusMX
 				cumulus.ProgramOptions.TimeFormat = settings.culture.timeFormat;
 				cumulus.ProgramOptions.Culture.RemoveSpaceFromDateSeparator = settings.culture.removespacefromdateseparator;
 
+				if (cumulus.ProgramOptions.TimeFormat == "t")
+					cumulus.ProgramOptions.TimeFormatLong = "T";
+				else if (cumulus.ProgramOptions.TimeFormat == "h:mm tt")
+					cumulus.ProgramOptions.TimeFormatLong = "h:mm:ss tt";
+				else
+					cumulus.ProgramOptions.TimeFormatLong = "HH:mm:ss";
+
 
 				if (cumulus.ProgramOptions.Culture.RemoveSpaceFromDateSeparator && CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator.Contains(" "))
 				{

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.24.1 - Build 3234")]
+[assembly: AssemblyDescription("Version 3.24.2 - Build 3235")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.24.1.3234")]
-[assembly: AssemblyFileVersion("3.24.1.3234")]
+[assembly: AssemblyVersion("3.24.2.3235")]
+[assembly: AssemblyFileVersion("3.24.2.3235")]

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2194,6 +2194,7 @@ namespace CumulusMX
 		public void CreateEodGraphDataFiles()
 		{
 			string json = "";
+
 			for (var i = 0; i < cumulus.GraphDataEodFiles.Length; i++)
 			{
 				if (cumulus.GraphDataEodFiles[i].Create)
@@ -2203,20 +2204,17 @@ namespace CumulusMX
 					try
 					{
 						var dest = cumulus.GraphDataEodFiles[i].LocalPath + cumulus.GraphDataEodFiles[i].LocalFileName;
-						using (var file = new StreamWriter(dest, false))
-						{
-							file.WriteLine(json);
-							file.Close();
-						}
-						// Now set the flag that upload is required (if enabled)
-						cumulus.GraphDataEodFiles[i].FtpRequired = true;
-						cumulus.GraphDataEodFiles[i].CopyRequired = true;
+						File.WriteAllText(dest, json);
 					}
 					catch (Exception ex)
 					{
 						cumulus.LogMessage($"Error writing {cumulus.GraphDataEodFiles[i].LocalFileName}: {ex}");
 					}
 				}
+
+				// Now set the flag that upload is required (if enabled)
+				cumulus.GraphDataEodFiles[i].FtpRequired = true;
+				cumulus.GraphDataEodFiles[i].CopyRequired = true;
 			}
 		}
 
@@ -13541,7 +13539,7 @@ namespace CumulusMX
 				HiLoToday.LowAppTemp, HiLoToday.HighAppTempTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.LowAppTempTime.ToString(cumulus.ProgramOptions.TimeFormat), (int)Math.Round(CurrentSolarMax),
 				AllTime.HighPress.Val, AllTime.LowPress.Val, SunshineHours, CompassPoint(DominantWindBearing), LastRainTip,
 				HiLoToday.HighHourlyRain, HiLoToday.HighHourlyRainTime.ToString(cumulus.ProgramOptions.TimeFormat), "F" + cumulus.Beaufort(HiLoToday.HighWind), "F" + cumulus.Beaufort(WindAverage),
-				cumulus.BeaufortDesc(WindAverage), LastDataReadTimestamp.ToString("T"), DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
+				cumulus.BeaufortDesc(WindAverage), LastDataReadTimestamp.ToString(cumulus.ProgramOptions.TimeFormatLong), DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
 				cumulus.LowTempAlarm.Triggered, cumulus.HighTempAlarm.Triggered, cumulus.TempChangeAlarm.UpTriggered, cumulus.TempChangeAlarm.DownTriggered, cumulus.HighRainTodayAlarm.Triggered, cumulus.HighRainRateAlarm.Triggered,
 				cumulus.LowPressAlarm.Triggered, cumulus.HighPressAlarm.Triggered, cumulus.PressChangeAlarm.UpTriggered, cumulus.PressChangeAlarm.DownTriggered, cumulus.HighGustAlarm.Triggered, cumulus.HighWindAlarm.Triggered,
 				cumulus.SensorAlarm.Triggered, cumulus.BatteryLowAlarm.Triggered, cumulus.SpikeAlarm.Triggered, cumulus.UpgradeAlarm.Triggered, cumulus.HttpUploadAlarm.Triggered, cumulus.MySqlUploadAlarm.Triggered, cumulus.IsRainingAlarm.Triggered,

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,21 @@
+3.24.2 - b3235
+——————————————
+New
+- Extra Files now allows you to use the variables <custinterval1> thru <custinterval10> in the source and destination fields to specify custom log files to be uploaded/copied
+- Copy/Upload Now! gets a new option to transfer the latest NOAA monthly/year reports
+
+Changed
+- Copy/Upload Now! the upload of full rather than incremental versions of graph data files is now optional
+
+Fixed
+- Davis VP2 logger suppression of full logger downloads if CMX is stopped and immediately restarted fractionally after a logging interval
+- Extra Files with EOD flag having "tmp" appended to all source files
+- Not running as a 64 bit application on Windows
+- NOAA report PHP uploads were no using the UTF8 flag
+- Davis WLL using "stale" current wind gust data
+- Daily graphs not being uploaded/copied after day reset
+
+
 3.24.1 - b3234
 ——————————————
 New


### PR DESCRIPTION
New
- Extra Files now allows you to use the variables <custinterval1> thru <custinterval10> in the source and destination fields to specify custom log files to be uploaded/copied
- Copy/Upload Now! gets a new option to transfer the latest NOAA monthly/year reports

Changed
- Copy/Upload Now! the upload of full rather than incremental versions of graph data files is now optional

Fixed
- Davis VP2 logger suppression of full logger downloads if CMX is stopped and immediately restarted fractionally after a logging interval
- Extra Files with EOD flag having "tmp" appended to all source files
- Not running as a 64 bit application on Windows
- NOAA report PHP uploads were no using the UTF8 flag
- Davis WLL using "stale" current wind gust data
- Daily graphs not being uploaded/copied after day reset