### PR TITLE
v3.25.1

### DIFF
--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -118,8 +118,7 @@ namespace CumulusMX
 							try
 							{
 								// Prepare the process to run
-								var parser = new TokenParser();
-								parser.OnToken += cumulus.TokenParserOnToken;
+								var parser = new TokenParser(cumulus.TokenParserOnToken);
 								parser.InputText = ActionParams;
 								var args = parser.ToStringFromString();
 								cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {args}");
@@ -276,8 +275,7 @@ namespace CumulusMX
 						try
 						{
 							// Prepare the process to run
-							var parser = new TokenParser();
-							parser.OnToken += cumulus.TokenParserOnToken;
+							var parser = new TokenParser(cumulus.TokenParserOnToken);
 							parser.InputText = ActionParams;
 							var args = parser.ToStringFromString();
 							cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {args}");
@@ -351,8 +349,7 @@ namespace CumulusMX
 						try
 						{
 							// Prepare the process to run
-							var parser = new TokenParser();
-							parser.OnToken += cumulus.TokenParserOnToken;
+							var parser = new TokenParser(cumulus.TokenParserOnToken);
 							parser.InputText = ActionParams;
 							var args = parser.ToStringFromString();
 							cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {args}");

--- a/CumulusMX/ApiTagProcessor.cs
+++ b/CumulusMX/ApiTagProcessor.cs
@@ -9,15 +9,11 @@ namespace CumulusMX
 	public class ApiTagProcessor
 	{
 		private readonly Cumulus cumulus;
-		private readonly TokenParser tokenParser;
 		private WebTags webtags;
 
 		internal ApiTagProcessor(Cumulus cumulus)
 		{
 			this.cumulus = cumulus;
-			tokenParser = new TokenParser();
-			tokenParser.OnToken += cumulus.TokenParserOnToken;
-			tokenParser.Encoding = new UTF8Encoding(false);
 		}
 
 		internal void SetWebTags(WebTags webtags)
@@ -91,6 +87,8 @@ namespace CumulusMX
 
 				cumulus.LogDataMessage($"API tag: Source = {request.RemoteEndPoint} Input string = {data}");
 
+				var tokenParser = new TokenParser(cumulus.TokenParserOnToken);
+				tokenParser.Encoding = new UTF8Encoding(false);
 				tokenParser.InputText = data;
 				var output = tokenParser.ToStringFromString();
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -9025,9 +9025,14 @@ namespace CumulusMX
 			{
 				try
 				{
-					var parser = new TokenParser(TokenParserOnToken);
-					parser.InputText = ProgramOptions.ShutdownTaskParams;
-					var args = parser.ToStringFromString();
+					var args = string.Empty;
+
+					if (!string.IsNullOrEmpty(ProgramOptions.ShutdownTaskParams))
+					{
+						var parser = new TokenParser(TokenParserOnToken);
+						parser.InputText = ProgramOptions.ShutdownTaskParams;
+						args = parser.ToStringFromString();
+					}
 					LogMessage($"Running shutdown task: {ProgramOptions.ShutdownTask}, arguments: {args}");
 					Utils.RunExternalTask(ProgramOptions.ShutdownTask, args, false);
 				}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -2842,9 +2842,14 @@ namespace CumulusMX
 					{
 						try
 						{
-							var parser = new TokenParser(TokenParserOnToken);
-							parser.InputText = RealtimeParams;
-							var args = parser.ToStringFromString();
+							var args = string.Empty;
+
+							if (!string.IsNullOrEmpty(RealtimeParams))
+							{
+								var parser = new TokenParser(TokenParserOnToken);
+								parser.InputText = RealtimeParams;
+								args = parser.ToStringFromString();
+							}
 							LogDebugMessage($"Realtime[{cycle}]: Execute realtime program - {RealtimeProgram}, with parameters - {args}");
 							Utils.RunExternalTask(RealtimeProgram, args, false);
 						}
@@ -9130,9 +9135,14 @@ namespace CumulusMX
 				{
 					try
 					{
-						var parser = new TokenParser(TokenParserOnToken);
-						parser.InputText = ExternalParams;
-						var args = parser.ToStringFromString();
+						var args = string.Empty;
+
+						if (!string.IsNullOrEmpty(ExternalParams))
+						{
+							var parser = new TokenParser(TokenParserOnToken);
+							parser.InputText = ExternalParams;
+							args = parser.ToStringFromString();
+						}
 						LogDebugMessage("Interval: Executing program " + ExternalProgram + " " + args);
 						Utils.RunExternalTask(ExternalProgram, args, false);
 						LogDebugMessage("Interval: External program started");

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -2918,7 +2918,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				LogExceptionMessage($"Realtime[{cycle}]: Error during update", ex);
+				LogExceptionMessage(ex, $"Realtime[{cycle}]: Error during update");
 				if (FtpOptions.RealtimeEnabled && FtpOptions.Enabled)
 				{
 					RealtimeFTPReconnect();
@@ -3368,7 +3368,15 @@ namespace CumulusMX
 				// wait for all the tasks to complete
 				if (tasklist.Count > 0)
 				{
-					Task.WaitAll(tasklist.ToArray(), cancellationToken);
+					try
+					{
+						Task.WaitAll(tasklist.ToArray(), cancellationToken);
+					}
+					catch (Exception ex)
+					{
+						LogExceptionMessage(ex, $"Realtime[{cycle}]: Eror waiting on upload tasks");
+					}
+
 				}
 				LogDebugMessage($"Realtime[{cycle}]: Real time files complete, {tasklist.Count()} files uploaded");
 				tasklist.Clear();
@@ -9534,7 +9542,7 @@ namespace CumulusMX
 							}
 							catch (Exception ex) when (!(ex is TaskCanceledException))
 							{
-								LogExceptionMessage($"ProcessHttpFiles: Error uploading http file {item.Url} to: {item.Remote}", ex);
+								LogExceptionMessage(ex, $"ProcessHttpFiles: Error uploading http file {item.Url} to: {item.Remote}");
 							}
 							finally
 							{
@@ -9658,7 +9666,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex) when (!(ex is TaskCanceledException))
 						{
-							LogExceptionMessage($"ProcessHttpFiles: Error uploading http file {item.Url} to: {item.Remote}", ex);
+							LogExceptionMessage(ex, $"ProcessHttpFiles: Error uploading http file {item.Url} to: {item.Remote}");
 						}
 						finally
 						{
@@ -9720,7 +9728,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex) when (!(ex is TaskCanceledException))
 						{
-							LogExceptionMessage($"ProcessHttpFiles: Error uploading http file {downloadfile} to: {remotefile}", ex);
+							LogExceptionMessage(ex, $"ProcessHttpFiles: Error uploading http file {downloadfile} to: {remotefile}");
 						}
 						finally
 						{
@@ -10369,7 +10377,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex)
 						{
-							LogExceptionMessage($"PHP[Int]: Error uploading NOAA files", ex);
+							LogExceptionMessage(ex, $"PHP[Int]: Error uploading NOAA files");
 						}
 						finally
 						{
@@ -10418,7 +10426,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex)
 						{
-							LogExceptionMessage($"PHP[Int]: Error uploading NOAA Year file", ex);
+							LogExceptionMessage(ex, $"PHP[Int]: Error uploading NOAA Year file");
 						}
 						finally
 						{
@@ -10505,7 +10513,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex) when (!(ex is TaskCanceledException))
 						{
-							LogExceptionMessage($"PHP[Int]: Error uploading file {uploadfile} to: {remotefile}", ex);
+							LogExceptionMessage(ex, $"PHP[Int]: Error uploading file {uploadfile} to: {remotefile}");
 						}
 						finally
 						{
@@ -10593,7 +10601,7 @@ namespace CumulusMX
 							}
 							catch (Exception ex)
 							{
-								LogExceptionMessage($"PHP[Int]: Error uploading file {item.RemoteFileName}", ex);
+								LogExceptionMessage(ex, $"PHP[Int]: Error uploading file {item.RemoteFileName}");
 							}
 							finally
 							{
@@ -10682,7 +10690,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex)
 						{
-							LogExceptionMessage($"PHP[Int]: Error uploading graph data file [{item.RemoteFileName}]", ex);
+							LogExceptionMessage(ex, $"PHP[Int]: Error uploading graph data file [{item.RemoteFileName}]");
 						}
 						finally
 						{
@@ -10758,7 +10766,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex)
 						{
-							LogExceptionMessage($"PHP[Int]: Error uploading daily graph data file [{item.RemoteFileName}]", ex);
+							LogExceptionMessage(ex, $"PHP[Int]: Error uploading daily graph data file [{item.RemoteFileName}]");
 						}
 						finally
 						{
@@ -10824,7 +10832,7 @@ namespace CumulusMX
 						}
 						catch (Exception ex)
 						{
-							LogExceptionMessage("PHP[Int]: Error uploading moon image", ex);
+							LogExceptionMessage(ex, "PHP[Int]: Error uploading moon image");
 						}
 						finally
 						{
@@ -10854,7 +10862,14 @@ namespace CumulusMX
 				// wait for all the EOD files to complete
 				if (tasklist.Count > 0)
 				{
-					Task.WaitAll(tasklist.ToArray(), cancellationToken);
+					try
+					{
+						Task.WaitAll(tasklist.ToArray(), cancellationToken);
+					}
+					catch(Exception ex)
+					{
+						LogExceptionMessage(ex, "PHP[Int]: Eror waiting on upload tasks");
+					}
 				}
 				//LogDebugMessage($"PHP[Int]: EOD Graph files upload complete, {tasklist.Count()} files processed");
 
@@ -11316,7 +11331,7 @@ namespace CumulusMX
 				}
 				catch (System.Net.Http.HttpRequestException ex)
 				{
-					LogExceptionMessage($"PHP[{cycleStr}]: Error uploading to {remotefile}", ex);
+					LogExceptionMessage(ex, $"PHP[{cycleStr}]: Error uploading to {remotefile}");
 					retry++;
 					if (retry < 2)
 					{
@@ -11325,7 +11340,7 @@ namespace CumulusMX
 				}
 				catch (Exception ex)
 				{
-					LogExceptionMessage($"PHP[{cycleStr}]: Error uploading to {remotefile}", ex);
+					LogExceptionMessage(ex, $"PHP[{cycleStr}]: Error uploading to {remotefile}");
 					retry = 99;
 				}
 				finally
@@ -11415,7 +11430,7 @@ namespace CumulusMX
 			Program.svcTextListener.Flush();
 		}
 
-		public void LogExceptionMessage(string message, Exception ex)
+		public void LogExceptionMessage(Exception ex, string message)
 		{
 			LogMessage(message);
 			LogMessage(message + " - " + Utils.ExceptionToString(ex));
@@ -12098,7 +12113,7 @@ namespace CumulusMX
 					}
 					catch (Exception ex)
 					{
-						LogExceptionMessage($"CustomSqlTimed[{i}]: Error excuting: {MySqlSettings.CustomTimed.Commands[i]} ", ex);
+						LogExceptionMessage(ex, $"CustomSqlTimed[{i}]: Error excuting: {MySqlSettings.CustomTimed.Commands[i]} ");
 					}
 				}
 				customMySqlTimedUpdateInProgress = false;
@@ -12918,7 +12933,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				LogExceptionMessage("Failed to get the latest build version from GitHub", ex);
+				LogExceptionMessage(ex, "Failed to get the latest build version from GitHub");
 			}
 		}
 
@@ -12947,7 +12962,7 @@ namespace CumulusMX
 					}
 					catch (Exception ex)
 					{
-						LogExceptionMessage("CustomHttpSeconds: Error occurred", ex);
+						LogExceptionMessage(ex, "CustomHttpSeconds: Error occurred");
 					}
 				}
 
@@ -12983,7 +12998,7 @@ namespace CumulusMX
 					}
 					catch (Exception ex)
 					{
-						LogExceptionMessage("CustomHttpMinutes: Error ocurred", ex);
+						LogExceptionMessage(ex, "CustomHttpMinutes: Error ocurred");
 					}
 				}
 
@@ -13015,7 +13030,7 @@ namespace CumulusMX
 					}
 					catch (Exception ex)
 					{
-						LogExceptionMessage("CustomHttpRollover: Error occurred", ex);
+						LogExceptionMessage(ex, "CustomHttpRollover: Error occurred");
 					}
 				}
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -9653,7 +9653,6 @@ namespace CumulusMX
 					{
 						try
 						{
-
 							if (cancellationToken.IsCancellationRequested)
 								return false;
 

--- a/CumulusMX/DavisAirLink.cs
+++ b/CumulusMX/DavisAirLink.cs
@@ -27,9 +27,6 @@ namespace CumulusMX
 		private bool startupDayResetIfRequired = true;
 		private int maxArchiveRuns = 1;
 
-		private static readonly HttpClientHandler HistoricHttpHandler = new HttpClientHandler() { SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13 };
-		private readonly HttpClient wlHttpClient = new HttpClient(HistoricHttpHandler);
-		private readonly HttpClient dogsBodyClient = new HttpClient();
 		private const int WeatherLinkArchiveInterval = 16 * 60; // Used to get historic Health, 16 minutes in seconds only for initial fetch after load
 
 		//private bool alVoltageLow = false;
@@ -221,8 +218,8 @@ namespace CumulusMX
 
 			cumulus.LogMessage($"Davis AirLink ({locationStr}) - using IP address {(indoor ? cumulus.AirLinkInIPAddr : cumulus.AirLinkOutIPAddr)}");
 
-			wlHttpClient.Timeout = TimeSpan.FromSeconds(20); // 20 seconds for internet queries
-			dogsBodyClient.Timeout = TimeSpan.FromSeconds(10); // 10 seconds for local queries
+			//wlHttpClient.Timeout = TimeSpan.FromSeconds(20); // 20 seconds for internet queries
+			//dogsBodyClient.Timeout = TimeSpan.FromSeconds(10); // 10 seconds for local queries
 
 			// Only start reading history if the main station isn't a WLL
 			// and we have a station id
@@ -325,7 +322,7 @@ namespace CumulusMX
 					{
 						string responseBody;
 
-						using (HttpResponseMessage response = await dogsBodyClient.GetAsync(urlCurrent))
+						using (var response = await Cumulus.MyHttpClient.GetAsync(urlCurrent))
 						{
 							response.EnsureSuccessStatusCode();
 							responseBody = await response.Content.ReadAsStringAsync();
@@ -566,17 +563,6 @@ namespace CumulusMX
 
 			try
 			{
-				// Configure a web proxy if required
-				if (!string.IsNullOrEmpty(cumulus.HTTPProxyName))
-				{
-					HistoricHttpHandler.Proxy = new WebProxy(cumulus.HTTPProxyName, cumulus.HTTPProxyPort);
-					HistoricHttpHandler.UseProxy = true;
-					if (!string.IsNullOrEmpty(cumulus.HTTPProxyUser))
-					{
-						HistoricHttpHandler.Credentials = new NetworkCredential(cumulus.HTTPProxyUser, cumulus.HTTPProxyPassword);
-					}
-				}
-
 				do
 				{
 					GetWlHistoricData();
@@ -701,7 +687,7 @@ namespace CumulusMX
 				int responseCode;
 
 				// we want to do this synchronously, so .Result
-				using (HttpResponseMessage response = wlHttpClient.GetAsync(historicUrl.ToString()).Result)
+				using (var response = Cumulus.MyHttpClient.GetAsync(historicUrl.ToString()).Result)
 				{
 					responseBody = response.Content.ReadAsStringAsync().Result;
 					responseCode = (int)response.StatusCode;
@@ -1137,7 +1123,7 @@ namespace CumulusMX
 				int responseCode;
 
 				// we want to do this synchronously, so .Result
-				using (HttpResponseMessage response = wlHttpClient.GetAsync(historicUrl.ToString()).Result)
+				using (var response = Cumulus.MyHttpClient.GetAsync(historicUrl.ToString()).Result)
 				{
 					responseBody = response.Content.ReadAsStringAsync().Result;
 					responseCode = (int)response.StatusCode;
@@ -1402,7 +1388,7 @@ namespace CumulusMX
 				int responseCode;
 				// We want to do this synchronously
 
-				using (HttpResponseMessage response = wlHttpClient.GetAsync(stationsUrl.ToString()).Result)
+				using (var response = Cumulus.MyHttpClient.GetAsync(stationsUrl.ToString()).Result)
 				{
 					responseBody = response.Content.ReadAsStringAsync().Result;
 					responseCode = (int)response.StatusCode;
@@ -1520,7 +1506,7 @@ namespace CumulusMX
 				string responseBody;
 				int responseCode;
 				// We want to do this synchronously
-				using (HttpResponseMessage response = wlHttpClient.GetAsync(sensorsUrl.ToString()).Result)
+				using (var response = Cumulus.MyHttpClient.GetAsync(sensorsUrl.ToString()).Result)
 				{
 					responseBody = response.Content.ReadAsStringAsync().Result;
 					responseCode = (int)response.StatusCode;

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -90,12 +90,6 @@ namespace CumulusMX
 			tmrBroadcastWatchdog = new System.Timers.Timer();
 			tmrHealth = new System.Timers.Timer();
 
-			//wlHttpClient.Timeout = TimeSpan.FromSeconds(20); // 20 seconds for internet queries
-
-			// used for kicking real time, and getting current conditions
-			//dogsBodyClient.Timeout = TimeSpan.FromSeconds(10); // 10 seconds for local queries
-			//dogsBodyClient.DefaultRequestHeaders.Add("Connection", "keep-alive"); - No persistent connections on the WLL
-
 			// The Davis leafwetness sensors send a decimal value via WLL (only integer available via VP2/Vue)
 			cumulus.LeafWetDPlaces = 1;
 			cumulus.LeafWetFormat = "F1";

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -36,7 +36,6 @@ namespace CumulusMX
 		private static readonly HttpClientHandler HistoricHttpHandler = new HttpClientHandler() { SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13 };
 		private readonly HttpClient wlHttpClient = new HttpClient(HistoricHttpHandler);
 		private readonly HttpClient dogsBodyClient = new HttpClient();
-		private readonly bool checkWllGustValues;
 		private bool broadcastReceived;
 		private bool broadcastStopped;
 		private int weatherLinkArchiveInterval = 16 * 60; // Used to get historic Health, 16 minutes in seconds only for initial fetch after load
@@ -45,7 +44,7 @@ namespace CumulusMX
 		private readonly AutoResetEvent bwDoneEvent = new AutoResetEvent(false);
 		private readonly List<WlSensor> sensorList = new List<WlSensor>();
 		private readonly bool useWeatherLinkDotCom = true;
-		private double currentAvgWindSpd = 0;
+		private readonly bool checkWllGustValues;
 
 		public DavisWllStation(Cumulus cumulus) : base(cumulus)
 		{
@@ -104,12 +103,17 @@ namespace CumulusMX
 			cumulus.LeafWetDPlaces = 1;
 			cumulus.LeafWetFormat = "F1";
 
+			// the broadcast data does not contain an average speed, and the current data is only updated once a minute, so make CMX calculate the average
+			cumulus.StationOptions.CalcuateAverageWindSpeed = true;
+			// calculate it by averaging the gust values
+			cumulus.StationOptions.UseSpeedForAvgCalc = false;
 
+			/*
 			// If the user is using the default 10 minute Wind gust, always use gust data from the WLL - simple
 			if (cumulus.StationOptions.PeakGustMinutes == 10)
 			{
-				CalcRecentMaxGust = false;
-				checkWllGustValues = false;
+				CalcRecentMaxGust = true;
+				checkWllGustValues = true;
 			}
 			else if (cumulus.StationOptions.PeakGustMinutes > 10)
 			{
@@ -124,6 +128,8 @@ namespace CumulusMX
 				CalcRecentMaxGust = true;
 				checkWllGustValues = true;
 			}
+			*/
+			CalcRecentMaxGust = true;
 
 
 			// Sanity check - do we have all the info we need?
@@ -585,43 +591,11 @@ namespace CumulusMX
 							try
 							{
 								// WLL BUG/FEATURE: The WLL sends a null wind direction for calm when the avg speed falls to zero, we use zero
-								int windDir = rec.wind_dir_last ?? 0;
+								var windDir = (int) (rec.wind_dir_last ?? 0);
+								var spd = ConvertWindMPHToUser(rec.wind_speed_last);
 
-								// No average in the broadcast data, so use last value from current
-								DoWind(ConvertWindMPHToUser(rec.wind_speed_last), windDir, currentAvgWindSpd, dateTime);
-
-								var gust = ConvertWindMPHToUser(rec.wind_speed_hi_last_10_min);
-								var gustCal = cumulus.Calib.WindGust.Calibrate(gust);
-								if (checkWllGustValues)
-								{
-									if (gustCal > RecentMaxGust)
-									{
-										// See if the station 10 min high speed is higher than our current 10-min max
-										// i.e. we missed the high gust
-
-										// Check for spikes, and set highs
-										if (CheckHighGust(gustCal, rec.wind_dir_at_hi_speed_last_10_min, dateTime))
-										{
-											cumulus.LogDebugMessage("Set max gust from broadcast 10 min high value: " + gustCal.ToString(cumulus.WindFormat) + " was: " + RecentMaxGust.ToString(cumulus.WindFormat));
-
-											// add to recent values so normal calculation includes this value
-											WindRecent[nextwind].Gust = gustCal; // use calibrated value
-											WindRecent[nextwind].Speed = WindAverage;
-											WindRecent[nextwind].Timestamp = dateTime;
-											nextwind = (nextwind + 1) % MaxWindRecent;
-
-											RecentMaxGust = gustCal;
-										}
-									}
-								}
-								else if (!CalcRecentMaxGust)
-								{
-									// Check for spikes, and set highs
-									if (CheckHighGust(gustCal, rec.wind_dir_at_hi_speed_last_10_min, dateTime))
-									{
-										RecentMaxGust = gustCal;
-									}
-								}
+								// No average in the broadcast data, so use current average.
+								DoWind(spd, windDir, -1, dateTime);
 							}
 							catch (Exception ex)
 							{
@@ -844,79 +818,53 @@ namespace CumulusMX
 								*/
 								try
 								{
-									cumulus.LogDebugMessage($"WLL current: using average wind speed data from TxId {data1.txid}");
-
-									// pesky null values from WLL when it is calm
-									if (cumulus.StationOptions.AvgSpeedMinutes == 1)
-										currentAvgWindSpd = ConvertWindMPHToUser(data1.wind_speed_avg_last_1_min ?? 0);
-									else if (cumulus.StationOptions.AvgSpeedMinutes < 10)
-										currentAvgWindSpd = ConvertWindMPHToUser(data1.wind_speed_avg_last_2_min ?? 0);
-									else
-										currentAvgWindSpd = ConvertWindMPHToUser(data1.wind_speed_avg_last_10_min ?? 0);
-
 									// Only use wind data from current if we are not receiving broadcasts
 									if (broadcastStopped)
 									{
-										cumulus.LogDebugMessage($"WLL current: no broadcast data so using full wind data from TxId {data1.txid}");
+										cumulus.LogDebugMessage($"WLL current: no broadcast data so using wind data from TxId {data1.txid}");
+
+										// pesky null values from WLL when it is calm
+										double currentAvgWindSpd;
+										if (cumulus.StationOptions.AvgSpeedMinutes == 1)
+											currentAvgWindSpd = ConvertWindMPHToUser(data1.wind_speed_avg_last_1_min ?? 0);
+										else if (cumulus.StationOptions.AvgSpeedMinutes < 10)
+											currentAvgWindSpd = ConvertWindMPHToUser(data1.wind_speed_avg_last_2_min ?? 0);
+										else
+											currentAvgWindSpd = ConvertWindMPHToUser(data1.wind_speed_avg_last_10_min ?? 0);
+
 
 										// pesky null values from WLL when it is calm
 										int wdir = data1.wind_dir_last ?? 0;
 										double wind = ConvertWindMPHToUser(data1.wind_speed_last ?? 0);
 
+										var savCalc = cumulus.StationOptions.CalcuateAverageWindSpeed;
+										cumulus.StationOptions.CalcuateAverageWindSpeed = false;
+										CalcRecentMaxGust = false;
 										DoWind(wind, wdir, currentAvgWindSpd, dateTime);
+										cumulus.StationOptions.CalcuateAverageWindSpeed = savCalc;
+										CalcRecentMaxGust = true;
 									}
 
-									double gust;
-									int gustDir;
-									if (cumulus.StationOptions.PeakGustMinutes < 10)
+									if (cumulus.StationOptions.PeakGustMinutes >= 2)
 									{
-										gust = ConvertWindMPHToUser(data1.wind_speed_hi_last_2_min ?? 0);
-										gustDir = data1.wind_dir_at_hi_speed_last_2_min ?? 0;
-									}
-									else
-									{
-										gust = ConvertWindMPHToUser(data1.wind_speed_hi_last_10_min ?? 0);
-										gustDir = data1.wind_dir_at_hi_speed_last_10_min ?? 0;
+										var gust = ConvertWindMPHToUser(data1.wind_speed_hi_last_2_min ?? 0);
+										var gustCal = cumulus.Calib.WindGust.Calibrate(gust);
+										var gustDir = data1.wind_dir_at_hi_speed_last_2_min ?? 0;
+										var gustDirCal = gustDir == 0 ? 0 : (int) cumulus.Calib.WindDir.Calibrate(gustDir);
 
-									}
-
-									ConvertWindMPHToUser(gust);
-									var gustCal = cumulus.Calib.WindGust.Calibrate(gust);
-
-
-									if (checkWllGustValues)
-									{
-										// See if the current speed is higher than the current 10-min max
+										// See if the current speed is higher than the current max
 										// We can then update the figure before the next data packet is read
 
-										if (gustCal > RecentMaxGust)
+										cumulus.LogDebugMessage($"WLL current: Checking recent gust using wind data from TxId {data1.txid}");
+
+										if (gustCal > HiLoToday.HighGust)
 										{
 											// Check for spikes, and set highs
-											if (CheckHighGust(gustCal, gustDir, dateTime))
+											if (CheckHighGust(gustCal, gustDirCal, dateTime))
 											{
 												cumulus.LogDebugMessage("Setting max gust from current value: " + gustCal.ToString(cumulus.WindFormat) + " was: " + RecentMaxGust.ToString(cumulus.WindFormat));
-
-												// add to recent values so normal calculation includes this value
-												WindRecent[nextwind].Gust = gustCal; // use calibrated value
-												WindRecent[nextwind].Speed = cumulus.Calib.WindSpeed.Calibrate(currentAvgWindSpd);
-												WindRecent[nextwind].Timestamp = dateTime;
-												nextwind = (nextwind + 1) % MaxWindRecent;
-
-												if (broadcastStopped)
-												{
-													// if we are not receiving live broadcasts, then use current gust value)
-													RecentMaxGust = gustCal;
-												}
+												RecentMaxGust = gustCal;
 											}
-										}
-									}
-									else if (!CalcRecentMaxGust)
-									{
-										// Check for spikes, and set highs
-										if (CheckHighGust(gustCal, gustDir, dateTime) && broadcastStopped)
-										{
-											// if we are not receiving live broadcasts, then use current gust value
-											RecentMaxGust = gustCal;
 										}
 									}
 								}
@@ -1510,8 +1458,6 @@ namespace CumulusMX
 			//}
 			cumulus.NormalRunning = true;
 
-			// restore settings
-			cumulus.StationOptions.UseSpeedForAvgCalc = savedUseSpeedForAvgCalc;
 			CalcRecentMaxGust = savedCalculatePeakGust;
 
 			StartLoop();
@@ -1548,7 +1494,6 @@ namespace CumulusMX
 			try
 			{
 				// set this temporarily, so speed is done from average and not peak gust from logger
-				savedUseSpeedForAvgCalc = cumulus.StationOptions.UseSpeedForAvgCalc;
 				cumulus.StationOptions.UseSpeedForAvgCalc = true;
 
 				// same for gust values
@@ -1571,11 +1516,17 @@ namespace CumulusMX
 					GetWlHistoricData(worker);
 					archiveRun++;
 				} while (archiveRun < maxArchiveRuns && worker.CancellationPending == false);
+
+				// restore the setting
+				cumulus.StationOptions.UseSpeedForAvgCalc = false;
 			}
 			catch (Exception ex)
 			{
 				cumulus.LogMessage("Exception occurred reading archive data: " + ex.Message);
 			}
+
+			// force a calculation of the current gust and average wind speed so we do not get a zero values at startup
+
 
 			//cumulus.LogDebugMessage("Lock: Station releasing the lock");
 			Cumulus.syncInit.Release();
@@ -2222,8 +2173,11 @@ namespace CumulusMX
 							{
 								if (data11.wind_speed_hi != null && data11.wind_speed_hi_dir != null && data11.wind_speed_avg != null)
 								{
+									var gust = ConvertWindMPHToUser((double) data11.wind_speed_hi);
+									var spd = ConvertWindMPHToUser((double) data11.wind_speed_avg);
+									var dir = data11.wind_speed_hi_dir ?? 0;
 									cumulus.LogDebugMessage($"WL.com historic: using wind data from TxId {data11.tx_id}");
-									DoWind(ConvertWindMPHToUser((double)data11.wind_speed_hi), (int)data11.wind_speed_hi_dir, ConvertWindMPHToUser((double)data11.wind_speed_avg), recordTs);
+									DoWind(gust, dir, spd, recordTs);
 								}
 								else
 								{

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -21,9 +21,6 @@ namespace CumulusMX
 		private readonly Cumulus cumulus;
 		private readonly WeatherStation station;
 
-		private static readonly HttpClientHandler httpHandler = new HttpClientHandler() { SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13 };
-		private static readonly HttpClient httpClient = new HttpClient(httpHandler);
-
 		private static readonly string historyUrl = "https://api.ecowitt.net/api/v3/device/history?";
 
 		private static readonly int EcowittApiFudgeFactor = 5; // Number of minutes that Ecowitt API data is delayed
@@ -33,18 +30,7 @@ namespace CumulusMX
 			cumulus = cuml;
 			station = stn;
 
-			// Configure a web proxy if required
-			if (!string.IsNullOrEmpty(cumulus.HTTPProxyName))
-			{
-				httpHandler.Proxy = new WebProxy(cumulus.HTTPProxyName, cumulus.HTTPProxyPort);
-				httpHandler.UseProxy = true;
-				if (!string.IsNullOrEmpty(cumulus.HTTPProxyUser))
-				{
-					httpHandler.Credentials = new NetworkCredential(cumulus.HTTPProxyUser, cumulus.HTTPProxyPassword);
-				}
-			}
-
-			httpClient.DefaultRequestHeaders.ConnectionClose = true;
+			//httpClient.DefaultRequestHeaders.ConnectionClose = true;
 
 			// Let's decode the Unix ts to DateTime
 			JsConfig.Init(new Config {
@@ -203,7 +189,7 @@ namespace CumulusMX
 				do
 				{
 					// we want to do this synchronously, so .Result
-					using (HttpResponseMessage response = httpClient.GetAsync(url).Result)
+					using (var response = Cumulus.MyHttpClient.GetAsync(url).Result)
 					{
 						responseBody = response.Content.ReadAsStringAsync().Result;
 						responseCode = (int)response.StatusCode;

--- a/CumulusMX/EmailSender.cs
+++ b/CumulusMX/EmailSender.cs
@@ -34,8 +34,9 @@ namespace CumulusMX
 				//cumulus.LogDebugMessage($"SendEmail: Has the lock");
 
 				var logMessage = ToLiteral(message);
+				var sendSubject = subject + " - " + cumulus.LocationName;
 
-				cumulus.LogMessage($"SendEmail: Sending email, to [{string.Join("; ", to)}], subject [{subject}], body [{logMessage}]...");
+				cumulus.LogMessage($"SendEmail: Sending email, to [{string.Join("; ", to)}], subject [{sendSubject}], body [{logMessage}]...");
 
 				var m = new MimeMessage();
 				m.From.Add(new MailboxAddress("", from));
@@ -43,7 +44,8 @@ namespace CumulusMX
 				{
 					m.To.Add(new MailboxAddress("", addr));
 				}
-				m.Subject = subject;
+
+				m.Subject = sendSubject;
 
 				BodyBuilder bodyBuilder = new BodyBuilder();
 				if (isHTML)

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -49,7 +49,7 @@ namespace CumulusMX
 			cumulus.Units.LeafWetnessUnitText = "%";
 
 			// GW1000 does not provide 10 min average wind speeds
-			cumulus.StationOptions.UseWind10MinAvg = true;
+			cumulus.StationOptions.CalcuateAverageWindSpeed = true;
 
 			// GW1000 does not provide an interval gust value, it gives us a 30 second high
 			// so force using the wind speed for the average calculation

--- a/CumulusMX/HttpFiles.cs
+++ b/CumulusMX/HttpFiles.cs
@@ -182,7 +182,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogExceptionMessage($"DownloadHttpFile: Error downloading from {url} to {filename}", ex);
+				cumulus.LogExceptionMessage(ex, $"DownloadHttpFile: Error downloading from {url} to {filename}");
 			}
 		}
 
@@ -208,7 +208,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogExceptionMessage($"DownloadHttpFileString: Error downloading from {url}", ex);
+				cumulus.LogExceptionMessage(ex, $"DownloadHttpFileString: Error downloading from {url}");
 				return null;
 			}
 		}
@@ -229,7 +229,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogExceptionMessage($"DownloadHttpFileStream: Error downloading from {url}", ex);
+				cumulus.LogExceptionMessage(ex, $"DownloadHttpFileStream: Error downloading from {url}");
 				return null;
 			}
 

--- a/CumulusMX/HttpFiles.cs
+++ b/CumulusMX/HttpFiles.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 //using System.Net.Security;
 using System.Runtime.Serialization;
 //using System.Security.Cryptography.X509Certificates;
@@ -25,35 +26,10 @@ namespace CumulusMX
 	internal class HttpFiles
 	{
 		private readonly Cumulus cumulus;
-		private HttpClient client;
 
 		public HttpFiles(Cumulus cumulus)
 		{
 			this.cumulus = cumulus;
-
-			var handler = new HttpClientHandler()
-			{
-				SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13
-				/*
-				ServerCertificateCustomValidationCallback = (HttpRequestMessage requestMessage, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslErrors) =>
-				{
-					// It is possible to inspect the certificate provided by the server.
-					cumulus.LogDebugMessage($"Http File: Requested URI : {requestMessage.RequestUri}");
-					cumulus.LogDebugMessage($"Http File: Name          : {certificate.GetName()}");
-					cumulus.LogDebugMessage($"Http File: Effective date: {certificate.GetEffectiveDateString()}");
-					cumulus.LogDebugMessage($"Http File: Exp date      : {certificate.GetExpirationDateString()}");
-					cumulus.LogDebugMessage($"Http File: Issuer        : {certificate.Issuer}");
-					cumulus.LogDebugMessage($"Http File: Subject       : {certificate.Subject}");
-
-					// Based on the custom logic it is possible to decide whether the client considers certificate valid or not
-					cumulus.LogDebugMessage($"Http File: Errors        : {sslErrors}");
-					return sslErrors == SslPolicyErrors.None;
-				}
-				*/
-			};
-			handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13;
-
-			client = new HttpClient(handler);
 		}
 
 		public string GetAlpacaFormData()
@@ -172,9 +148,10 @@ namespace CumulusMX
 
 			try
 			{
-				var response = await client.GetAsync(new Uri(modUrl));
+				using (var response = await Cumulus.MyHttpClient.GetAsync(new Uri(modUrl)))
 				using (var fileStream = new FileStream(filename, FileMode.Create))
 				{
+					response.EnsureSuccessStatusCode();
 					await response.Content.CopyToAsync(fileStream);
 				}
 
@@ -194,15 +171,17 @@ namespace CumulusMX
 
 			try
 			{
-				var request = new HttpRequestMessage(HttpMethod.Get, modUrl);
-				var sendTask = client.SendAsync(request);
-				var response = sendTask.Result.EnsureSuccessStatusCode();
-				var bytes = await response.Content.ReadAsByteArrayAsync();
-
 				string ret = null;
-				if (bytes != null)
+				var request = new HttpRequestMessage(HttpMethod.Get, modUrl);
+				var sendTask = Cumulus.MyHttpClient.SendAsync(request);
+				using (var response = sendTask.Result.EnsureSuccessStatusCode())
 				{
-					ret = Convert.ToBase64String(bytes);
+					var bytes = await response.Content.ReadAsByteArrayAsync();
+
+					if (bytes != null)
+					{
+						ret = Convert.ToBase64String(bytes);
+					}
 				}
 				return ret;
 			}
@@ -213,7 +192,7 @@ namespace CumulusMX
 			}
 		}
 
-		public Stream DownloadHttpFileStream(string url)
+		public async Task<Stream> DownloadHttpFileStream(string url)
 		{
 			var modUrl = url + (url.Contains("?") ? "&" : "?") + "_=" + DateTime.Now.ToUnixTime();
 
@@ -221,18 +200,18 @@ namespace CumulusMX
 
 			try
 			{
-				var request = new HttpRequestMessage(HttpMethod.Get, modUrl);
-				var sendTask = client.SendAsync(request);
-				var response = sendTask.Result.EnsureSuccessStatusCode();
-
-				return response.Content.ReadAsStreamAsync().Result;
+				using (var request = new HttpRequestMessage(HttpMethod.Get, modUrl))
+				using (var response = await Cumulus.MyHttpClient.SendAsync(request))
+				{
+					response.EnsureSuccessStatusCode();
+					return response.Content.ReadAsStreamAsync().Result;
+				}
 			}
 			catch (Exception ex)
 			{
 				cumulus.LogExceptionMessage(ex, $"DownloadHttpFileStream: Error downloading from {url}");
 				return null;
 			}
-
 		}
 
 		private class HttpFileSettings
@@ -284,6 +263,10 @@ namespace CumulusMX
 			{
 				// We always revert to the start time so we remain consistent across DST changes
 				NextDownload = now.Date + StartTime;
+			}
+			else if (NextDownload == DateTime.MinValue)
+			{
+				NextDownload = now;
 			}
 
 			// Not timed or timed and we have now set the start, add on intervals until we reach the future

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -28,7 +28,7 @@ namespace CumulusMX
 
 			//cumulus.StationOptions.CalculatedWC = true;
 			// Ambient does not provide average wind speeds
-			cumulus.StationOptions.UseWind10MinAvg = true;
+			cumulus.StationOptions.CalcuateAverageWindSpeed = true;
 			//cumulus.StationOptions.UseSpeedForAvgCalc = false;
 			// Ambient does not send the rain rate, so we will calculate it
 			calculaterainrate = true;

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -51,7 +51,7 @@ namespace CumulusMX
 			if (mainStation)
 			{
 				// does not provide 10 min average wind speeds
-				cumulus.StationOptions.UseWind10MinAvg = true;
+				cumulus.StationOptions.CalcuateAverageWindSpeed = true;
 
 				// GW1000 does not provide an interval gust value, it gives us a 2 minute high
 				// The speed is the average for that update

--- a/CumulusMX/ImetStation.cs
+++ b/CumulusMX/ImetStation.cs
@@ -908,7 +908,7 @@ namespace CumulusMX
 				    !string.IsNullOrEmpty(sl[WINDPOS]) && double.TryParse(sl[WINDPOS], NumberStyles.Float, provider, out varDbl))
 				{
 					windspeed = varDbl;
-					DoWind(ConvertWindMSToUser(windspeed), varInt, ConvertWindMSToUser(windspeed), now);
+					DoWind(ConvertWindMSToUser(windspeed), varInt, -1, now);
 				}
 				else
 				{

--- a/CumulusMX/LangSettings.cs
+++ b/CumulusMX/LangSettings.cs
@@ -326,6 +326,7 @@ namespace CumulusMX
 					cumulus.Trans.UserTempCaptions = settings.userTemp;
 					cumulus.Trans.SoilTempCaptions = settings.soilTemp;
 					cumulus.Trans.SoilMoistureCaptions = settings.soilMoist;
+					cumulus.Trans.LeafWetnessCaptions = settings.leafWet;
 				}
 				catch (Exception ex)
 				{

--- a/CumulusMX/MqttPublisher.cs
+++ b/CumulusMX/MqttPublisher.cs
@@ -139,8 +139,7 @@ namespace CumulusMX
 			{
 				foreach (var feed in templateObj.topics)
 				{
-					var mqttTokenParser = new TokenParser { Encoding = new System.Text.UTF8Encoding(false) };
-					mqttTokenParser.OnToken += cumulus.TokenParserOnToken;
+					var mqttTokenParser = new TokenParser(cumulus.TokenParserOnToken) { Encoding = new System.Text.UTF8Encoding(false) };
 					mqttTokenParser.InputText = feed.data;
 					string message = mqttTokenParser.ToStringFromString();
 

--- a/CumulusMX/NOAA.cs
+++ b/CumulusMX/NOAA.cs
@@ -462,15 +462,11 @@ namespace CumulusMX
 						var sep = Utils.GetLogFileSeparator(line, cumulus.ListSeparator);
 						st = new List<string>(line.Split(sep[0]));
 
-						idx = 0;
-						int entryday = Convert.ToInt32(st[idx].Substring(0, 2));
-						int entrymonth = Convert.ToInt32(st[idx].Substring(3, 2));
-						int entryyear = Convert.ToInt32(st[idx].Substring(6, 2));
 						idx = 1;
-						int entryhour = Convert.ToInt32(st[idx].Substring(0, 2));
-						int entryminute = Convert.ToInt32(st[idx].Substring(3, 2));
 
-						DateTime entrydate = new DateTime(entryyear, entrymonth, entryday, entryhour, entryminute, 0);
+						var entrydate = Utils.ddmmyyhhmmStrToDate(st[0], st[1]);
+
+						//DateTime entrydate = new DateTime(entryyear, entrymonth, entryday, entryhour, entryminute, 0);
 
 						entrydate = entrydate.AddHours(cumulus.GetHourInc(entrydate));
 

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.25.1 - Build 3243")]
+[assembly: AssemblyDescription("Version 3.25.1 - Build 3244")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.25.1.3243")]
-[assembly: AssemblyFileVersion("3.25.1.3243")]
+[assembly: AssemblyVersion("3.25.1.3244")]
+[assembly: AssemblyFileVersion("3.25.1.3244")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.25.1 - Build 3242")]
+[assembly: AssemblyDescription("Version 3.25.1 - Build 3243")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.25.1.3242")]
-[assembly: AssemblyFileVersion("3.25.1.3242")]
+[assembly: AssemblyVersion("3.25.1.3243")]
+[assembly: AssemblyFileVersion("3.25.1.3243")]

--- a/CumulusMX/Properties/AssemblyInfo.cs
+++ b/CumulusMX/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Cumulus MX")]
-[assembly: AssemblyDescription("Version 3.25.0 - Build 3241")]
+[assembly: AssemblyDescription("Version 3.25.1 - Build 3242")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Cumulus MX")]
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.25.0.3241")]
-[assembly: AssemblyFileVersion("3.25.0.3241")]
+[assembly: AssemblyVersion("3.25.1.3242")]
+[assembly: AssemblyFileVersion("3.25.1.3242")]

--- a/CumulusMX/Simulator.cs
+++ b/CumulusMX/Simulator.cs
@@ -33,7 +33,7 @@ namespace CumulusMX
 			cumulus.StationOptions.CalculatedDP = true;
 			cumulus.StationOptions.CalculatedET = true;
 			cumulus.StationOptions.CalculatedWC = true;
-			cumulus.StationOptions.UseWind10MinAvg = true;
+			cumulus.StationOptions.CalcuateAverageWindSpeed = true;
 			cumulus.StationOptions.UseCumulusPresstrendstr = true;
 			cumulus.StationOptions.UseSpeedForAvgCalc = false;
 
@@ -105,7 +105,7 @@ namespace CumulusMX
 		{
 			cumulus.LogDataMessage($"Simulated data: temp={ConvertTempCToUser(currData.tempVal):f1}, hum={currData.humVal}, gust={ConvertWindMPHToUser(currData.windSpeedVal):f2}, dir={currData.windBearingVal}, press={ConvertPressMBToUser(currData.pressureVal):f2}, r.rate={ConvertRainMMToUser(currData.rainRateVal):f2}");
 
-			DoWind(ConvertWindMPHToUser(currData.windSpeedVal), currData.windBearingVal, WindAverage, recDate, true);
+			DoWind(ConvertWindMPHToUser(currData.windSpeedVal), currData.windBearingVal, -1, recDate);
 
 			var rain = Raincounter + ConvertRainMMToUser(currData.rainRateVal * dataUpdateRate / 1000 / 3600);
 

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -49,7 +49,7 @@ namespace CumulusMX
 			var options = new JsonStationSettingsOptions()
 			{
 				usezerobearing = cumulus.StationOptions.UseZeroBearing,
-				calcwindaverage = cumulus.StationOptions.UseWind10MinAvg,
+				calcwindaverage = cumulus.StationOptions.CalcuateAverageWindSpeed,
 				use100for98hum = cumulus.StationOptions.Humidity98Fix,
 				calculatedewpoint = cumulus.StationOptions.CalculatedDP,
 				calculatewindchill = cumulus.StationOptions.CalculatedWC,
@@ -667,7 +667,7 @@ namespace CumulusMX
 				try
 				{
 					cumulus.StationOptions.UseZeroBearing = settings.Options.usezerobearing;
-					cumulus.StationOptions.UseWind10MinAvg = settings.Options.calcwindaverage;
+					cumulus.StationOptions.CalcuateAverageWindSpeed = settings.Options.calcwindaverage;
 					cumulus.StationOptions.Humidity98Fix = settings.Options.use100for98hum;
 					cumulus.StationOptions.CalculatedDP = settings.Options.calculatedewpoint;
 					cumulus.StationOptions.CalculatedWC = settings.Options.calculatewindchill;

--- a/CumulusMX/TempestStation.cs
+++ b/CumulusMX/TempestStation.cs
@@ -28,6 +28,9 @@ namespace CumulusMX
 			// Tempest does not provide wind chill
 			cumulus.StationOptions.CalculatedWC = true;
 
+			// Tempest does not provide average wind speeds
+			cumulus.StationOptions.UseWind10MinAvg = true;
+
 			LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
 
 			Task.Run(getAndProcessHistoryData);// grab old data, then start the station

--- a/CumulusMX/TempestStation.cs
+++ b/CumulusMX/TempestStation.cs
@@ -29,7 +29,7 @@ namespace CumulusMX
 			cumulus.StationOptions.CalculatedWC = true;
 
 			// Tempest does not provide average wind speeds
-			cumulus.StationOptions.UseWind10MinAvg = true;
+			cumulus.StationOptions.CalcuateAverageWindSpeed = true;
 
 			LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
 
@@ -339,7 +339,7 @@ namespace CumulusMX
 
 						DoWind(ConvertWindMSToUser((double) rw.WindSpeed),
 							rw.WindDirection,
-							ConvertWindMSToUser((double) rw.WindSpeed),
+							-1,
 							rw.Timestamp);
 						UpdateStatusPanel(rw.Timestamp);
 

--- a/CumulusMX/TokenParser.cs
+++ b/CumulusMX/TokenParser.cs
@@ -33,8 +33,9 @@ namespace CumulusMX
 		public delegate void TokenHandler(string strToken, ref string strReplacement);
 		public event TokenHandler OnToken;
 
-		public TokenParser()
+		public TokenParser(TokenHandler tokenHandler)
 		{
+			OnToken = tokenHandler;
 		}
 
 		/*

--- a/CumulusMX/WM918Station.cs
+++ b/CumulusMX/WM918Station.cs
@@ -294,7 +294,7 @@ namespace CumulusMX
 			double average = ConvertWindMSToUser((double)(BCDchartoint(buff[4]) + ((BCDchartoint(buff[5]) % 10) * 100)) / 10);
 			int bearing = BCDchartoint(buff[2]) / 10 + (BCDchartoint(buff[3]) * 10);
 
-			DoWind(current,bearing,average,DateTime.Now);
+			DoWind(current, bearing ,average, DateTime.Now);
 
 			// Extract wind chill
 			int wc = BCDchartoint(buff[16]);

--- a/CumulusMX/WMR200Station.cs
+++ b/CumulusMX/WMR200Station.cs
@@ -1444,7 +1444,7 @@ namespace CumulusMX
 			// average
 			double average = ((packetBuffer[24]*16) + (packetBuffer[23]/16))/10.0;
 
-			DoWind(ConvertWindMSToUser(gust),bearing,ConvertWindMSToUser(average),timestamp);
+			DoWind(ConvertWindMSToUser(gust), bearing,ConvertWindMSToUser(average), timestamp);
 
 			// add in 'interval' minutes worth of wind speed to windrun
 			WindRunToday += (WindAverage*WindRunHourMult[cumulus.Units.Wind]*interval*60)/1000.0;

--- a/CumulusMX/WS2300Station.cs
+++ b/CumulusMX/WS2300Station.cs
@@ -690,7 +690,7 @@ namespace CumulusMX
 				if ((wind > -1) && ((previouswind == 999) || (Math.Abs(wind - previouswind) < cumulus.Spike.WindDiff)))
 				{
 					previouswind = wind;
-					DoWind(ConvertWindMSToUser(wind), (int)direction, ConvertWindMSToUser(wind), now);
+					DoWind(ConvertWindMSToUser(wind), (int)direction, -1, now);
 				}
 				else
 				{

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -6750,9 +6750,14 @@ namespace CumulusMX
 					try
 					{
 						// Prepare the process to run
-						var parser = new TokenParser(cumulus.TokenParserOnToken);
-						parser.InputText = cumulus.DailyParams;
-						var args = parser.ToStringFromString();
+						var args = string.Empty;
+
+						if (!string.IsNullOrEmpty(cumulus.DailyParams))
+						{
+							var parser = new TokenParser(cumulus.TokenParserOnToken);
+							parser.InputText = cumulus.DailyParams;
+							args = parser.ToStringFromString();
+						}
 						cumulus.LogMessage("Executing daily program: " + cumulus.DailyProgram + " params: " + args);
 						Utils.RunExternalTask(cumulus.DailyProgram, args, false);
 					}

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -3554,10 +3554,10 @@ namespace CumulusMX
 								if (entrydate > dateFrom)
 								{
 									// entry is from required period
-									var temp = 0;
+									var temp = 0.0;
 									for (var i = 0; i < 2; i++)
 									{
-										if (cumulus.GraphOptions.Visible.LeafWetness.ValVisible(i, local) && int.TryParse(st[i + 42], out temp))
+										if (cumulus.GraphOptions.Visible.LeafWetness.ValVisible(i, local) && double.TryParse(st[i + 42], out temp))
 											sbExt[i].Append($"[{Utils.ToPseudoJSTime(entrydate)},{temp}],");
 									}
 								}

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -2593,14 +2593,12 @@ namespace CumulusMX
 
 		private string Tagrecordsbegandate(Dictionary<string,string> tagParams)
 		{
-			var begandate = cumulus.RecordsBeganDateTime;
-			return GetFormattedDateTime(begandate, "dd MMMM yyyy", tagParams);
+			return GetFormattedDateTime(cumulus.RecordsBeganDateTime, "dd MMMM yyyy", tagParams);
 		}
 
 		private string TagDaysSinceRecordsBegan(Dictionary<string,string> tagParams)
 		{
-			var begandate = cumulus.RecordsBeganDateTime;
-			return (DateTime.Now - begandate).Days.ToString();
+			return (DateTime.Now - cumulus.RecordsBeganDateTime).Days.ToString();
 		}
 
 		private string TagmintempH(Dictionary<string,string> tagParams)

--- a/Updates.txt
+++ b/Updates.txt
@@ -4,7 +4,7 @@ New
 - Adds the station name to the main dashboard page and email subject
 
 Changed
-- None
+- NOAA report selectors no longer limited to years greater than 2000
 
 Fixed
 - Tempest station now forces MX to calculate the average wind speed
@@ -15,11 +15,12 @@ Fixed
 - Dashboard Local Time block - again!
 - Zero length string error processing web tags
 - Graph colours for PM2.5 and PM10 getting set to the same value
-- Uncaught expection (TaskList has null entry) in PHP uploads
+- Uncaught exception (TaskList has null entry) in PHP uploads
 - 100% CPU bug in the new HTTP files on first processing of each file
 - Revert TLS1.2/1.3 changes in v3.25.0
 - Extensive HTTPClient code optimisations
 - Fix year bug reading from monthly log in NOAA monthly report generation
+- Fix suprious TokenParser messages from various extrernal task executions
 
 
 3.25.0 - b3241

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,7 +1,7 @@
 3.25.1 - b3242
 ——————————————
 New
-- None
+- Adds the station name to the main dashboard page and email subject
 
 Changed
 - None
@@ -10,6 +10,13 @@ Fixed
 - Tempest station now forces MX to calculate the average wind speed
 - Leaf wetness sensor name changes not being saved in Locale strings
 - Leaf wetness graph data empty for Davis sensors
+- Average wind speed calculation for Davis VP, Davis WLL (when calibration applied), Imet, Tempest, WS2300 stations
+- Another average wind speed calculation for Davis VP and Davis WLL (when broadcasts are not being received)
+- Dashboard Local Time block - again!
+- Zero length string error processing web tags
+- Graph colours for PM2.5 and PM10 getting set to the same value
+- Uncaught expection (TaskList has null entry) in PHP uploads
+
 
 
 3.25.0 - b3241

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.25.1 - b3242
+3.25.1 - b3243
 ——————————————
 New
 - Adds the station name to the main dashboard page and email subject
@@ -16,7 +16,9 @@ Fixed
 - Zero length string error processing web tags
 - Graph colours for PM2.5 and PM10 getting set to the same value
 - Uncaught expection (TaskList has null entry) in PHP uploads
-
+- 100% CPU bug in the new HTTP files on first processing of each file
+- Revert TLS1.2/1.3 changes in v3.25.0
+- Extensive HTTPClient code optimisations
 
 
 3.25.0 - b3241

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,12 +1,15 @@
 3.25.1 - b3242
 ——————————————
 New
+- None
 
 Changed
+- None
 
 Fixed
 - Tempest station now forces MX to calculate the average wind speed
 - Leaf wetness sensor name changes not being saved in Locale strings
+- Leaf wetness graph data empty for Davis sensors
 
 
 3.25.0 - b3241

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,14 @@
+3.25.1 - b3242
+——————————————
+New
+
+Changed
+
+Fixed
+- Tempest station now forces MX to calculate the average wind speed
+
+
+
 3.25.0 - b3241
 ——————————————
 New

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,7 +6,7 @@ Changed
 
 Fixed
 - Tempest station now forces MX to calculate the average wind speed
-
+- Leaf wetness sensor name changes not being saved in Locale strings
 
 
 3.25.0 - b3241

--- a/Updates.txt
+++ b/Updates.txt
@@ -19,6 +19,7 @@ Fixed
 - 100% CPU bug in the new HTTP files on first processing of each file
 - Revert TLS1.2/1.3 changes in v3.25.0
 - Extensive HTTPClient code optimisations
+- Fix year bug reading from monthly log in NOAA monthly report generation
 
 
 3.25.0 - b3241

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-3.25.1 - b3243
+3.25.1 - b3244
 ——————————————
 New
 - Adds the station name to the main dashboard page and email subject
@@ -20,7 +20,7 @@ Fixed
 - Revert TLS1.2/1.3 changes in v3.25.0
 - Extensive HTTPClient code optimisations
 - Fix year bug reading from monthly log in NOAA monthly report generation
-- Fix suprious TokenParser messages from various extrernal task executions
+- Fix spurious TokenParser messages from various external task executions
 
 
 3.25.0 - b3241


### PR DESCRIPTION
New
- Adds the station name to the main dashboard page and email subject

Changed
- NOAA report selectors no longer limited to years greater than 2000

Fixed
- Tempest station now forces MX to calculate the average wind speed
- Leaf wetness sensor name changes not being saved in Locale strings
- Leaf wetness graph data empty for Davis sensors
- Average wind speed calculation for Davis VP, Davis WLL (when calibration applied), Imet, Tempest, WS2300 stations
- Another average wind speed calculation for Davis VP and Davis WLL (when broadcasts are not being received)
- Dashboard Local Time block - again!
- Zero length string error processing web tags
- Graph colours for PM2.5 and PM10 getting set to the same value
- Uncaught exception (TaskList has null entry) in PHP uploads
- 100% CPU bug in the new HTTP files on first processing of each file
- Revert TLS1.2/1.3 changes in v3.25.0
- Extensive HTTPClient code optimisations
- Fix year bug reading from monthly log in NOAA monthly report generation
- Fix spurious TokenParser messages from various external task executions
