### PR TITLE
mqtt: only publish when message has changed for dataupdates

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -13837,6 +13837,7 @@ namespace CumulusMX
 		public string topic { get; set; }
 		public string data { get; set; }
 		public bool retain { get; set; }
+		public string doNotTriggerOnTags { get; set; }
 	}
 
 	public class MySqlGeneralSettings

--- a/CumulusMX/MqttPublisher.cs
+++ b/CumulusMX/MqttPublisher.cs
@@ -117,7 +117,6 @@ namespace CumulusMX
 		public static void UpdateMQTTfeed(string feedType)
 		{
 			var template = "mqtt/";
-			bool useAltResult = false;
 
 			if (feedType == "Interval")
 			{
@@ -143,7 +142,7 @@ namespace CumulusMX
 			{
 				foreach (var feed in templateObj.topics)
 				{
-					useAltResult = false;
+					bool useAltResult = false;
 					var mqttTokenParser = new TokenParser { Encoding = new System.Text.UTF8Encoding(false) };
 
 					if ((feedType == "DataUpdate") && (feed.doNotTriggerOnTags != null))
@@ -177,7 +176,6 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine(ex.ToString());
 				cumulus.LogMessage($"UpdateMQTTfeed: Error process the template file [{template}], error = {ex.Message}");
 			}
 		}


### PR DESCRIPTION
This change introduces a default change to MQTT DataUpdates.  In the existing code, DataUpdates are published whenever the station reports - even if the data in the topics' messages has not changed.  This creates needless mqtt publishes for when data is not changing.

This change caches all of the topics and messages that are published for DataUpdates into a dictionary, taking care to not track time-based webtags.  It then compares the message with what was last published.  If there is no-last-published message, or if is different, then the message is published and the dictionary updated.

I made the changes the default because I think this is more in keeping with the general use of MQTT: messages are published on topics when they have new data to share with subscribers.