### PR TITLE
v3.28.2

### DIFF
--- a/CumulusMX/App.config
+++ b/CumulusMX/App.config
@@ -1,27 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <configSections>
-      <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-          <section name="CumulusMX.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-      </sectionGroup>
-  </configSections>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
-  </startup>
-  <runtime>
-    <GCConserveMemory enabled="6" />
-  </runtime>
-<applicationSettings>
-    <CumulusMX.Properties.Settings>
-        <setting name="MinThreadPoolSize" serializeAs="String">
-            <value>10</value>
-        </setting>
-        <setting name="MaxThreadPoolSize" serializeAs="String">
-            <value>30</value>
-        </setting>
-        <setting name="PhpMaxConnections" serializeAs="String">
-            <value>5</value>
-        </setting>
-    </CumulusMX.Properties.Settings>
-  </applicationSettings>
+	<configSections>
+		<sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+			<section name="CumulusMX.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+		</sectionGroup>
+	</configSections>
+	<runtime>
+		<GCConserveMemory enabled="6" />
+	</runtime>
+	<applicationSettings>
+		<CumulusMX.Properties.Settings>
+			<setting name="MinThreadPoolSize" serializeAs="String">
+				<value>10</value>
+			</setting>
+			<setting name="MaxThreadPoolSize" serializeAs="String">
+				<value>30</value>
+			</setting>
+			<setting name="PhpMaxConnections" serializeAs="String">
+				<value>5</value>
+			</setting>
+		</CumulusMX.Properties.Settings>
+	</applicationSettings>
 </configuration>

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -721,11 +721,10 @@ namespace CumulusMX
 			LogConsoleMessage("Cumulus MX v." + Version + " build " + Build);
 			LogConsoleMessage("Working Dir: " + AppDir);
 
+			IsOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 			Type type = Type.GetType("Mono.Runtime");
 			if (type != null)
 			{
-				IsOSX = IsRunningOnMac();
-
 				MethodInfo displayName = type.GetMethod("GetDisplayName", BindingFlags.NonPublic | BindingFlags.Static);
 				if (displayName != null)
 					LogMessage("Mono version   : " + displayName.Invoke(null, null));
@@ -3733,31 +3732,6 @@ namespace CumulusMX
 		}
 
 		public string DecimalSeparator { get; set; }
-
-		private static bool IsRunningOnMac()
-		{
-			IntPtr buf = IntPtr.Zero;
-			try
-			{
-				buf = Marshal.AllocHGlobal(8192);
-				// This is a hacktastic way of getting sysname from uname ()
-				if (SafeNativeMethods.uname(buf) == 0)
-				{
-					string os = Marshal.PtrToStringAnsi(buf);
-					if (os == "Darwin")
-						return true;
-				}
-			}
-			catch
-			{
-			}
-			finally
-			{
-				if (buf != IntPtr.Zero)
-					Marshal.FreeHGlobal(buf);
-			}
-			return false;
-		}
 
 		internal void DoMoonPhase()
 		{

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1344,7 +1344,8 @@ namespace CumulusMX
 			LogMessage("Email logging :" + (SmtpOptions.Logging ? "enabled" : "disabled"));
 			LogMessage("Spike logging :" + (ErrorLogSpikeRemoval ? "enabled" : "disabled"));
 			LogMessage("Logging interval = " + logints[DataLogInterval] + " mins");
-			LogMessage("Real time interval = " + RealtimeInterval / 1000 + " secs");
+			LogMessage("Real time interval:" + (RealtimeIntervalEnabled ? "enabled" : "disabled") + ", uploads:" + (FtpOptions.RealtimeEnabled ? "enabled" : "disabled") + ", (" + RealtimeInterval / 1000 + " secs)");
+			LogMessage("Interval          :" + (WebIntervalEnabled ? "enabled" : "disabled") + ", uploads:" + (FtpOptions.IntervalEnabled ? "enabled" : "disabled") + ", (" + UpdateInterval + " mins)");
 			LogMessage("NoSensorCheck = " + (StationOptions.NoSensorCheck ? "1" : "0"));
 
 			TempFormat = "F" + TempDPlaces;

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1401,6 +1401,18 @@ namespace CumulusMX
 
 			SetupUnitText();
 
+			// set alarms units
+			HighWindAlarm.Units = Units.WindText;
+			HighGustAlarm.Units = Units.WindText;
+			HighRainRateAlarm.Units = Units.RainTrendText;
+			HighRainTodayAlarm.Units = Units.RainText;
+			PressChangeAlarm.Units = Units.PressTrendText;
+			HighPressAlarm.Units = Units.PressText;
+			LowPressAlarm.Units = Units.PressText;
+			TempChangeAlarm.Units = Units.TempTrendText;
+			HighTempAlarm.Units = Units.TempText;
+			LowTempAlarm.Units = Units.TempText;
+
 			LogMessage($"WindUnit={Units.WindText} RainUnit={Units.RainText} TempUnit={Units.TempText} PressureUnit={Units.PressText}");
 			LogMessage($"Manual rainfall: YTDRain={YTDrain:F3}, Correction Year={YTDrainyear}");
 			LogMessage($"RainDayThreshold={RainDayThreshold:F3}");

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -14298,17 +14298,20 @@ namespace CumulusMX
 
 		private string GetUploadFilename(string input, DateTime dat)
 		{
+			// we need to subtract the logging interval, otherwise the last log entry will be missed on the month rollover
+			var logDate = dat.AddMinutes(-(logints[DataLogInterval] + 1));
+
 			if (input == "<currentlogfile>")
 			{
-				return GetLogFileName(dat);
+				return GetLogFileName(logDate);
 			}
 			else if (input == "<currentextralogfile>")
 			{
-				return GetExtraLogFileName(dat);
+				return GetExtraLogFileName(logDate);
 			}
 			else if (input == "<airlinklogfile>")
 			{
-				return GetAirLinkLogFileName(dat);
+				return GetAirLinkLogFileName(logDate);
 			}
 			else if (input == "<noaayearfile>")
 			{
@@ -14329,8 +14332,10 @@ namespace CumulusMX
 					if (match.Success)
 					{
 						var idx = int.Parse(match.Groups[1].Value) - 1; // we use a zero relative array
+						// we need to subtract the logging interval, otherwise the last log entry will be missed on the month rollover
+						var custDate = dat.AddMinutes(-(CustomIntvlLogSettings[idx].Interval + 1));
 
-						return GetCustomIntvlLogFileName(idx, dat);
+						return GetCustomIntvlLogFileName(idx, custDate);
 					}
 					else
 					{
@@ -14349,17 +14354,20 @@ namespace CumulusMX
 
 		private string GetRemoteFileName(string input, DateTime dat)
 		{
+			// we need to subtract the logging interval, otherwise the last log entry will be missed on the month rollover
+			var logDate = dat.AddMinutes(-(logints[DataLogInterval] + 1));
+
 			if (input.Contains("<currentlogfile>"))
 			{
-				return input.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(dat)));
+				return input.Replace("<currentlogfile>", Path.GetFileName(GetLogFileName(logDate)));
 			}
 			else if (input.Contains("<currentextralogfile>"))
 			{
-				return input.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(dat)));
+				return input.Replace("<currentextralogfile>", Path.GetFileName(GetExtraLogFileName(logDate)));
 			}
 			else if (input.Contains("<airlinklogfile>"))
 			{
-				return input.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(dat)));
+				return input.Replace("<airlinklogfile>", Path.GetFileName(GetAirLinkLogFileName(logDate)));
 			}
 			else if (input.Contains("<noaayearfile>"))
 			{
@@ -14380,8 +14388,10 @@ namespace CumulusMX
 					if (match.Success)
 					{
 						var idx = int.Parse(match.Groups[1].Value) - 1; // we use a zero relative array
+						// we need to subtract the logging interval, otherwise the last log entry will be missed on the month rollover
+						var custDate = dat.AddMinutes(-(CustomIntvlLogSettings[idx].Interval + 1));
 
-						return input.Replace(match.Groups[0].Value, Path.GetFileName(GetCustomIntvlLogFileName(idx, dat)));
+						return input.Replace(match.Groups[0].Value, Path.GetFileName(GetCustomIntvlLogFileName(idx, custDate)));
 					}
 					else
 					{

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -7471,7 +7471,7 @@ namespace CumulusMX
 			{
 				// air quality captions (for Extra Sensor Data screen)
 				Trans.AirQualityCaptions[i] = ini.GetValue("AirQualityCaptions", "Sensor" + (i + 1), Trans.AirQualityCaptions[i]);
-				Trans.AirQualityAvgCaptions[i] = ini.GetValue("AirQualityCaptions", "SensorAvg" + (i + 1), Trans.AirQualityAvgCaptions[1]);
+				Trans.AirQualityAvgCaptions[i] = ini.GetValue("AirQualityCaptions", "SensorAvg" + (i + 1), Trans.AirQualityAvgCaptions[i]);
 			}
 
 			for (var i = 0; i < 8; i++)
@@ -7664,7 +7664,7 @@ namespace CumulusMX
 			{
 				// air quality captions (for Extra Sensor Data screen)
 				ini.SetValue("AirQualityCaptions", "Sensor" + (i + 1), Trans.AirQualityCaptions[i]);
-				ini.SetValue("AirQualityCaptions", "SensorAvg" + (i + 1), Trans.AirQualityAvgCaptions[1]);
+				ini.SetValue("AirQualityCaptions", "SensorAvg" + (i + 1), Trans.AirQualityAvgCaptions[i]);
 			}
 
 			for (var i = 0; i < 8; i++)

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -76,7 +76,7 @@
     <StartupObject>CumulusMX.Program</StartupObject>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
-    <Version>3.28.1.3278</Version>
+    <Version>3.28.2.3279</Version>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -18,16 +18,15 @@ namespace CumulusMX
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
 	{
 		private readonly System.Timers.Timer tmrCurrent;
-		private readonly System.Timers.Timer tmrHealth;
 		//private bool savedUseSpeedForAvgCalc;
 		private bool savedCalculatePeakGust;
 		private int maxArchiveRuns = 1;
-		private int weatherLinkArchiveInterval = 16 * 60; // Used to get historic Health, 16 minutes in seconds only for initial fetch after load
 		private int wlStationArchiveInterval = 5;
-		private bool wlLastArchiveFetchOk;
-		private bool wllVoltageLow;
 		private readonly AutoResetEvent bwDoneEvent = new AutoResetEvent(false);
 		private List<WlSensorListSensor> sensorList;
+		private readonly Dictionary<int, int> lsidToTx = new Dictionary<int, int>();
+		private readonly Dictionary<int, long> lsidLastUpdate = new Dictionary<int, long>();
+
 		private bool startingUp = true;
 		private new readonly Random random = new Random();
 		private DateTime lastRecordTime = DateTime.MinValue;
@@ -75,14 +74,13 @@ namespace CumulusMX
 			};
 
 			tmrCurrent = new System.Timers.Timer();
-			tmrHealth = new System.Timers.Timer();
 
 			// The Davis leafwetness sensors send a decimal value via WLL (only integer available via VP2/Vue)
 			cumulus.LeafWetDPlaces = 1;
 			cumulus.LeafWetFormat = "F1";
 
-			CalcRecentMaxGust = false;
-			cumulus.StationOptions.CalcuateAverageWindSpeed = false;
+			CalcRecentMaxGust = true;
+			cumulus.StationOptions.CalcuateAverageWindSpeed = true;
 			cumulus.StationOptions.UseSpeedForAvgCalc = true;
 			cumulus.StationOptions.CalculatedDP = false;
 			cumulus.StationOptions.CalculatedWC = false;
@@ -114,23 +112,26 @@ namespace CumulusMX
 			if (string.IsNullOrEmpty(cumulus.WllApiKey) && string.IsNullOrEmpty(cumulus.WllApiSecret))
 			{
 				// The basic API details have not been supplied
-				cumulus.LogWarningMessage("WLL - No WeatherLink.com API configuration supplied, just going to work locally");
-				cumulus.LogMessage("WLL - Cannot start historic downloads or retrieve health data");
+				cumulus.LogWarningMessage("No WeatherLink.com API configuration supplied, cannot continue");
+				cumulus.LogMessage("Cannot continue");
 				Cumulus.LogConsoleMessage("*** No WeatherLink.com API details supplied. Cannot start station", ConsoleColor.DarkCyan);
+				return;
 			}
 			else if (string.IsNullOrEmpty(cumulus.WllApiKey) || string.IsNullOrEmpty(cumulus.WllApiSecret))
 			{
 				// One of the API details is missing
 				if (string.IsNullOrEmpty(cumulus.WllApiKey))
 				{
-					cumulus.LogWarningMessage("WLL - Missing WeatherLink.com API Key");
+					cumulus.LogWarningMessage("Missing WeatherLink.com API Key");
 					Cumulus.LogConsoleMessage("*** Missing WeatherLink.com API Key. Cannot start station", ConsoleColor.Yellow);
 				}
 				else
 				{
-					cumulus.LogWarningMessage("WLL - Missing WeatherLink.com API Secret");
+					cumulus.LogWarningMessage("Missing WeatherLink.com API Secret");
 					Cumulus.LogConsoleMessage("*** Missing WeatherLink.com API Secret. Cannot start station", ConsoleColor.Yellow);
 				}
+
+				return;
 			}
 
 			// Get wl.com status
@@ -155,7 +156,7 @@ namespace CumulusMX
 			if (cumulus.WllStationId < 10)
 			{
 				// API details supplied, but Station Id is still invalid - do not start the station up.
-				cumulus.LogErrorMessage("WLL - The WeatherLink.com API is enabled, but no Station Id has been configured, not starting the station. Please correct this and restart Cumulus");
+				cumulus.LogErrorMessage("The WeatherLink.com API is enabled, but no Station Id has been configured, not starting the station. Please correct this and restart Cumulus");
 				Cumulus.LogConsoleMessage("The WeatherLink.com API is enabled, but no Station Id has been configured. Please correct this and restart Cumulus", ConsoleColor.Yellow);
 				return;
 			}
@@ -177,7 +178,7 @@ namespace CumulusMX
 				DoDayResetIfNeeded();
 				DoTrendValues(DateTime.Now);
 
-				cumulus.LogMessage("Starting Davis WLL");
+				cumulus.LogMessage("Starting Davis Cloud Station");
 				StartLoop();
 			}
 			else
@@ -196,20 +197,12 @@ namespace CumulusMX
 				Cumulus.syncInit.Wait();
 				//cumulus.LogDebugMessage("Lock: Station has the lock");
 
-				// Create a current conditions thread to poll readings every 10 seconds as temperature updates every 10 seconds
-				//GetWlCurrent(null, null);
-				//tmrCurrent.Elapsed += GetWlCurrent;
-				GetWlLastArchive(null, null);
-				tmrCurrent.Elapsed += GetWlLastArchive;
-				tmrCurrent.Interval = 30 * 1000;  // Every 30 seconds
+				// Create a current conditions thread to poll readings
+				GetCurrent(null, null);
+				tmrCurrent.Elapsed += GetCurrent;
+				tmrCurrent.Interval = 60 * 1000;  // Every 60 seconds
 				tmrCurrent.AutoReset = true;
 				tmrCurrent.Start();
-
-				// Get the archive data health to do the initial value populations
-				GetWlHistoricHealth();
-				// And reset the fetch interval to 2 minutes
-				weatherLinkArchiveInterval = 2 * 60;
-
 			}
 			catch (ThreadAbortException)
 			{
@@ -223,13 +216,11 @@ namespace CumulusMX
 
 		public override void Stop()
 		{
-			cumulus.LogMessage("Closing WLL connections");
+			cumulus.LogMessage("Closing Davis Cloud (WLL/WLC) connections");
 			try
 			{
 				if (tmrCurrent != null)
 					tmrCurrent.Stop();
-				if (tmrHealth != null)
-					tmrHealth.Stop();
 			}
 			catch
 			{
@@ -252,28 +243,14 @@ namespace CumulusMX
 			}
 		}
 
-		/*
-		private async void GetWlCurrent(object source, ElapsedEventArgs e)
+
+		private async void GetCurrent(object source, ElapsedEventArgs e)
 		{
-			// We only want to process at every archive interval, or on intial load, or if the last fetch was unsucessful
-			// Initial run, source will be null
-			// Possible intervals are 1, 5, or 30 minutes, fetch one minute after the archive time to allow for clock differences etc
-			var now = DateTime.Now;
-
-			if ((source != null && wlLastArchiveFetchOk && ((now.Minute - 1) % wlStationArchiveInterval != 0)) || now.Second > 35)
-			{
-				cumulus.LogDebugMessage("GetWlCurrent: Skipping");
-				return;
-			}
-
-			wlLastArchiveFetchOk = false;
-
-			//cumulus.LogMessage("GetWlCurrent: Get WL.com Current Data");
-			cumulus.LogMessage("GetWlCurrent: Get WL.com last archive Data");
+			cumulus.LogMessage("GetCurrent: Get WL.com Current Data");
 
 			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
 			{
-				cumulus.LogWarningMessage("GetWlCurrent: Missing WeatherLink API data in the configuration, aborting!");
+				cumulus.LogWarningMessage("GetCurrent: Missing WeatherLink API data in the configuration, aborting!");
 				cumulus.LastUpdateTime = DateTime.Now;
 				return;
 			}
@@ -282,12 +259,11 @@ namespace CumulusMX
 			{
 				const string msg = "No WeatherLink API station ID in the configuration";
 				cumulus.LogWarningMessage(msg);
-				Cumulus.LogConsoleMessage("GetWlCurrent: " + msg);
+				Cumulus.LogConsoleMessage("GetCurrent: " + msg);
 
 			}
 
-			//cumulus.LogMessage($"GetWlCurrent: Downloading Current Data from weatherlink.com");
-			cumulus.LogMessage($"GetWlCurrent: Downloading last archive Data from weatherlink.com");
+			cumulus.LogMessage($"GetWlCurrent: Downloading Current Data from weatherlink.com");
 
 			StringBuilder currentUrl = new StringBuilder("https://api.weatherlink.com/v2/current/" + cumulus.WllStationId);
 			currentUrl.Append("?api-key=" + cumulus.WllApiKey);
@@ -309,14 +285,14 @@ namespace CumulusMX
 				{
 					responseBody = response.Content.ReadAsStringAsync().Result;
 					responseCode = (int) response.StatusCode;
-					cumulus.LogDebugMessage($"GetWlCurrent: WeatherLink API Current Response code: {responseCode}");
-					cumulus.LogDataMessage($"GetWlCurrent: WeatherLink API Current Response: {responseBody}");
+					cumulus.LogDebugMessage($"GetCurrent: WeatherLink API Current Response code: {responseCode}");
+					cumulus.LogDataMessage($"GetCurrent: WeatherLink API Current Response: {responseBody}");
 				}
 
 				if (responseCode != 200)
 				{
 					var error = responseBody.FromJson<WlErrorResponse>();
-					cumulus.LogErrorMessage($"GetWlCurrent: WeatherLink API Current Error: {error.code}, {error.message}");
+					cumulus.LogErrorMessage($"GetCurrent: WeatherLink API Current Error: {error.code}, {error.message}");
 					Cumulus.LogConsoleMessage($" - Error {error.code}: {error.message}", ConsoleColor.Red);
 					return;
 				}
@@ -325,19 +301,19 @@ namespace CumulusMX
 
 				if (responseBody == "{}")
 				{
-					cumulus.LogWarningMessage("GetWlCurrent: WeatherLink API Current: No data was returned. Check your Device Id.");
+					cumulus.LogWarningMessage("GetCurrent: WeatherLink API Current: No data was returned. Check your Device Id.");
 					return;
 				}
 				else if (responseBody.StartsWith("{\"")) // basic sanity check
 				{
 					if (currObj.sensors.Count == 0)
 					{
-						cumulus.LogMessage("GetWlCurrent: No current data available");
+						cumulus.LogMessage("GetCurrent: No current data available");
 						return;
 					}
 					else
 					{
-						cumulus.LogMessage($"GetWlCurrent: Found {currObj.sensors.Count} sensors to process");
+						cumulus.LogMessage($"GetCurrent: Found {currObj.sensors.Count} sensors to process");
 
 						DecodeCurrent(currObj.sensors);
 
@@ -347,193 +323,26 @@ namespace CumulusMX
 				}
 				else // No idea what we got, dump it to the log
 				{
-					cumulus.LogErrorMessage("GetWlCurrent: Invalid current response received");
+					cumulus.LogErrorMessage("GetCurrent: Invalid current response received");
 					cumulus.LogMessage("Response body = " + responseBody.ToString());
 					return;
 				}
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage("GetWlCurrent:  Exception: " + ex.Message);
+				cumulus.LogErrorMessage("GetCurrent:  Exception: " + ex.Message);
 				if (ex.InnerException != null)
 				{
 					ex = Utils.GetOriginalException(ex);
-					cumulus.LogMessage($"GetWlCurrent: Base exception - {ex.Message}");
+					cumulus.LogMessage($"GetCurrent: Base exception - {ex.Message}");
 				}
 			}
-
-			wlLastArchiveFetchOk = true;
 
 			return;
 		}
-		*/
-
-		private async void GetWlLastArchive(object source, ElapsedEventArgs e)
-		{
-			// We only want to process at every archive interval, or on intial load, or if the last fetch was unsucessful
-			// Initial run, source will be null
-			// Possible intervals are 1, 5, or 30 minutes, fetch one minute after the archive time to allow for clock differences etc
-			var now = DateTime.Now;
-
-			if ((source != null && wlLastArchiveFetchOk && ((now.Minute - 1) % wlStationArchiveInterval != 0)) || now.Second > 35)
-			{
-				cumulus.LogDebugMessage("GetWlLastArchive: Skipping");
-				return;
-			}
-
-			wlLastArchiveFetchOk = false;
-
-			cumulus.LogMessage("GetWlLastArchive: Get WL.com last archive Data");
-
-			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
-			{
-				cumulus.LogWarningMessage("GetWlLastArchive: Missing WeatherLink API data in the configuration, aborting!");
-				cumulus.LastUpdateTime = DateTime.Now;
-				return;
-			}
-
-			if (cumulus.WllStationId < 10)
-			{
-				const string msg = "No WeatherLink API station ID in the configuration";
-				cumulus.LogWarningMessage(msg);
-				Cumulus.LogConsoleMessage("GetWlLastArchive: " + msg);
-
-			}
-
-			var unixDateTime = Utils.ToUnixTime(DateTime.Now);
-			var startTime = unixDateTime - weatherLinkArchiveInterval;
-			long endTime = unixDateTime;
-
-			cumulus.LogDebugMessage($"GetWlLastArchive: Downloading the historic record from WL.com from: {Utils.FromUnixTime(startTime):s} to: {Utils.FromUnixTime(endTime):s}");
-
-			StringBuilder historicUrl = new StringBuilder("https://api.weatherlink.com/v2/historic/" + cumulus.WllStationId);
-			historicUrl.Append("?api-key=" + cumulus.WllApiKey);
-			historicUrl.Append("&start-timestamp=" + startTime.ToString());
-			historicUrl.Append("&end-timestamp=" + endTime.ToString());
-
-			cumulus.LogDebugMessage($"WeatherLink URL = {historicUrl.ToString().Replace(cumulus.WllApiKey, "API_KEY")}");
-
-			WlHistory histObj;
-
-			try
-			{
-				string responseBody;
-				int responseCode;
-
-				var request = new HttpRequestMessage(HttpMethod.Get, historicUrl.ToString());
-				request.Headers.Add("X-Api-Secret", cumulus.WllApiSecret);
-
-				// we want to do this synchronously, so .Result
-				using (var response = await Cumulus.MyHttpClient.SendAsync(request))
-				{
-					responseBody = response.Content.ReadAsStringAsync().Result;
-					responseCode = (int) response.StatusCode;
-					cumulus.LogDebugMessage($"GetWlLastArchive: WeatherLink API Historic Response code: {responseCode}");
-					cumulus.LogDataMessage($"GetWlLastArchive: WeatherLink API Historic Response: {responseBody}");
-				}
-
-				if (responseCode != 200)
-				{
-					var error = responseBody.FromJson<WlErrorResponse>();
-					cumulus.LogWarningMessage($"GetWlLastArchive: WeatherLink API Historic Error: {error.code}, {error.message}");
-					Cumulus.LogConsoleMessage($" - Error {error.code}: {error.message}", ConsoleColor.Red);
-					return;
-				}
-
-				if (responseBody == "{}")
-				{
-					cumulus.LogWarningMessage("GetWlLastArchive: WeatherLink API Historic: No data was returned. Check your Device Id.");
-					return;
-				}
-				else if (responseBody.StartsWith("{\"")) // basic sanity check
-				{
-					histObj = responseBody.FromJson<WlHistory>();
-
-					if (histObj.sensors.Count == 0)
-					{
-						cumulus.LogMessage("GetWlLastArchive: No historic data available");
-						return;
-					}
-					else
-					{
-						cumulus.LogMessage($"GetWlLastArchive: Found {histObj.sensors.Count} sensors to process");
-
-						foreach (var sensor in histObj.sensors)
-						{
-							int sensorType = sensor.sensor_type;
-							int dataStructureType = sensor.data_structure_type;
-
-							if (sensor.data.Count > 0)
-							{
-								DecodeHistoric(dataStructureType, sensorType, sensor.data[sensor.data.Count - 1], true);
-							}
-						}
-
-						if (lastRecordTime != DateTime.MinValue)
-						{
-							// Now we have the primary data, calculate the derived data
-							if (cumulus.StationOptions.CalculatedWC)
-							{
-								// DoWindChill does all the required checks and conversions
-								DoWindChill(OutdoorTemperature, lastRecordTime);
-							}
-
-							DoApparentTemp(lastRecordTime);
-							DoFeelsLike(lastRecordTime);
-							DoHumidex(lastRecordTime);
-							DoCloudBaseHeatIndex(lastRecordTime);
-
-							DoForecast(string.Empty, false);
-
-							UpdateStatusPanel(lastRecordTime);
-							UpdateMQTT();
-
-							// SensorContactLost = localSensorContactLost;
-
-							cumulus.BatteryLowAlarm.Triggered = TxBatText.Contains("LOW");
-
-							cumulus.LogDebugMessage("WL current: Last data update = " + lastRecordTime.ToString("s"));
 
 
-							//// syncronise the timer to read just after the next update
-							//var time = (DateTime.Now - lastDataUpdate).TotalSeconds % 60;
-							//// get difference to 60 seconds and add 10 seconds to allow the servers to update
-							//// allow a drift of 5 seconds (10 + 5 = 15)
-							//if (time > 15)
-							//{
-							//	tmrCurrent.Interval = (70 - time) * 1000;
-							//	tmrCurrent.Stop();
-							//	tmrCurrent.Start();
-							//	cumulus.LogMessage($"WL current: Amending fetch timimg by {(time):F1} seconds");
-							//};
 
-						}
-
-						if (startingUp)
-							startingUp = false;
-					}
-				}
-				else // No idea what we got, dump it to the log
-				{
-					cumulus.LogErrorMessage("GetWlLastArchive: Invalid current response received");
-					cumulus.LogMessage("Response body = " + responseBody.ToString());
-					return;
-				}
-			}
-			catch (Exception ex)
-			{
-				cumulus.LogErrorMessage("GetWlLastArchive:  Exception: " + ex.Message);
-				if (ex.InnerException != null)
-				{
-					ex = Utils.GetOriginalException(ex);
-					cumulus.LogMessage($"GetWlLastArchive: Base exception - {ex.Message}");
-				}
-			}
-
-			wlLastArchiveFetchOk = true;
-
-			return;
-		}
 
 		/*
 		private void DecodeCurrent(List<WlCurrentSensor> sensors)
@@ -1472,10 +1281,10 @@ namespace CumulusMX
 
 		public override void startReadingHistoryData()
 		{
-			cumulus.LogMessage("WLL history: Reading history data from log files");
+			cumulus.LogMessage("History: Reading history data from log files");
 			LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
 
-			cumulus.LogMessage("WLL history: Reading archive data from WeatherLink API");
+			cumulus.LogMessage("History: Reading archive data from WeatherLink API");
 			bw = new BackgroundWorker { WorkerSupportsCancellation = true };
 			bw.DoWork += bw_ReadHistory;
 			bw.RunWorkerCompleted += bw_ReadHistoryCompleted;
@@ -1485,12 +1294,12 @@ namespace CumulusMX
 
 		private void bw_ReadHistoryCompleted(object sender, RunWorkerCompletedEventArgs e)
 		{
-			cumulus.LogMessage("WLL history: WeatherLink API archive reading thread completed");
+			cumulus.LogMessage("History: WeatherLink API archive reading thread completed");
 			if (e.Error != null)
 			{
-				cumulus.LogErrorMessage("WLL history: Archive reading thread apparently terminated with an error: " + e.Error.Message);
+				cumulus.LogErrorMessage("History: Archive reading thread apparently terminated with an error: " + e.Error.Message);
 			}
-			cumulus.LogMessage("WLL history: Updating highs and lows");
+			cumulus.LogMessage("History: Updating highs and lows");
 			//using (cumulusEntities dataContext = new cumulusEntities())
 			//{
 			//    UpdateHighsAndLows(dataContext);
@@ -1525,7 +1334,7 @@ namespace CumulusMX
 
 				do
 				{
-					GetWlHistoricData(worker);
+					GetHistoricData(worker);
 					archiveRun++;
 				} while (archiveRun < maxArchiveRuns && worker.CancellationPending == false);
 
@@ -1545,13 +1354,13 @@ namespace CumulusMX
 			bwDoneEvent.Set();
 		}
 
-		private void GetWlHistoricData(BackgroundWorker worker)
+		private void GetHistoricData(BackgroundWorker worker)
 		{
-			cumulus.LogMessage("GetWlHistoricData: Get WL.com Historic Data");
+			cumulus.LogMessage("GetHistoricData: Get WL.com Historic Data");
 
 			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
 			{
-				cumulus.LogWarningMessage("GetWlHistoricData: Missing WeatherLink API data in the configuration, aborting!");
+				cumulus.LogWarningMessage("GetHistoricData: Missing WeatherLink API data in the configuration, aborting!");
 				cumulus.LastUpdateTime = DateTime.Now;
 				return;
 			}
@@ -1560,7 +1369,7 @@ namespace CumulusMX
 			{
 				const string msg = "No WeatherLink API station ID in the configuration";
 				cumulus.LogWarningMessage(msg);
-				Cumulus.LogConsoleMessage("GetWlHistoricData: " + msg);
+				Cumulus.LogConsoleMessage("GetHistoricData: " + msg);
 
 			}
 
@@ -1578,7 +1387,7 @@ namespace CumulusMX
 			}
 
 			Cumulus.LogConsoleMessage($"Downloading Historic Data from WL.com from: {cumulus.LastUpdateTime:s} to: {Utils.FromUnixTime(endTime):s}");
-			cumulus.LogMessage($"GetWlHistoricData: Downloading Historic Data from WL.com from: {cumulus.LastUpdateTime:s} to: {Utils.FromUnixTime(endTime):s}");
+			cumulus.LogMessage($"GetHistoricData: Downloading Historic Data from WL.com from: {cumulus.LastUpdateTime:s} to: {Utils.FromUnixTime(endTime):s}");
 
 			StringBuilder historicUrl = new StringBuilder("https://api.weatherlink.com/v2/historic/" + cumulus.WllStationId);
 			historicUrl.Append("?api-key=" + cumulus.WllApiKey);
@@ -1615,14 +1424,14 @@ namespace CumulusMX
 				{
 					responseBody = response.Content.ReadAsStringAsync().Result;
 					responseCode = (int) response.StatusCode;
-					cumulus.LogDebugMessage($"GetWlHistoricData: WeatherLink API Historic Response code: {responseCode}");
-					cumulus.LogDataMessage($"GetWlHistoricData: WeatherLink API Historic Response: {responseBody}");
+					cumulus.LogDebugMessage($"GetHistoricData: WeatherLink API Historic Response code: {responseCode}");
+					cumulus.LogDataMessage($"GetHistoricData: WeatherLink API Historic Response: {responseBody}");
 				}
 
 				if (responseCode != 200)
 				{
 					var historyError = responseBody.FromJson<WlErrorResponse>();
-					cumulus.LogErrorMessage($"GetWlHistoricData: WeatherLink API Historic Error: {historyError.code}, {historyError.message}");
+					cumulus.LogErrorMessage($"GetHistoricData: WeatherLink API Historic Error: {historyError.code}, {historyError.message}");
 					Cumulus.LogConsoleMessage($" - Error {historyError.code}: {historyError.message}", ConsoleColor.Red);
 					cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
 					return;
@@ -1630,7 +1439,7 @@ namespace CumulusMX
 
 				if (responseBody == "{}")
 				{
-					cumulus.LogWarningMessage("GetWlHistoricData: WeatherLink API Historic: No data was returned. Check your Device Id.");
+					cumulus.LogWarningMessage("GetHistoricData: WeatherLink API Historic: No data was returned. Check your Device Id.");
 					Cumulus.LogConsoleMessage(" - No historic data available");
 					cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
 					return;
@@ -1658,31 +1467,31 @@ namespace CumulusMX
 
 					if (noOfRecs == 0)
 					{
-						cumulus.LogMessage("GetWlHistoricData: No historic data available");
+						cumulus.LogMessage("GetHistoricData: No historic data available");
 						Cumulus.LogConsoleMessage(" - No historic data available");
 						cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
 						return;
 					}
 					else
 					{
-						cumulus.LogMessage($"GetWlHistoricData: Found {noOfRecs} historic records to process");
+						cumulus.LogMessage($"GetHistoricData: Found {noOfRecs} historic records to process");
 					}
 				}
 				else // No idea what we got, dump it to the log
 				{
-					cumulus.LogErrorMessage("GetWlHistoricData: Invalid historic message received");
-					cumulus.LogMessage("GetWlHistoricData: Received: " + responseBody);
+					cumulus.LogErrorMessage("GetHistoricData: Invalid historic message received");
+					cumulus.LogMessage("GetHistoricData: Received: " + responseBody);
 					cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
 					return;
 				}
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage("GetWlHistoricData:  Exception: " + ex.Message);
+				cumulus.LogErrorMessage("GetHistoricData:  Exception: " + ex.Message);
 				if (ex.InnerException != null)
 				{
 					ex = Utils.GetOriginalException(ex);
-					cumulus.LogMessage($"GetWlHistoricData: Base exception - {ex.Message}");
+					cumulus.LogMessage($"GetHistoricData: Base exception - {ex.Message}");
 				}
 
 				cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
@@ -1703,7 +1512,7 @@ namespace CumulusMX
 					var refData = sensorWithMostRecs.data[dataIndex].FromJsv<WlHistorySensorDataType13Baro>();
 					var timestamp = Utils.FromUnixTime(refData.ts);
 
-					cumulus.LogMessage($"GetWlHistoricData: Processing record {timestamp:yyyy-MM-dd HH:mm}");
+					cumulus.LogMessage($"GetHistoricData: Processing record {timestamp:yyyy-MM-dd HH:mm}");
 
 					var h = timestamp.Hour;
 
@@ -1724,7 +1533,7 @@ namespace CumulusMX
 					if ((h == rollHour) && !rolloverdone)
 					{
 						// do roll-over
-						cumulus.LogMessage("GetWlHistoricData: Day roll-over " + timestamp.ToShortTimeString());
+						cumulus.LogMessage("GetHistoricData: Day roll-over " + timestamp.ToShortTimeString());
 						DayReset(timestamp);
 						rolloverdone = true;
 					}
@@ -1775,7 +1584,7 @@ namespace CumulusMX
 									}
 								}
 								if (!found)
-									cumulus.LogDebugMessage("GetWlHistoricData: Warning. No outdoor AirLink data for this log interval !!");
+									cumulus.LogDebugMessage("GetHistoricData: Warning. No outdoor AirLink data for this log interval !!");
 							}
 							else
 							{
@@ -1804,7 +1613,7 @@ namespace CumulusMX
 									}
 								}
 								if (!found)
-									cumulus.LogDebugMessage("GetWlHistoricData: Warning. No indoor AirLink data for this log interval !!");
+									cumulus.LogDebugMessage("GetHistoricData: Warning. No indoor AirLink data for this log interval !!");
 							}
 							else
 							{
@@ -1837,7 +1646,7 @@ namespace CumulusMX
 
 					// Log all the data
 					cumulus.DoLogFile(timestamp, false);
-					cumulus.LogMessage("GetWlHistoricData: Log file entry written");
+					cumulus.LogMessage("GetHistoricData: Log file entry written");
 					cumulus.MySqlRealtimeFile(999, false, timestamp);
 					cumulus.DoCustomIntervalLogs(timestamp);
 
@@ -1867,11 +1676,11 @@ namespace CumulusMX
 
 					if (!Program.service)
 						Console.Write("\r - processed " + (((double) dataIndex + 1) / noOfRecs).ToString("P0"));
-					cumulus.LogMessage($"GetWlHistoricData: {dataIndex + 1} of {noOfRecs} archive entries processed");
+					cumulus.LogMessage($"GetHistoricData: {dataIndex + 1} of {noOfRecs} archive entries processed");
 				}
 				catch (Exception ex)
 				{
-					cumulus.LogErrorMessage("GetWlHistoricData: Exception: " + ex.Message);
+					cumulus.LogErrorMessage("GetHistoricData: Exception: " + ex.Message);
 				}
 			}
 
@@ -1879,7 +1688,1312 @@ namespace CumulusMX
 				Console.WriteLine(""); // flush the progress line
 		}
 
-		private void DecodeHistoric(int dataType, int sensorType, string json, bool current=false)
+
+		private void DecodeCurrent(List<WlCurrentSensor> sensors)
+		{
+			// The WLL sends the timestamp in Unix ticks, and in UTC
+
+			foreach (var sensor in sensors)
+			{
+				try
+				{
+					// first separate out the "special" sensors
+					switch (sensor.sensor_type)
+					{
+						// Leaf/soil sensor
+						case 56:
+							{
+								var data = sensor.data.FromJsv<WLCurrentSensorDataType12_25[]>();
+								var txid = lsidToTx[sensor.lsid];
+								/*
+								 * Leaf Wetness
+								 * wet_leaf_1
+								 * wet_leaf_2
+								 */
+
+								foreach (var rec in data)
+								{
+									try
+									{
+										if (rec.ts == lsidLastUpdate[sensor.lsid])
+										{
+											cumulus.LogDebugMessage($"DecodeCurrent: Skipping Leaf/Soil sensor {txid}, already processed this ts");
+											continue;
+										}
+										cumulus.LogDebugMessage($"DecodeCurrent: Using Leaf/Soil {txid}");
+									}
+									catch (KeyNotFoundException)
+									{
+										lsidLastUpdate.Add(sensor.lsid, rec.ts);
+									}
+									catch (Exception ex)
+									{
+										cumulus.LogExceptionMessage(ex, "DecodeCurrent: Error determining Leaf/Soil last ts");
+									}
+
+									lsidLastUpdate[sensor.lsid] = rec.ts;
+
+									// We are relying on user configuration here, trap any errors
+									try
+									{
+										if (cumulus.WllExtraLeafTx1 == txid)
+										{
+											var idx = "wet_leaf_" + cumulus.WllExtraLeafIdx1;
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoLeafWetness(val.Value, 1);
+										}
+
+										if (cumulus.WllExtraLeafTx2 == txid)
+										{
+											var idx = "wet_leaf_" + cumulus.WllExtraLeafIdx2;
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoLeafWetness(val.Value, 2);
+										}
+									}
+									catch (Exception e)
+									{
+										cumulus.LogErrorMessage($"Error, DecodeCurrent, LeafWetness: {e.Message}");
+									}
+
+									/*
+									 * Soil Moisture
+									 * Available fields
+									 * moist_soil_1
+									 * moist_soil_2
+									 * moist_soil_3
+									 * moist_soil_4
+									 *
+									 */
+
+									if (cumulus.WllExtraSoilMoistureTx1 == txid)
+									{
+										var idx = "moist_soil_" + cumulus.WllExtraSoilMoistureIdx1;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilMoisture(val.Value, 1);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing soil moisture #{cumulus.WllExtraSoilMoistureIdx1} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+									if (cumulus.WllExtraSoilMoistureTx2 == txid)
+									{
+										var idx = "moist_soil_" + cumulus.WllExtraSoilMoistureIdx2;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilMoisture(val.Value, 2);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing soil moisture #{cumulus.WllExtraSoilMoistureIdx2} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+									if (cumulus.WllExtraSoilMoistureTx3 == txid)
+									{
+										var idx = "moist_soil_" + cumulus.WllExtraSoilMoistureIdx3;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilMoisture(val.Value, 3);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing soil moisture #{cumulus.WllExtraSoilMoistureIdx3} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+									if (cumulus.WllExtraSoilMoistureTx4 == txid)
+									{
+										var idx = "moist_soil_" + cumulus.WllExtraSoilMoistureIdx4;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilMoisture(val.Value, 4);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing soil moisture #{cumulus.WllExtraSoilMoistureIdx4} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+
+									/*
+									* Soil Temperature
+									* Available fields
+									* temp_1
+									* temp_2
+									* temp_3
+									* temp_4
+									*/
+
+									if (cumulus.WllExtraSoilTempTx1 == txid)
+									{
+										var idx = "temp_" + cumulus.WllExtraSoilTempIdx1;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilTemp(ConvertUnits.TempFToUser(val.Value), 1);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing extra soil temp #{cumulus.WllExtraSoilTempIdx1} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+									if (cumulus.WllExtraSoilTempTx2 == txid)
+									{
+										var idx = "temp_" + cumulus.WllExtraSoilTempIdx2;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilTemp(ConvertUnits.TempFToUser(val.Value), 2);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing extra soil temp #{cumulus.WllExtraSoilTempIdx2} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+									if (cumulus.WllExtraSoilTempTx3 == txid)
+									{
+										var idx = "temp_" + cumulus.WllExtraSoilTempIdx3;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilTemp(ConvertUnits.TempFToUser(val.Value), 3);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing extra soil temp #{cumulus.WllExtraSoilTempIdx3} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+									if (cumulus.WllExtraSoilTempTx4 == txid)
+									{
+										var idx = "temp_" + cumulus.WllExtraSoilTempIdx4;
+										try
+										{
+											var val = (double?) rec[idx];
+											if (val.HasValue)
+												DoSoilTemp(ConvertUnits.TempFToUser(val.Value), 4);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing extra soil temp #{cumulus.WllExtraSoilTempIdx4} on TxId {txid}");
+											cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+										}
+									}
+
+									// health data
+									if (rec.trans_battery_flag.HasValue)
+									{
+										SetTxBatteryStatus(txid, rec.trans_battery_flag.Value);
+
+										if (rec.trans_battery_flag == 1)
+										{
+											cumulus.LogWarningMessage($"Battery voltage is low in TxId {txid}");
+										}
+									}
+									if (rec.rx_state.HasValue && rec.rx_state != 0)
+									{
+										cumulus.LogWarningMessage($"Recive state for ISS TxId {txid} is: {(rec.rx_state == 1 ? "Rescan" : "Lost")}");
+									}
+
+								}
+							}
+							break;
+
+						// WLL/WLC barometer
+						case 242:
+							/*
+							* Available fields
+							* bar_sea_level
+							* bar_trend
+							* bar_absolute
+							* bar_offset
+							*/
+							{
+								// log the current value
+								try
+								{
+									var data = sensor.data.FromJsv<WlCurrentSensorDataType12_19Baro[]>();
+
+									foreach (var rec in data)
+									{
+										try
+										{
+											if (rec.ts == lsidLastUpdate[sensor.lsid])
+											{
+												cumulus.LogDebugMessage($"DecodeCurrent: Skipping barometer, already processed this ts");
+												continue;
+											}
+											cumulus.LogDebugMessage("DecodeCurrent: Using barometer");
+										}
+										catch (KeyNotFoundException)
+										{
+											lsidLastUpdate.Add(sensor.lsid, rec.ts);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogExceptionMessage(ex, "DecodeCurrent: Error determining barometer last ts");
+										}
+
+										lsidLastUpdate[sensor.lsid] = rec.ts;
+
+										if (rec.bar_sea_level.HasValue)
+										{
+											// leave it at current value
+											var ts = Utils.FromUnixTime(rec.ts);
+											DoPressure(ConvertUnits.PressINHGToUser(rec.bar_sea_level.Value), ts);
+										}
+										else
+										{
+											cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Baro data (high)");
+										}
+
+										// Altimeter from absolute
+										if (rec.bar_absolute.HasValue)
+										{
+											StationPressure = ConvertUnits.PressINHGToUser(rec.bar_absolute.Value);
+											// Or do we use calibration? The VP2 code doesn't?
+											//StationPressure = ConvertUnits.PressINHGToUser(data.Value<double>("bar_absolute")) * cumulus.Calib.Press.Mult + cumulus.Calib.Press.Offset;
+											AltimeterPressure = ConvertUnits.PressMBToUser(StationToAltimeter(ConvertUnits.UserPressureToHPa(StationPressure), AltitudeM(cumulus.Altitude)));
+										}
+									}
+								}
+								catch (Exception ex)
+								{
+									cumulus.LogErrorMessage($"DecodeCurrent: Error processing baro reading. Error: {ex.Message}");
+								}
+							}
+
+							break;
+
+						// WLL/WLC Inside temp/hum
+						case 243:
+						case 365:
+							/*
+							 * Available fields
+							 * temp_in
+							 * hum_in
+							 * dew_point_in
+							 * heat_index_in
+							 * wet_bulb_in
+							 * wbgt_in
+							 */
+							{
+								var data = sensor.data.FromJsv<WlCurrentSensorDataType12_21Temp[]>();
+
+								foreach (var rec in data)
+								{
+									try
+									{
+										if (rec.ts == lsidLastUpdate[sensor.lsid])
+										{
+											cumulus.LogDebugMessage("DecodeCurrent: Skipping inside temp/hum, already processed this ts");
+											continue;
+										}
+										cumulus.LogDebugMessage($"DecodeCurrent: Using Inside temp/hum");
+									}
+									catch (KeyNotFoundException)
+									{
+										lsidLastUpdate.Add(sensor.lsid, rec.ts);
+									}
+									catch (Exception ex)
+									{
+										cumulus.LogExceptionMessage(ex, "DecodeCurrent: Error determining inside t/h last ts");
+									}
+
+									lsidLastUpdate[sensor.lsid] = rec.ts;
+
+									try
+									{
+										if (rec.temp_in.HasValue)
+										{
+											DoIndoorTemp(ConvertUnits.TempFToUser(rec.temp_in.Value));
+										}
+										else
+										{
+											cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Inside Temperature");
+										}
+									}
+									catch (Exception ex)
+									{
+										cumulus.LogErrorMessage($"DecodeCurrent: Error processing temp-in reading. Error: {ex.Message}]");
+									}
+
+
+									try
+									{
+										if (rec.hum_in.HasValue)
+										{
+											DoIndoorHumidity(Convert.ToInt32(rec.hum_in.Value));
+										}
+										else
+										{
+											cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Inside Humidity");
+										}
+									}
+									catch (Exception ex)
+									{
+										cumulus.LogDebugMessage($"DecodeCurrent: Error processing humidity-in. Error: {ex.Message}]");
+									}
+								}
+							}
+
+							break;
+
+						// WLL Health
+						case 504:
+							{
+								var data = sensor.data.FromJsv<WlHealthDataType15[]>();
+								foreach (var rec in data)
+								{
+									try
+									{
+										if (rec.ts == lsidLastUpdate[sensor.lsid])
+										{
+											cumulus.LogDebugMessage($"DecodeCurrent: Skipping WLL Health, already processed this ts");
+											continue;
+										}
+										cumulus.LogDebugMessage("DecodeCurrent: Using WLL health");
+									}
+									catch (KeyNotFoundException)
+									{
+										lsidLastUpdate.Add(sensor.lsid, rec.ts);
+									}
+									catch (Exception ex)
+									{
+										cumulus.LogExceptionMessage(ex, "DecodeCurrent: Error determining WLL health last ts");
+									}
+
+									lsidLastUpdate[sensor.lsid] = rec.ts;
+
+									DecodeWllHealth(rec, false);
+								}
+							}
+							break;
+
+						// WLC health
+						case 509:
+							{
+								var data = sensor.data.FromJsv<WlHealthDataType27[]>();
+								foreach (var rec in data)
+								{
+									try
+									{
+										if (rec.ts == lsidLastUpdate[sensor.lsid])
+										{
+											cumulus.LogDebugMessage($"DecodeCurrent: Skipping WLC Health, already processed this ts");
+											continue;
+										}
+										cumulus.LogDebugMessage("DecodeCurrent: Using WLC health");
+									}
+									catch (KeyNotFoundException)
+									{
+										lsidLastUpdate.Add(sensor.lsid, rec.ts);
+									}
+									catch (Exception ex)
+									{
+										cumulus.LogExceptionMessage(ex, "DecodeCurrent: Error determining WLC health last ts");
+									}
+
+									lsidLastUpdate[sensor.lsid] = rec.ts;
+									DecodeWlcHealth(rec, false);
+								}
+							}
+							break;
+
+						// AirLink - Outdoor/Indoor
+						case 323:
+						case 326:
+							//cumulus.LogDebugMessage("TODO: Decode AirLink");
+							break;
+
+						// AirLink Health
+						case 506:
+							//cumulus.LogDebugMessage("TODO: Decode AirLink Health");
+							break;
+
+						// everything else is ISS - too many sensor types to list, just go on structure type!
+						default:
+							switch (sensor.data_structure_type)
+							{
+								// VP2 ISS archive revision A/B
+								case 1:
+									{
+										var data = sensor.data.FromJsv<WLCurrentSensordDataType1_2>();
+
+										try
+										{
+											if (data.ts == lsidLastUpdate[sensor.lsid])
+											{
+												cumulus.LogDebugMessage($"DecodeCurrent: Skipping ISS {data.tx_id}, already processed this ts");
+												continue;
+											}
+											cumulus.LogDebugMessage($"DecodeCurrent: Using ISS {data.tx_id}");
+										}
+										catch (KeyNotFoundException)
+										{
+											lsidLastUpdate.Add(sensor.lsid, data.ts);
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogExceptionMessage(ex, $"DecodeCurrent: Error determining ISS {data.tx_id} last ts");
+										}
+
+										lsidLastUpdate[sensor.lsid] = data.ts;
+
+										lastRecordTime = Utils.FromUnixTime(data.ts);
+										// Temperature & Humidity
+										/*
+										 * Available fields
+										 * hum_in
+										 * hum_out
+										 * temp_in
+										 * temp_out
+										 * dew_point
+										 * wet_bulb
+										 * heat_index
+										 * wind_chill
+										 * thw_index
+										 * thsw_index
+										 * wbgt
+										 * hdd_day
+										 * cdd_day
+										 */
+
+										try
+										{
+											// do humidity
+											if (data.hum_out.HasValue)
+											{
+												DoOutdoorHumidity(Convert.ToInt32(data.hum_out.Value), lastRecordTime);
+											}
+											else
+											{
+												cumulus.LogErrorMessage($"DecodeCurrent: Warning, no valid Humidity data on TxId {data.tx_id}");
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing Primary humidity value on TxId {data.tx_id}. Error: {ex.Message}");
+										}
+
+										// do temperature after humidity as DoOutdoorTemp contains dewpoint calculation (if user selected)
+										try
+										{
+											if (data.temp_out.HasValue && data.temp_out == -99)
+											{
+												cumulus.LogErrorMessage($"DecodeCurrent: Warning, no valid Primary temperature value found [-99] on TxId {data.tx_id}");
+											}
+											else
+											{
+												cumulus.LogDebugMessage($"DecodeCurrent: using temp/hum data from TxId {data.tx_id}");
+
+												// do last temp
+												if (data.temp_out.HasValue)
+												{
+													DoOutdoorTemp(ConvertUnits.TempFToUser(data.temp_out.Value), lastRecordTime);
+												}
+												else
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Warning, no valid Temperature data on TxId {data.tx_id}");
+												}
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing Primary temperature value on TxId {data.tx_id}. Error: {ex.Message}");
+										}
+
+
+										try
+										{
+											// do DP
+											if (data.dew_point.HasValue)
+											{
+												DoOutdoorDewpoint(ConvertUnits.TempFToUser(data.dew_point.Value), lastRecordTime);
+											}
+											else
+											{
+												cumulus.LogErrorMessage($"DecodeCurrent: Warning, no valid Dew Point data on TxId {data.tx_id}");
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing dew point value on TxId {data.tx_id}. Error: {ex.Message}");
+										}
+
+										if (!cumulus.StationOptions.CalculatedWC)
+										{
+											// use wind chill from station - otherwise we calculate it at the end of processing the record when we have all the data
+											try
+											{
+												// do last WC
+												if (data.wind_chill.HasValue)
+												{
+													DoWindChill(ConvertUnits.TempFToUser(data.wind_chill.Value), lastRecordTime);
+												}
+												else
+												{
+													cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Wind Chill data on TxId {data.tx_id}");
+												}
+											}
+											catch (Exception ex)
+											{
+												cumulus.LogErrorMessage($"DecodeCurrent: Error processing wind chill value on TxId {data.tx_id}. Error: {ex.Message}");
+											}
+										}
+
+										// Wind
+										/*
+											* Available fields
+											*
+											* wind_speed
+											* wind_dir
+											* wind_speed_10_min_avg
+											* wind_gust_10_min
+											*
+											*/
+
+										try
+										{
+											if (data.wind_speed.HasValue && data.wind_dir.HasValue)
+											{
+												var gust = ConvertUnits.WindMPHToUser(data.wind_speed.Value);
+												// dir is a direction code: 0=N, 1=NNE, ... 14=NW, 15=NNW - convert to degress
+												var dir = (int) ((data.wind_dir ?? 0) * 22.5);
+
+												cumulus.LogDebugMessage($"DecodeCurrent: using wind data from TxId {data.tx_id}");
+
+												DoWind(gust, dir, -1, lastRecordTime);
+
+												if (data.wind_gust_10_min.HasValue)
+												{
+													CheckHighGust(ConvertUnits.WindMPHToUser(data.wind_gust_10_min.Value), dir, lastRecordTime);
+												}
+											}
+											else
+											{
+												cumulus.LogDebugMessage($"DecodeCurrent: Warning, no valid Wind data on TxId {data.tx_id}");
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing wind values on TxId {data.tx_id}. Error: {ex.Message}");
+										}
+
+										// Rainfall
+										/*
+											* Available fields:
+											*
+											* rain_rate_clicks
+											* rain_rate_in
+											* rain_rate_mm
+											* rain_storm_clicks
+											* rain_storm_in
+											* rain_storm_mm
+											* rain_storm_start_date
+											* rain_day_clicks
+											* rain_day_in
+											* rain_day_mm
+											* rain_month_clicks
+											* rain_month_in
+											* rain_month_mm
+											* rain_year_clicks
+											* rain_year_in
+											* rain_year_mm
+											*
+											*/
+
+										try
+										{
+											if (data.rain_year_clicks.HasValue && data.rain_rate_clicks.HasValue)
+											{
+												cumulus.LogDebugMessage($"DecodeCurrent: using rain data from TxId {data.tx_id}");
+
+												var rain = ConvertRainClicksToUser(data.rain_year_clicks.Value, cumulus.DavisOptions.RainGaugeType);
+												var rainrate = ConvertRainClicksToUser(data.rain_rate_clicks.Value, cumulus.DavisOptions.RainGaugeType);
+												if (rainrate < 0)
+												{
+													rainrate = 0;
+												}
+
+												DoRain(rain, rainrate, lastRecordTime);
+											}
+											else
+											{
+												cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Rain data on TxId {data.tx_id}");
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing rain data on TxId {data.tx_id}. Error:{ex.Message}");
+										}
+
+										// Pressure
+										/*
+											bar
+										*/
+										// log the current value
+										try
+										{
+											if (data.bar != null)
+											{
+												// leave it at current value
+												cumulus.LogDebugMessage("DecodeCurrent: found Baro data");
+												DoPressure(ConvertUnits.PressINHGToUser((double) data.bar), lastRecordTime);
+											}
+											else
+											{
+												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Baro data");
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing baro reading. Error: {ex.Message}");
+										}
+
+
+										// UV
+										/*
+											* Available fields
+											* "uv"
+											*/
+										try
+										{
+											if (data.uv.HasValue)
+											{
+												cumulus.LogDebugMessage($"DecodeCurrent: using UV data from TxId {data.tx_id}");
+
+												DoUV(data.uv.Value, lastRecordTime);
+											}
+											else
+											{
+												cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid UV data on TxId {data.tx_id}");
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing UV value on TxId {data.tx_id}. Error: {ex.Message}");
+										}
+
+										// Solar
+										/*
+											* Available fields
+											* solar_rad
+											* et_day (inches) - ET field is populated in the ISS archive records, which may not be the same as the solar
+											* et_month
+											* et_year
+											*/
+										try
+										{
+											if (data.solar_rad.HasValue)
+											{
+												cumulus.LogDebugMessage($"DecodeCurrent: using solar data from TxId {data.tx_id}");
+												DoSolarRad(data.solar_rad.Value, lastRecordTime);
+											}
+											else
+											{
+												cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Solar data on TxId {data.tx_id}");
+											}
+
+											if (data.et_year.HasValue && !cumulus.StationOptions.CalculatedET)
+											{
+												if ((data.et_year.Value >= 0) && (data.et_year.Value < 32000))
+												{
+													DoET(ConvertUnits.RainINToUser(data.et_year.Value), lastRecordTime);
+												}
+											}
+										}
+										catch (Exception ex)
+										{
+											cumulus.LogErrorMessage($"DecodeCurrent: Error processing Solar value on TxId {data.tx_id}. Error: {ex.Message}");
+										}
+
+										string idx = "";
+
+										// Leaf Wetness
+										try
+										{
+
+											if (data.wet_leaf_1.HasValue)
+											{
+												DoLeafWetness(data.wet_leaf_1.Value, 1);
+											}
+											if (data.wet_leaf_2.HasValue)
+											{
+												DoLeafWetness(data.wet_leaf_2.Value, 2);
+											}
+											if (data.wet_leaf_3.HasValue)
+											{
+												DoLeafWetness(data.wet_leaf_3.Value, 3);
+											}
+											if (data.wet_leaf_4.HasValue)
+											{
+												DoLeafWetness(data.wet_leaf_4.Value, 4);
+											}
+										}
+										catch (Exception e)
+										{
+											cumulus.LogErrorMessage($"Error, DecodeCurrent, LeafWetness txid={data.tx_id}: {e.Message}");
+										}
+
+
+										// Soil Moisture
+										try
+										{
+											if (data.moist_soil_1.HasValue)
+											{
+												DoSoilMoisture(data.moist_soil_1.Value, 1);
+											}
+											if (data.moist_soil_2.HasValue)
+											{
+												DoSoilMoisture(data.moist_soil_2.Value, 2);
+											}
+											if (data.moist_soil_3.HasValue)
+											{
+												DoSoilMoisture(data.moist_soil_3.Value, 3);
+											}
+											if (data.moist_soil_4.HasValue)
+											{
+												DoSoilMoisture(data.moist_soil_4.Value, 4);
+											}
+										}
+										catch (Exception e)
+										{
+											cumulus.LogErrorMessage($"Error, DecodeCurrent, SoilMoisture txid={data.tx_id}, idx={idx}: {e.Message}");
+										}
+
+
+										// Soil Temperature
+										try
+										{
+											if (data.temp_soil_1.HasValue)
+											{
+												DoSoilMoisture(ConvertUnits.TempFToUser(data.temp_soil_1.Value), 1);
+											}
+											if (data.temp_soil_2.HasValue)
+											{
+												DoSoilMoisture(ConvertUnits.TempFToUser(data.temp_soil_2.Value), 2);
+											}
+											if (data.temp_soil_3.HasValue)
+											{
+												DoSoilMoisture(ConvertUnits.TempFToUser(data.temp_soil_3.Value), 3);
+											}
+											if (data.temp_soil_4.HasValue)
+											{
+												DoSoilMoisture(ConvertUnits.TempFToUser(data.temp_soil_4.Value), 4);
+											}
+										}
+										catch (Exception e)
+										{
+											cumulus.LogErrorMessage($"Error, DecodeCurrent, SoilTemp txid={data.tx_id}, idx={idx}: {e.Message}");
+										}
+
+										// Extra Temperature
+										try
+										{
+											if (data.temp_extra_1.HasValue)
+											{
+												DoExtraTemp(ConvertUnits.TempFToUser(data.temp_extra_1.Value), 1);
+											}
+											if (data.temp_extra_2.HasValue)
+											{
+												DoExtraTemp(ConvertUnits.TempFToUser(data.temp_extra_2.Value), 2);
+											}
+											if (data.temp_extra_3.HasValue)
+											{
+												DoExtraTemp(ConvertUnits.TempFToUser(data.temp_extra_3.Value), 3);
+											}
+											if (data.temp_extra_4.HasValue)
+											{
+												DoExtraTemp(ConvertUnits.TempFToUser(data.temp_extra_4.Value), 4);
+											}
+											if (data.temp_extra_5.HasValue)
+											{
+												DoExtraTemp(ConvertUnits.TempFToUser(data.temp_extra_5.Value), 5);
+											}
+											if (data.temp_extra_6.HasValue)
+											{
+												DoExtraTemp(ConvertUnits.TempFToUser(data.temp_extra_6.Value), 6);
+											}
+											if (data.temp_extra_7.HasValue)
+											{
+												DoExtraTemp(ConvertUnits.TempFToUser(data.temp_extra_7.Value), 7);
+											}
+										}
+										catch (Exception e)
+										{
+											cumulus.LogErrorMessage($"Error, DecodeCurrent, ExtraTemp txid={data.tx_id}, idx={idx}: {e.Message}");
+										}
+
+										// Extra Humidity
+										try
+										{
+											if (data.hum_extra_1.HasValue)
+											{
+												DoExtraHum(data.hum_extra_1.Value, 1);
+											}
+											if (data.hum_extra_2.HasValue)
+											{
+												DoExtraHum(data.hum_extra_2.Value, 2);
+											}
+											if (data.hum_extra_3.HasValue)
+											{
+												DoExtraHum(data.hum_extra_3.Value, 3);
+											}
+											if (data.hum_extra_4.HasValue)
+											{
+												DoExtraHum(data.hum_extra_4.Value, 4);
+											}
+											if (data.hum_extra_5.HasValue)
+											{
+												DoExtraHum(data.hum_extra_5.Value, 5);
+											}
+											if (data.hum_extra_6.HasValue)
+											{
+												DoExtraHum(data.hum_extra_6.Value, 6);
+											}
+											if (data.hum_extra_7.HasValue)
+											{
+												DoExtraHum(data.hum_extra_7.Value, 7);
+											}
+										}
+										catch (Exception e)
+										{
+											cumulus.LogErrorMessage($"Error, DecodeCurrent, ExtraHum txid={data.tx_id}, idx={idx}: {e.Message}");
+										}
+									}
+									break;
+
+								// WLL/WLC ISS data
+								case 10:
+								case 23:
+									{
+										var data = sensor.data.FromJsv<WLCurrentSensorDataType10_23[]>();
+
+										foreach (var rec in data)
+										{
+											try
+											{
+												if (rec.ts == lsidLastUpdate[sensor.lsid])
+												{
+													cumulus.LogDebugMessage($"DecodeCurrent: Skipping ISS {rec.tx_id}, already processed this ts");
+													continue;
+												}
+												cumulus.LogDebugMessage($"DecodeCurrent: Using ISS {rec.tx_id}");
+											}
+											catch (KeyNotFoundException)
+											{
+												lsidLastUpdate.Add(sensor.lsid, rec.ts);
+											}
+											catch (Exception ex)
+											{
+												cumulus.LogExceptionMessage(ex, $"DecodeCurrent: Error determining ISS {rec.tx_id} last ts");
+											}
+
+											lsidLastUpdate[sensor.lsid] = rec.ts;
+
+											lastRecordTime = Utils.FromUnixTime(rec.ts);
+
+											// Temperature & Humidity
+											if (cumulus.WllPrimaryTempHum == rec.tx_id)
+											{
+												/*
+												 * Available fields
+												 * temp
+												 * hum
+												 * dew_point
+												 * wet_bulb
+												 * heat_index
+												 * wind_chill
+												 * thw_index
+												 * thsw_index
+												 * wbgt
+												 */
+
+
+												try
+												{
+													// do humidity
+													if (rec.hum.HasValue)
+													{
+														// do current humidity
+														DoOutdoorHumidity(Convert.ToInt32(rec.hum), lastRecordTime);
+													}
+													else
+													{
+														cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Humidity data on TxId {rec.tx_id}");
+													}
+												}
+												catch (Exception ex)
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Error processing Primary humidity value on TxId {rec.tx_id}. Error: {ex.Message}");
+												}
+
+												// do temperature after humidity as DoOutdoorTemp contains dewpoint calculation (if user selected)
+												try
+												{
+													if (rec.temp == -99)
+													{
+														cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Primary temperature value found [-99] on TxId {rec.tx_id}");
+													}
+													else
+													{
+														cumulus.LogDebugMessage($"DecodeCurrent: using temp/hum data from TxId {rec.tx_id}");
+
+														// do last temp
+														if (rec.hum.HasValue)
+														{
+															DoOutdoorTemp(ConvertUnits.TempFToUser(rec.temp.Value), lastRecordTime);
+														}
+														else
+														{
+															cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Temperature data on TxId {rec.tx_id}");
+														}
+													}
+												}
+												catch (Exception ex)
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Error processing Primary temperature value on TxId {rec.tx_id}. Error: {ex.Message}");
+												}
+
+
+												try
+												{
+													// do DP
+													if (rec.dew_point.HasValue)
+													{
+														DoOutdoorDewpoint(ConvertUnits.TempFToUser(rec.dew_point.Value), lastRecordTime);
+													}
+													else
+													{
+														cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Dew Point data on TxId {rec.tx_id}");
+													}
+												}
+												catch (Exception ex)
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Error processing dew point value on TxId {rec.tx_id}. Error: {ex.Message}");
+												}
+
+												if (!cumulus.StationOptions.CalculatedWC)
+												{
+													// use wind chill from WL.com - otherwise we calculate it at the end of processing the historic record when we have all the data
+													try
+													{
+														// do last WC
+														if (rec.wind_chill.HasValue)
+														{
+															DoWindChill(ConvertUnits.TempFToUser(rec.wind_chill.Value), lastRecordTime);
+														}
+														else
+														{
+															cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Wind Chill data on TxId {rec.tx_id}");
+														}
+													}
+													catch (Exception ex)
+													{
+														cumulus.LogErrorMessage($"DecodeCurrent: Error processing wind chill value on TxId {rec.tx_id}. Error: {ex.Message}");
+													}
+												}
+											}
+
+											// Wind
+											if (cumulus.WllPrimaryWind == rec.tx_id)
+											{
+												/*
+												 * Available fields
+												 *
+												 * wind_speed_last
+												 * wind_dir_last
+												 * wind_speed_avg_last_1_min
+												 * wind_dir_scalar_avg_last_1_min
+												 * wind_speed_avg_last_2_min
+												 * wind_dir_scalar_avg_last_2_min
+												 * wind_speed_hi_last_2_min
+												 * wind_dir_at_hi_speed_last_2_min
+												 * wind_speed_avg_last_10_min
+												 * wind_dir_scalar_avg_last_10_min
+												 * wind_speed_hi_last_10_min
+												 * wind_dir_at_hi_speed_last_10_min
+												 * wind_run_day
+												*/
+
+												try
+												{
+													// WLL BUG/FEATURE: The WLL sends a null wind direction for calm when the avg speed falls to zero, we use zero
+													var windDir = (int) (rec.wind_dir_last ?? 0);
+													var spd = ConvertUnits.WindMPHToUser(rec.wind_speed_last.Value);
+
+													// No average in the broadcast data, so use current average.
+													DoWind(spd, windDir, -1, lastRecordTime);
+
+													double gust;
+													int gustDir;
+													if (cumulus.StationOptions.PeakGustMinutes <= 10)
+													{
+														gust = ConvertUnits.WindMPHToUser(rec.wind_speed_hi_last_2_min ?? 0);
+														gustDir = rec.wind_dir_at_hi_speed_last_2_min ?? 0;
+													}
+													else
+													{
+														gust = ConvertUnits.WindMPHToUser(rec.wind_speed_hi_last_10_min ?? 0);
+														gustDir = rec.wind_dir_at_hi_speed_last_10_min;
+													}
+
+													var gustCal = cumulus.Calib.WindGust.Calibrate(gust);
+													var gustDirCal = gustDir == 0 ? 0 : (int) cumulus.Calib.WindDir.Calibrate(gustDir);
+
+													// See if the current speed is higher than the current max
+													// We can then update the figure before the next data packet is read
+
+													cumulus.LogDebugMessage($"DecodeCurrent: Checking recent gust using wind data from TxId {rec.tx_id}");
+
+													// Check for spikes, and set highs
+													if (CheckHighGust(gustCal, gustDirCal, lastRecordTime))
+													{
+														cumulus.LogDebugMessage("Setting max gust from current value: " + gustCal.ToString(cumulus.WindFormat) + " was: " + RecentMaxGust.ToString(cumulus.WindFormat));
+														AddValuesToRecentWind(gust, WindAverage, gustDir, lastRecordTime, lastRecordTime);
+														RecentMaxGust = gustCal;
+													}
+												}
+												catch (Exception ex)
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Error processing wind values on TxId {rec.tx_id}. Error: {ex.Message}");
+												}
+											}
+
+											// Rainfall
+											if (cumulus.WllPrimaryRain == rec.tx_id)
+											{
+												/*
+												 * Available fields:
+												 * rain_size
+												 * rain_rate_last_clicks
+												 * rain_rate_last_in
+												 * rain_rate_last_mm
+												 * rain_rate_hi_clicks
+												 * rain_rate_hi_in
+												 * rain_rate_hi_mm
+												 *
+												 * rainfall_last_15_min_clicks
+												 * rainfall_last_15_min_in
+												 * rainfall_last_15_min_mm
+												 * rain_rate_hi_last_15_min_clicks
+												 * rain_rate_hi_last_15_min_in
+												 * rain_rate_hi_last_15_min_mm
+												 *
+												 * rainfall_last_60_min_clicks
+												 * rainfall_last_60_min_in
+												 * rainfall_last_60_min_mm
+												 *
+												 * rainfall_last_24_hr_clicks
+												 * rainfall_last_24_hr_in
+												 * rainfall_last_24_hr_mm
+												 *
+												 * rain_storm_clicks
+												 * rain_storm_in
+												 * rain_storm_mm
+												 * rain_storm_start_at
+												 * rain_storm_last_clicks
+												 * rain_storm_last_in
+												 * rain_storm_last_mm
+												 * rain_storm_last_start_at
+												 * rain_storm_last_end_at
+												 *
+												 * rainfall_daily_clicks
+												 * rainfall_daily_in
+												 * rainfall_daily_mm
+												 * rainfall_monthly_clicks
+												 * rainfall_monthly_in
+												 * rainfall_monthly_mm
+												 * rainfall_year_clicks
+												 * rainfall_year_in
+												 * rainfall_year_mm
+												 */
+
+
+												try
+												{
+													if (!rec.rainfall_year_clicks.HasValue || !rec.rain_rate_last_clicks.HasValue || !rec.rain_size.HasValue)
+													{
+														cumulus.LogDebugMessage("DecodeCurrent: No rain values present!");
+													}
+													else
+													{
+														var rain = ConvertRainClicksToUser(rec.rainfall_year_clicks.Value, rec.rain_size.Value);
+														var rainrate = ConvertRainClicksToUser(rec.rain_rate_last_clicks.Value, rec.rain_size.Value);
+
+														DoRain(rain, rainrate, lastRecordTime);
+													}
+
+													if (!rec.rain_storm_clicks.HasValue || !rec.rain_storm_start_at.HasValue || !rec.rain_size.HasValue)
+													{
+														cumulus.LogDebugMessage("DecodeCurrent: No rain storm values present");
+													}
+													else
+													{
+														try
+														{
+															StormRain = ConvertRainClicksToUser(rec.rain_storm_clicks.Value, rec.rain_size.Value) * cumulus.Calib.Rain.Mult;
+															StartOfStorm = Utils.FromUnixTime(rec.rain_storm_start_at.Value);
+														}
+														catch (Exception ex)
+														{
+															cumulus.LogErrorMessage($"DecodeCurrent: Error processing rain storm values on TxId {rec.tx_id}");
+															cumulus.LogDebugMessage($"DecodeCurrent: Exception: {ex.Message}");
+														}
+													}
+												}
+												catch (Exception ex)
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Error processing rain data on TxId {rec.tx_id}. Error:{ex.Message}");
+												}
+
+											}
+
+											// UV
+											if (cumulus.WllPrimaryUV == rec.tx_id)
+											{
+												/*
+												 * Available fields
+												 * uv_index
+												 * uv_dose_day
+												 */
+												try
+												{
+													if (rec.uv_index.HasValue)
+													{
+														cumulus.LogDebugMessage($"DecodeCurrent: using UV data from TxId {rec.tx_id}");
+
+														DoUV((double) rec.uv_index, lastRecordTime);
+													}
+													else
+													{
+														cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid UV data on TxId {rec.tx_id}");
+													}
+												}
+												catch (Exception ex)
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Error processing UV value on TxId {rec.tx_id}. Error: {ex.Message}");
+												}
+
+											}
+
+											// Solar
+											if (cumulus.WllPrimarySolar == rec.tx_id)
+											{
+												/*
+												 * Available fields
+												 * solar_rad
+												 * solar_energy_day
+												 * et_day (inches) - ET field is populated in the ISS archive records, which may not be the same as the solar
+												 * et_month
+												 * et_year
+												 */
+												try
+												{
+													if (rec.solar_rad.HasValue)
+													{
+														cumulus.LogDebugMessage($"DecodeCurrent: using solar data from TxId {rec.tx_id}");
+														DoSolarRad((int) rec.solar_rad, lastRecordTime);
+													}
+													else
+													{
+														cumulus.LogWarningMessage($"DecodeCurrent: Warning, no valid Solar data on TxId {rec.tx_id}");
+													}
+
+													if (rec.et_year.HasValue && !cumulus.StationOptions.CalculatedET)
+													{
+														DoET(ConvertUnits.RainINToUser(rec.et_year.Value), lastRecordTime);
+													}
+												}
+												catch (Exception ex)
+												{
+													cumulus.LogErrorMessage($"DecodeCurrent: Error processing Solar value on TxId {rec.tx_id}. Error: {ex.Message}");
+												}
+											}
+
+											// health data
+											if (rec.trans_battery_flag.HasValue)
+											{
+												SetTxBatteryStatus(rec.tx_id, rec.trans_battery_flag.Value);
+
+												if (rec.trans_battery_flag == 1)
+												{
+													cumulus.LogWarningMessage($"Battery voltage is low in TxId {rec.tx_id}");
+												}
+											}
+											if (rec.rx_state != 0)
+											{
+												cumulus.LogWarningMessage($"Recive state for ISS TxId {rec.tx_id} is: {(rec.rx_state == 1 ? "Rescan" : "Lost")}");
+											}
+										}
+									}
+									break;
+
+								default:
+									cumulus.LogDebugMessage($"DecodeCurrent: found an unknown data structure type [{sensor.data_structure_type}], SensorType={sensor.sensor_type}!");
+									break;
+							}
+
+							break;
+					}
+				}
+				catch (Exception e)
+				{
+					cumulus.LogErrorMessage($"Error, DecodeCurrent, DataType={sensor.data_structure_type}, SensorType={sensor.sensor_type}: " + e.Message);
+				}
+			}
+
+			var dateTime = DateTime.Now;
+
+			// Now we have the primary data, calculate the derived data
+			if (cumulus.StationOptions.CalculatedWC)
+			{
+				DoWindChill(OutdoorTemperature, dateTime);
+			}
+
+			DoApparentTemp(dateTime);
+			DoFeelsLike(dateTime);
+			DoHumidex(dateTime);
+			DoCloudBaseHeatIndex(dateTime);
+
+			DoForecast(string.Empty, false);
+
+			UpdateStatusPanel(DateTime.Now);
+			UpdateMQTT();
+
+			//SensorContactLost = localSensorContactLost;
+
+			// If the station isn't using the logger function for WLL - i.e. no API key, then only alarm on Tx battery status
+			// otherwise, trigger the alarm when we read the Health data which also contains the WLL backup battery status
+			if (!cumulus.UseDataLogger)
+			{
+				cumulus.BatteryLowAlarm.Triggered = TxBatText.Contains("LOW");
+			}
+
+		}
+
+
+
+		private void DecodeHistoric(int dataType, int sensorType, string json, bool current = false)
 		{
 			// The WLL sends the timestamp in Unix ticks, and in UTC
 
@@ -1896,22 +3010,22 @@ namespace CumulusMX
 							CheckLoggingDataStopped(data.arch_int / 60);
 
 							// Temperature & Humidity
-								/*
-								 * Available fields
-								 * deg_days_cool
-								 * deg_days_heat
-								 * dew_point_in
-								 * dew_point_out
-								 * heat_index_in
-								 * heat_index_out
-								 * hum_in
-								 * hum_out
-								 * temp_in
-								 * temp_out
-								 * temp_out_hi
-								 * temp_out_lo
-								 * wind_chill
-								 */
+							/*
+							 * Available fields
+							 * deg_days_cool
+							 * deg_days_heat
+							 * dew_point_in
+							 * dew_point_out
+							 * heat_index_in
+							 * heat_index_out
+							 * hum_in
+							 * hum_out
+							 * temp_in
+							 * temp_out
+							 * temp_out_hi
+							 * temp_out_lo
+							 * wind_chill
+							 */
 
 							try
 							{
@@ -1922,12 +3036,12 @@ namespace CumulusMX
 								}
 								else
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Warning, no valid Humidity data on TxId {data.tx_id}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Warning, no valid Humidity data on TxId {data.tx_id}");
 								}
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing Primary humidity value on TxId {data.tx_id}. Error: {ex.Message}");
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing Primary humidity value on TxId {data.tx_id}. Error: {ex.Message}");
 							}
 
 							// do temperature after humidity as DoOutdoorTemp contains dewpoint calculation (if user selected)
@@ -1935,11 +3049,11 @@ namespace CumulusMX
 							{
 								if (data.temp_out.HasValue && data.temp_out == -99)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Warning, no valid Primary temperature value found [-99] on TxId {data.tx_id}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Warning, no valid Primary temperature value found [-99] on TxId {data.tx_id}");
 								}
 								else
 								{
-									cumulus.LogDebugMessage($"WL.com historic: using temp/hum data from TxId {data.tx_id}");
+									cumulus.LogDebugMessage($"DecodeHistoric: using temp/hum data from TxId {data.tx_id}");
 
 									// do high temp
 									if (data.temp_out_hi.HasValue)
@@ -1948,7 +3062,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogErrorMessage($"WL.com historic: Warning, no valid Temperature (high) data on TxId {data.tx_id}");
+										cumulus.LogErrorMessage($"DecodeHistoric: Warning, no valid Temperature (high) data on TxId {data.tx_id}");
 									}
 
 									// do low temp
@@ -1958,7 +3072,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogErrorMessage($"WL.com historic: Warning, no valid Temperature (low) data on TxId {data.tx_id}");
+										cumulus.LogErrorMessage($"DecodeHistoric: Warning, no valid Temperature (low) data on TxId {data.tx_id}");
 									}
 
 									// do last temp
@@ -1988,13 +3102,13 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogErrorMessage($"WL.com historic: Warning, no valid Temperature data on TxId {data.tx_id}");
+										cumulus.LogErrorMessage($"DecodeHistoric: Warning, no valid Temperature data on TxId {data.tx_id}");
 									}
 								}
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing Primary temperature value on TxId {data.tx_id}. Error: {ex.Message}");
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing Primary temperature value on TxId {data.tx_id}. Error: {ex.Message}");
 							}
 
 
@@ -2007,12 +3121,12 @@ namespace CumulusMX
 								}
 								else
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Warning, no valid Dew Point data on TxId {data.tx_id}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Warning, no valid Dew Point data on TxId {data.tx_id}");
 								}
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing dew point value on TxId {data.tx_id}. Error: {ex.Message}");
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing dew point value on TxId {data.tx_id}. Error: {ex.Message}");
 							}
 
 							if (!cumulus.StationOptions.CalculatedWC)
@@ -2027,12 +3141,12 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Wind Chill data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Wind Chill data on TxId {data.tx_id}");
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing wind chill value on TxId {data.tx_id}. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing wind chill value on TxId {data.tx_id}. Error: {ex.Message}");
 								}
 							}
 
@@ -2057,14 +3171,14 @@ namespace CumulusMX
 									var spd = ConvertUnits.WindMPHToUser(data.wind_speed_avg.Value);
 									// dir is a direction code: 0=N, 1=NNE, ... 14=NW, 15=NNW - convert to degress
 									var dir = (int) ((data.wind_dir_of_hi ?? 0) * 22.5);
-									cumulus.LogDebugMessage($"WL.com historic: using wind data from TxId {data.tx_id}");
+									cumulus.LogDebugMessage($"DecodeHistoric: using wind data from TxId {data.tx_id}");
 									DoWind(gust, dir, spd, lastRecordTime);
 									RecentMaxGust = cumulus.Calib.WindGust.Calibrate(gust);
 									//AddValuesToRecentWind(spd, spd, recordTs.AddSeconds(-data.arch_int), recordTs);
 								}
 								else
 								{
-									cumulus.LogDebugMessage($"WL.com historic: Warning, no valid Wind data on TxId {data.tx_id}");
+									cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid Wind data on TxId {data.tx_id}");
 								}
 
 								if (data.wind_speed_avg.HasValue)
@@ -2080,7 +3194,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									cumulus.LogDebugMessage($"WL.com historic: Warning, no valid Wind data (avg) on TxId {data.tx_id}");
+									cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid Wind data (avg) on TxId {data.tx_id}");
 								}
 
 								if (current)
@@ -2091,7 +3205,7 @@ namespace CumulusMX
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing wind values on TxId {data.tx_id}. Error: {ex.Message}");
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing wind values on TxId {data.tx_id}. Error: {ex.Message}");
 							}
 
 							// Rainfall
@@ -2114,13 +3228,13 @@ namespace CumulusMX
 							{
 								if (data.rainfall_clicks != null && data.rain_rate_hi_clicks.HasValue)
 								{
-									cumulus.LogDebugMessage($"WL.com historic: using rain data from TxId {data.tx_id}");
+									cumulus.LogDebugMessage($"DecodeHistoric: using rain data from TxId {data.tx_id}");
 
 									var rain = ConvertRainClicksToUser(data.rainfall_clicks.Value, cumulus.DavisOptions.RainGaugeType);
 									var rainrate = ConvertRainClicksToUser(data.rain_rate_hi_clicks.Value, cumulus.DavisOptions.RainGaugeType);
 									if (rain > 0)
 									{
-										cumulus.LogDebugMessage($"WL.com historic: Adding rain {rain.ToString(cumulus.RainFormat)}");
+										cumulus.LogDebugMessage($"DecodeHistoric: Adding rain {rain.ToString(cumulus.RainFormat)}");
 									}
 									rain += RainCounter;
 
@@ -2133,12 +3247,12 @@ namespace CumulusMX
 								}
 								else
 								{
-									cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Rain data on TxId {data.tx_id}");
+									cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Rain data on TxId {data.tx_id}");
 								}
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing rain data on TxId {data.tx_id}. Error:{ex.Message}");
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing rain data on TxId {data.tx_id}. Error:{ex.Message}");
 							}
 
 							// Pressure
@@ -2149,7 +3263,7 @@ namespace CumulusMX
 								bar_alt
 							*/
 							// log the current value
-							cumulus.LogDebugMessage("WL.com historic: found Baro data");
+							cumulus.LogDebugMessage("DecodeHistoric: found Baro data");
 							try
 							{
 								if (data.bar != null)
@@ -2159,7 +3273,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									cumulus.LogWarningMessage("WL.com historic: Warning, no valid Baro data");
+									cumulus.LogWarningMessage("DecodeHistoric: Warning, no valid Baro data");
 								}
 
 								// Altimeter from absolute
@@ -2173,7 +3287,7 @@ namespace CumulusMX
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing baro reading. Error: {ex.Message}");
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing baro reading. Error: {ex.Message}");
 							}
 
 
@@ -2188,19 +3302,19 @@ namespace CumulusMX
 							{
 								if (data.uv_index_avg.HasValue)
 								{
-									cumulus.LogDebugMessage($"WL.com historic: using UV data from TxId {data.tx_id}");
+									cumulus.LogDebugMessage($"DecodeHistoric: using UV data from TxId {data.tx_id}");
 
 									DoUV(data.uv_index_avg.Value, lastRecordTime);
 								}
 								else
 								{
-									cumulus.LogWarningMessage($"WL.com historic: Warning, no valid UV data on TxId {data.tx_id}");
+									cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid UV data on TxId {data.tx_id}");
 								}
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing UV value on TxId {data.tx_id}. Error: {ex.Message}");
-								}
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing UV value on TxId {data.tx_id}. Error: {ex.Message}");
+							}
 
 							// Solar
 							/*
@@ -2214,7 +3328,7 @@ namespace CumulusMX
 							{
 								if (data.solar_rad_avg.HasValue)
 								{
-									cumulus.LogDebugMessage($"WL.com historic: using solar data from TxId {data.tx_id}");
+									cumulus.LogDebugMessage($"DecodeHistoric: using solar data from TxId {data.tx_id}");
 									DoSolarRad(data.solar_rad_avg.Value, lastRecordTime);
 
 									if (!current)
@@ -2228,7 +3342,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Solar data on TxId {data.tx_id}");
+									cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Solar data on TxId {data.tx_id}");
 								}
 
 								if (data.et.HasValue && !cumulus.StationOptions.CalculatedET)
@@ -2238,19 +3352,19 @@ namespace CumulusMX
 									// This is unlike the existing VP2 when the ET is an annual running total
 									// So we try and mimic the VP behaviour
 									var newET = AnnualETTotal + ConvertUnits.RainINToUser(data.et.Value);
-									cumulus.LogDebugMessage($"WLL DecodeHistoric: Adding {ConvertUnits.RainINToUser(data.et.Value):F3} to ET");
+									cumulus.LogDebugMessage($"DecodeHistoric: Adding {ConvertUnits.RainINToUser(data.et.Value):F3} to ET");
 									DoET(newET, lastRecordTime);
 								}
 							}
 							catch (Exception ex)
 							{
-								cumulus.LogErrorMessage($"WL.com historic: Error processing Solar value on TxId {data.tx_id}. Error: {ex.Message}");
+								cumulus.LogErrorMessage($"DecodeHistoric: Error processing Solar value on TxId {data.tx_id}. Error: {ex.Message}");
 							}
 
 							string idx = "";
 
 							// Leaf Wetness
-							cumulus.LogDebugMessage($"WL.com historic: found Leaf/Soil data on TxId {data.tx_id}");
+							cumulus.LogDebugMessage($"DecodeHistoric: found Leaf/Soil data on TxId {data.tx_id}");
 							try
 							{
 
@@ -2395,7 +3509,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Humidity (high) data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Humidity (high) data on TxId {data.tx_id}");
 									}
 
 									// do low humidity
@@ -2406,7 +3520,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Humidity (low) data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Humidity (low) data on TxId {data.tx_id}");
 									}
 
 									if (data.hum_last != null)
@@ -2416,12 +3530,12 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Humidity data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Humidity data on TxId {data.tx_id}");
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing Primary humidity value on TxId {data.tx_id}. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing Primary humidity value on TxId {data.tx_id}. Error: {ex.Message}");
 								}
 
 								// do temperature after humidity as DoOutdoorTemp contains dewpoint calculation (if user selected)
@@ -2429,11 +3543,11 @@ namespace CumulusMX
 								{
 									if (data.temp_last == -99)
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Primary temperature value found [-99] on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Primary temperature value found [-99] on TxId {data.tx_id}");
 									}
 									else
 									{
-										cumulus.LogDebugMessage($"WL.com historic: using temp/hum data from TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: using temp/hum data from TxId {data.tx_id}");
 
 										// do high temp
 										if (data.temp_hi_at != 0 && data.temp_hi != null)
@@ -2443,7 +3557,7 @@ namespace CumulusMX
 										}
 										else
 										{
-											cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Temperature (high) data on TxId {data.tx_id}");
+											cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Temperature (high) data on TxId {data.tx_id}");
 										}
 
 										// do low temp
@@ -2454,7 +3568,7 @@ namespace CumulusMX
 										}
 										else
 										{
-											cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Temperature (low) data on TxId {data.tx_id}");
+											cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Temperature (low) data on TxId {data.tx_id}");
 										}
 
 										// do last temp
@@ -2481,13 +3595,13 @@ namespace CumulusMX
 										}
 										else
 										{
-											cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Temperature data on TxId {data.tx_id}");
+											cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Temperature data on TxId {data.tx_id}");
 										}
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing Primary temperature value on TxId {data.tx_id}. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing Primary temperature value on TxId {data.tx_id}. Error: {ex.Message}");
 								}
 
 
@@ -2501,7 +3615,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Dew Point (high) data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Dew Point (high) data on TxId {data.tx_id}");
 									}
 
 									// do low DP
@@ -2512,7 +3626,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Dew Point (low) data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Dew Point (low) data on TxId {data.tx_id}");
 									}
 
 									// do last DP
@@ -2522,12 +3636,12 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Dew Point data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Dew Point data on TxId {data.tx_id}");
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing dew point value on TxId {data.tx_id}. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing dew point value on TxId {data.tx_id}. Error: {ex.Message}");
 								}
 
 								if (!cumulus.StationOptions.CalculatedWC)
@@ -2543,7 +3657,7 @@ namespace CumulusMX
 										}
 										else
 										{
-											cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Wind Chill (low) data on TxId {data.tx_id}");
+											cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Wind Chill (low) data on TxId {data.tx_id}");
 										}
 
 										// do last WC
@@ -2553,12 +3667,12 @@ namespace CumulusMX
 										}
 										else
 										{
-											cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Wind Chill data on TxId {data.tx_id}");
+											cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Wind Chill data on TxId {data.tx_id}");
 										}
 									}
 									catch (Exception ex)
 									{
-										cumulus.LogErrorMessage($"WL.com historic: Error processing wind chill value on TxId {data.tx_id}. Error: {ex.Message}");
+										cumulus.LogErrorMessage($"DecodeHistoric: Error processing wind chill value on TxId {data.tx_id}. Error: {ex.Message}");
 									}
 								}
 							}
@@ -2572,19 +3686,19 @@ namespace CumulusMX
 									{
 										if (data.temp_last == -99 || data.temp_last == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid Extra temperature value on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid Extra temperature value on TxId {data.tx_id}");
 										}
 										else
 										{
-											cumulus.LogDebugMessage($"WL.com historic: using extra temp data from TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: using extra temp data from TxId {data.tx_id}");
 
 											DoExtraTemp(ConvertUnits.TempFToUser((double) data.temp_last), tempTxId);
 										}
 									}
 									catch (Exception ex)
 									{
-										cumulus.LogErrorMessage($"WL.com historic: Error processing extra temp value on TxId {data.tx_id}");
-										cumulus.LogDebugMessage($"WL.com historic: Exception {ex.Message}");
+										cumulus.LogErrorMessage($"DecodeHistoric: Error processing extra temp value on TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: Exception {ex.Message}");
 									}
 
 									if (!cumulus.WllExtraHumTx[tempTxId]) continue;
@@ -2598,7 +3712,7 @@ namespace CumulusMX
 									}
 									catch (Exception ex)
 									{
-										cumulus.LogErrorMessage($"WL.com historic: Error processing extra humidity value on TxId {data.tx_id}. Error: {ex.Message}");
+										cumulus.LogErrorMessage($"DecodeHistoric: Error processing extra humidity value on TxId {data.tx_id}. Error: {ex.Message}");
 									}
 								}
 							}
@@ -2623,13 +3737,13 @@ namespace CumulusMX
 										var gust = ConvertUnits.WindMPHToUser((double) data.wind_speed_hi);
 										var spd = ConvertUnits.WindMPHToUser((double) data.wind_speed_avg);
 										var dir = data.wind_speed_hi_dir ?? 0;
-										cumulus.LogDebugMessage($"WL.com historic: using wind data from TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: using wind data from TxId {data.tx_id}");
 										DoWind(gust, dir, spd, lastRecordTime);
 										AddValuesToRecentWind(spd, spd, dir, lastRecordTime.AddSeconds(-data.arch_int), lastRecordTime);
 									}
 									else
 									{
-										cumulus.LogDebugMessage($"WL.com historic: Warning, no valid Wind data on TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid Wind data on TxId {data.tx_id}");
 									}
 
 									if (data.wind_speed_avg != null)
@@ -2645,7 +3759,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogDebugMessage($"WL.com historic: Warning, no valid Wind data (avg) on TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid Wind data (avg) on TxId {data.tx_id}");
 									}
 
 									if (current)
@@ -2657,7 +3771,7 @@ namespace CumulusMX
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing wind values on TxId {data.tx_id}. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing wind values on TxId {data.tx_id}. Error: {ex.Message}");
 								}
 							}
 
@@ -2684,13 +3798,13 @@ namespace CumulusMX
 								{
 									if (data.rain_rate_hi_at != 0 && data.rainfall_clicks != null && data.rain_rate_hi_clicks != null)
 									{
-										cumulus.LogDebugMessage($"WL.com historic: using rain data from TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: using rain data from TxId {data.tx_id}");
 
 										var rain = ConvertRainClicksToUser((double) data.rainfall_clicks, data.rain_size);
 										var rainrate = ConvertRainClicksToUser((double) data.rain_rate_hi_clicks, data.rain_size);
 										if (rain > 0)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Adding rain {rain.ToString(cumulus.RainFormat)}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Adding rain {rain.ToString(cumulus.RainFormat)}");
 										}
 										rain += RainCounter;
 
@@ -2703,12 +3817,12 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Rain data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Rain data on TxId {data.tx_id}");
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing rain data on TxId {data.tx_id}. Error:{ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing rain data on TxId {data.tx_id}. Error:{ex.Message}");
 								}
 
 							}
@@ -2728,18 +3842,18 @@ namespace CumulusMX
 								{
 									if (data.uv_index_avg != null)
 									{
-										cumulus.LogDebugMessage($"WL.com historic: using UV data from TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: using UV data from TxId {data.tx_id}");
 
 										DoUV((double) data.uv_index_avg, lastRecordTime);
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid UV data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid UV data on TxId {data.tx_id}");
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing UV value on TxId {data.tx_id}. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing UV value on TxId {data.tx_id}. Error: {ex.Message}");
 								}
 
 							}
@@ -2761,7 +3875,7 @@ namespace CumulusMX
 								{
 									if (data.solar_rad_avg != null)
 									{
-										cumulus.LogDebugMessage($"WL.com historic: using solar data from TxId {data.tx_id}");
+										cumulus.LogDebugMessage($"DecodeHistoric: using solar data from TxId {data.tx_id}");
 										DoSolarRad((int) data.solar_rad_avg, lastRecordTime);
 
 										if (!current)
@@ -2775,7 +3889,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage($"WL.com historic: Warning, no valid Solar data on TxId {data.tx_id}");
+										cumulus.LogWarningMessage($"DecodeHistoric: Warning, no valid Solar data on TxId {data.tx_id}");
 									}
 
 									if (data.et != null && !cumulus.StationOptions.CalculatedET)
@@ -2785,13 +3899,13 @@ namespace CumulusMX
 										// This is unlike the existing VP2 when the ET is an annual running total
 										// So we try and mimic the VP behaviour
 										var newET = AnnualETTotal + ConvertUnits.RainINToUser((double) data.et);
-										cumulus.LogDebugMessage($"WLL DecodeHistoric: Adding {ConvertUnits.RainINToUser((double) data.et):F3} to ET");
+										cumulus.LogDebugMessage($"DecodeHistoric: Adding {ConvertUnits.RainINToUser((double) data.et):F3} to ET");
 										DoET(newET, lastRecordTime);
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing Solar value on TxId {data.tx_id}. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing Solar value on TxId {data.tx_id}. Error: {ex.Message}");
 								}
 							}
 						}
@@ -2824,7 +3938,7 @@ namespace CumulusMX
 								 * "wet_leaf_min_2"
 								 */
 
-								cumulus.LogDebugMessage($"WL.com historic: found Leaf/Soil data on TxId {data.tx_id}");
+								cumulus.LogDebugMessage($"DecodeHistoric: found Leaf/Soil data on TxId {data.tx_id}");
 
 								// We are relying on user configuration here, trap any errors
 								try
@@ -2882,7 +3996,7 @@ namespace CumulusMX
 										idx = "moist_soil_last_" + cumulus.WllExtraSoilMoistureIdx1;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx1} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx1} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -2894,7 +4008,7 @@ namespace CumulusMX
 										idx = "moist_soil_last_" + cumulus.WllExtraSoilMoistureIdx2;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx2} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx2} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -2906,7 +4020,7 @@ namespace CumulusMX
 										idx = "moist_soil_last_" + cumulus.WllExtraSoilMoistureIdx3;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx3} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx3} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -2918,7 +4032,7 @@ namespace CumulusMX
 										idx = "moist_soil_last_" + cumulus.WllExtraSoilMoistureIdx4;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx4} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid soil moisture #{cumulus.WllExtraSoilMoistureIdx4} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -2967,7 +4081,7 @@ namespace CumulusMX
 										idx = "temp_last_" + cumulus.WllExtraSoilTempIdx1;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx1} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx1} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -2979,7 +4093,7 @@ namespace CumulusMX
 										idx = "temp_last_" + cumulus.WllExtraSoilTempIdx2;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx2} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx2} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -2991,7 +4105,7 @@ namespace CumulusMX
 										idx = "temp_last_" + cumulus.WllExtraSoilTempIdx3;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx3} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx3} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -3003,7 +4117,7 @@ namespace CumulusMX
 										idx = "temp_last_" + cumulus.WllExtraSoilTempIdx4;
 										if (data[idx] == null)
 										{
-											cumulus.LogDebugMessage($"WL.com historic: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx4} on TxId {data.tx_id}");
+											cumulus.LogDebugMessage($"DecodeHistoric: Warning, no valid extra soil temp #{cumulus.WllExtraSoilTempIdx4} on TxId {data.tx_id}");
 										}
 										else
 										{
@@ -3030,7 +4144,7 @@ namespace CumulusMX
 								 * "bar_lo_at"
 								 */
 								// log the current value
-								cumulus.LogDebugMessage("WL.com historic: found Baro data");
+								cumulus.LogDebugMessage("DecodeHistoric: found Baro data");
 								try
 								{
 									var data13baro = json.FromJsv<WlHistorySensorDataType13Baro>();
@@ -3043,7 +4157,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage("WL.com historic: Warning, no valid Baro data (high)");
+										cumulus.LogWarningMessage("DecodeHistoric: Warning, no valid Baro data (high)");
 									}
 									// check the low
 									if (data13baro.bar_lo_at != 0 && data13baro.bar_lo != null)
@@ -3053,7 +4167,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage("WL.com historic: Warning, no valid Baro data (high)");
+										cumulus.LogWarningMessage("DecodeHistoric: Warning, no valid Baro data (high)");
 									}
 
 									if (data13baro.bar_sea_level != null)
@@ -3064,7 +4178,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage("WL.com historic: Warning, no valid Baro data (high)");
+										cumulus.LogWarningMessage("DecodeHistoric: Warning, no valid Baro data (high)");
 									}
 
 									// Altimeter from absolute
@@ -3078,7 +4192,7 @@ namespace CumulusMX
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing baro reading. Error: {ex.Message}");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing baro reading. Error: {ex.Message}");
 								}
 								break;
 
@@ -3098,7 +4212,7 @@ namespace CumulusMX
 								 * "temp_in_lo"
 								 * "temp_in_lo_at"
 								 */
-								cumulus.LogDebugMessage("WL.com historic: found inside temp/hum data");
+								cumulus.LogDebugMessage("DecodeHistoric: found inside temp/hum data");
 
 								var data13temp = json.FromJsv<WlHistorySensorDataType13Temp>();
 								try
@@ -3109,12 +4223,12 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage("WL.com historic: Warning, no valid Inside Temperature");
+										cumulus.LogWarningMessage("DecodeHistoric: Warning, no valid Inside Temperature");
 									}
 								}
 								catch (Exception ex)
 								{
-									cumulus.LogErrorMessage($"WL.com historic: Error processing temp-in reading. Error: {ex.Message}]");
+									cumulus.LogErrorMessage($"DecodeHistoric: Error processing temp-in reading. Error: {ex.Message}]");
 								}
 
 
@@ -3126,7 +4240,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										cumulus.LogWarningMessage("WL.com historic: Warning, no valid Inside Humidity");
+										cumulus.LogWarningMessage("DecodeHistoric: Warning, no valid Inside Humidity");
 									}
 								}
 								catch (Exception ex)
@@ -3137,7 +4251,7 @@ namespace CumulusMX
 								break;
 
 							default:
-								cumulus.LogDebugMessage($"WL.com historic: Not processing sensor type [{sensorType}]!");
+								cumulus.LogDebugMessage($"DecodeHistoric: Not processing sensor type [{sensorType}]!");
 								break;
 
 						}
@@ -3158,8 +4272,15 @@ namespace CumulusMX
 						cumulus.LogDebugMessage("TODO: Decode AirLink Health");
 						break;
 
+					case 27: // WLC Health
+						{
+							var data = json.FromJsv<WlHealthDataType27>();
+							DecodeWlcHealth(data, false);
+						}
+						break;
+
 					default:
-						cumulus.LogDebugMessage($"WL.com historic: found an unknown data structure type [{dataType}]!");
+						cumulus.LogDebugMessage($"DecodeHistoric: found an unknown data structure type [{dataType}]!");
 						break;
 				}
 			}
@@ -3201,8 +4322,6 @@ namespace CumulusMX
 				* "ts"						- historic only
 				*/
 
-			cumulus.LogDebugMessage("WL Health - found health data for WLL device");
-
 			try
 			{
 				var dat = Utils.FromUnixTime(data.firmware_version);
@@ -3214,19 +4333,17 @@ namespace CumulusMX
 				// 1.35 * 4 = 5.4
 				if (battV < 5.4)
 				{
-					wllVoltageLow = true;
-					cumulus.LogWarningMessage($"WLL WARNING: Backup battery voltage is low = {battV:0.##}V");
+					cumulus.LogWarningMessage($"WARNING: WLL Backup battery voltage is low = {battV:0.##}V");
 				}
 				else
 				{
-					wllVoltageLow = false;
 					cumulus.LogDebugMessage($"WLL Battery Voltage = {battV:0.##}V");
 				}
 				var inpV = data.input_voltage / 1000.0;
 				ConSupplyVoltageText = inpV.ToString("F2");
 				if (inpV < 4.0)
 				{
-					cumulus.LogWarningMessage($"WLL WARNING: Input voltage is low = {inpV:0.##}V");
+					cumulus.LogWarningMessage($"WARNING: WLL Input voltage is low = {inpV:0.##}V");
 				}
 				else
 				{
@@ -3238,7 +4355,7 @@ namespace CumulusMX
 						upt.Hours,
 						upt.Minutes,
 						upt.Seconds);
-				cumulus.LogDebugMessage("WLL Uptime = " + uptStr);
+				cumulus.LogDebugMessage("WLL/WLC Uptime = " + uptStr);
 
 				// Only present if WiFi attached
 				if (data.wifi_rssi.HasValue)
@@ -3257,7 +4374,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage($"WL.com historic: Error processing WLL health. Error: {ex.Message}");
+				cumulus.LogErrorMessage($"DecodeWllHealth: Error processing health. Error: {ex.Message}");
 				DavisFirmwareVersion = "???";
 			}
 
@@ -3271,212 +4388,153 @@ namespace CumulusMX
 			}
 		}
 
-		private void DecodeISSHealth(WlHistorySensor sensor)
+		private void DecodeWlcHealth(WlHealthDataType27 data, bool startingup)
 		{
-			/* ISS & Non-ISS have the same health fields
-				* Available fields of interest to health
-				* "afc": -1
-				* "error_packets": 0
-				* "good_packets_streak": 602
-				* "reception": 100
-				* "resynchs": 0
-				* "rssi": -60
-				* "supercap_volt_last": null
-				* "trans_battery_flag": 0
-				* "trans_battery": null
-				* "tx_id": 2
+			/* WLL Device
+				*
+				* Available fields
+				* health_version
+				* console_sw_version
+				* console_os_version
+				* console_radio_version
+				* console_api_level
+				*
+				* battery_voltage
+				* battery_percent
+				* battery_condition  - 1:unknown, 2:good, 3:overheat, 4:dead, 5:overvoltage, 6:unspecified failure, 7:cold
+				* battery_current - mA
+				* battery_temp - Celcius
+				* charger_plugged - 0:unplugged, 1:plugged in
+				* battery_status - 1:unknown, 2:charging, 3:discharging, 4:not charging, 5:full
+				* battery_cycle_count
+				*
+				* os_uptime
+				* app_uptime
+				*
+				* bgn					- historic only?
+				*
+				* bootloader_version
+				* clock_source
+				* gnss_sip_tx_id
+				*
+				* free_mem
+				* internal_free_space
+				* system_free_space
+				*
+				* queue_kilobytes
+				* database_kilobytes
+				*
+				* ip_v4_address
+				* ip_v4_gateway
+				* ip_v4_netmask
+				* dns_type_used - 1:Primary, 2:secondary, 3:public
+				* rx_kilobytes
+				* tx_kilobytes
+				* local_api_queries
+				* wifi_rssi
+				* link_uptime
+				* connection_uptime
+				* "ts"						- historic only ?
 				*/
 
 			try
 			{
-				string type;
-				if (sensor.sensor_type == 37 || sensor.sensor_type == 84 || sensor.sensor_type == 85)
-					type = "Vue";
-				else
-					type = sensor.data_structure_type == 11 ? "ISS" : "Soil-Leaf/Temperature";
+				DavisFirmwareVersion = data.console_sw_version;
 
-				var data = sensor.data.Last().FromJsv<WlHealthDataType11_13>();
+				StationFreeMemory = (int) ((data.free_mem ?? 0.0) * 1024);
 
-				cumulus.LogDebugMessage($"XMTR Health - found health data for {type} device TxId = {data.tx_id}");
+				StationRuntime = data.app_uptime ?? 0;
 
-				// Check battery state 0=Good, 1=Low
-				SetTxBatteryStatus(data.tx_id, data.trans_battery_flag);
-				if (data.trans_battery_flag == 1)
+				var condition = "";
+				switch (data.battery_condition.Value)
 				{
-					cumulus.LogWarningMessage($"XMTR WARNING: Battery voltage is low in TxId {data.tx_id}");
+					case 1:
+						condition = "unknown"; break;
+					case 2:
+						condition = "good"; break;
+					case 3:
+						condition = "overheat"; break;
+					case 4:
+						condition = "dead"; break;
+					case 5:
+						condition = "over voltage"; break;
+					case 6:
+						condition = "unspecified failure"; break;
+					case 7:
+						condition = "cold"; break;
+					default:
+						condition = data.battery_condition.Value.ToString(); break;
 				}
-				else
+				var status = "";
+				switch (data.battery_status)
 				{
-					cumulus.LogDebugMessage($"XMTR Health: {type} {data.tx_id}: Battery state is OK");
+					case 1:
+						status = "unknown"; break;
+					case 2:
+						status = "charging"; break;
+					case 3:
+						status = "discharging"; break;
+					case 4:
+						status = "not charging"; break;
+					case 5:
+						status = "full"; break;
+					default:
+						status = data.battery_status.Value.ToString(); break;
 				}
 
-				//DavisTotalPacketsReceived[txid] = ;  // Do not have a value for this
-				DavisTotalPacketsMissed[data.tx_id] = data.error_packets;
-				DavisNumCRCerrors[data.tx_id] = data.error_packets;
-				DavisNumberOfResynchs[data.tx_id] = data.resynchs;
-				DavisMaxInARow[data.tx_id] = data.good_packets_streak;
-				DavisReceptionPct[data.tx_id] = data.reception;
-				DavisTxRssi[data.tx_id] = data.rssi;
+				cumulus.LogDebugMessage($"WLC: Battery: Percent={data.battery_percent}, voltage={(data.battery_voltage.Value / 1000.0).ToString("F2")}V, current={data.battery_current} mA, temp={data.battery_temp}°C");
+				cumulus.LogDebugMessage($"WLC: Battery: Condition={condition}, charger={(data.charger_plugged == 0 ? "unplugged" : "plugged-in")}, status={status}");
 
-				var logMsg = $"XMTR Health: {type} {data.tx_id}: Errors={DavisTotalPacketsMissed[data.tx_id]}, CRCs={DavisNumCRCerrors[data.tx_id]}, Resyncs={DavisNumberOfResynchs[data.tx_id]}, Streak={DavisMaxInARow[data.tx_id]}, %={DavisReceptionPct[data.tx_id]}, RSSI={DavisTxRssi[data.tx_id]}";
-				logMsg += data.supercap_volt_last != null ? $", Supercap={data.supercap_volt_last:F2}V" : "";
-				logMsg += data.solar_volt_last != null ? $", Supercap={data.solar_volt_last:F2}V" : "";
-				cumulus.LogDebugMessage(logMsg);
-
-				// Is there any ET in this record?
-				if (sensor.data_structure_type == 11 && data.et != null)
+				if (data.battery_condition.Value != 2)
 				{
-					// wl.com ET is only available in record the start of each hour.
-					// The number is the total for the one hour period.
-					// This is unlike the existing VP2 when the ET is an annual running total
-					// So we try and mimic the VP behaviour
-					var newET = AnnualETTotal + ConvertUnits.RainINToUser((double) data.et);
-					cumulus.LogDebugMessage($"XMTR Health: Adding {ConvertUnits.RainINToUser((double) data.et):F3} to ET");
-					DoET(newET, DateTime.Now);
+					cumulus.LogWarningMessage("WARNING: WLC battery condition = " + condition);
 				}
+
+				var upt = TimeSpan.FromSeconds(data.app_uptime.Value);
+				var uptStr = string.Format("{0}d:{1:D2}h:{2:D2}m:{3:D2}s",
+						(int) upt.TotalDays,
+						upt.Hours,
+						upt.Minutes,
+						upt.Seconds);
+				cumulus.LogDebugMessage("WLC App Uptime = " + uptStr);
+
+				upt = TimeSpan.FromSeconds(data.os_uptime.Value);
+				uptStr = string.Format("{0}d:{1:D2}h:{2:D2}m:{3:D2}s",
+						(int) upt.TotalDays,
+						upt.Hours,
+						upt.Minutes,
+						upt.Seconds);
+				cumulus.LogDebugMessage("WLC OS Uptime = " + uptStr);
+
+				// Only present if WiFi attached
+				if (data.wifi_rssi.HasValue)
+				{
+					DavisTxRssi[0] = data.wifi_rssi.Value;
+					cumulus.LogDebugMessage("WLC WiFi RSSI = " + DavisTxRssi[0] + "dB");
+				}
+
+				upt = TimeSpan.FromSeconds(data.link_uptime.Value);
+				uptStr = string.Format("{0}d:{1:D2}h:{2:D2}m:{3:D2}s",
+						(int) upt.TotalDays,
+						upt.Hours,
+						upt.Minutes,
+						upt.Seconds);
+				cumulus.LogDebugMessage("Link Uptime = " + uptStr);
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage($"XMTR Health: Error processing transmitter health. Error: {ex.Message}");
+				cumulus.LogErrorMessage($"DecodeWlcHealth: Error processing health. Error: {ex.Message}");
+				DavisFirmwareVersion = "???";
 			}
-		}
 
-		/*
-		private void HealthTimerTick(object source, ElapsedEventArgs e)
-		{
-			// Only run every 15 minutes
-			// We run at :01, :16, :31, :46 to allow time for wl.com to generate the stats
-			if (DateTime.Now.Minute % 15 == 1)
+			if (startingup)
 			{
-				GetWlHistoricHealth();
+				cumulus.LogMessage("WLC FW version = " + DavisFirmwareVersion);
 			}
-		}
-		*/
-
-		// Extracts health information from the last archive record
-		private void GetWlHistoricHealth()
-		{
-			cumulus.LogMessage("WL Health: Get WL.com Historic Data");
-
-			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
+			else
 			{
-				cumulus.LogWarningMessage("WL Health: Missing WeatherLink API data in the cumulus.ini file, aborting!");
-				return;
+				cumulus.LogDebugMessage("WLC FW version = " + DavisFirmwareVersion);
 			}
-
-			if (cumulus.WllStationId < 10)
-			{
-				const string msg = "No WeatherLink API station ID in the cumulus.ini file";
-				Cumulus.LogConsoleMessage("GetWlHistoricHealth: " + msg);
-				cumulus.LogWarningMessage($"WL Health: {msg}, aborting!");
-				return;
-			}
-
-			var unixDateTime = Utils.ToUnixTime(DateTime.Now);
-			var startTime = unixDateTime - weatherLinkArchiveInterval;
-			long endTime = unixDateTime;
-
-			cumulus.LogDebugMessage($"WL Health: Downloading the historic record from WL.com from: {Utils.FromUnixTime(startTime):s} to: {Utils.FromUnixTime(endTime):s}");
-
-			StringBuilder historicUrl = new StringBuilder("https://api.weatherlink.com/v2/historic/" + cumulus.WllStationId);
-			historicUrl.Append("?api-key=" + cumulus.WllApiKey);
-			historicUrl.Append("&start-timestamp=" + startTime.ToString());
-			historicUrl.Append("&end-timestamp=" + endTime.ToString());
-
-			cumulus.LogDebugMessage($"WL Health: WeatherLink URL = {historicUrl.ToString().Replace(cumulus.WllApiKey, "API_KEY")}");
-
-			try
-			{
-				WlHistory histObj;
-				string responseBody;
-				int responseCode;
-
-				var request = new HttpRequestMessage(HttpMethod.Get, historicUrl.ToString());
-				request.Headers.Add("X-Api-Secret", cumulus.WllApiSecret);
-
-				// we want to do this synchronously, so .Result
-				using (var response = Cumulus.MyHttpClient.SendAsync(request).Result)
-				{
-					responseBody = response.Content.ReadAsStringAsync().Result;
-					responseCode = (int) response.StatusCode;
-					cumulus.LogDebugMessage($"WL Health: WeatherLink API Response code: {responseCode}");
-					cumulus.LogDataMessage($"WL Health: WeatherLink API Response: {responseBody}");
-				}
-
-				if (responseCode != 200)
-				{
-					var errObj = responseBody.FromJson<WlErrorResponse>();
-					cumulus.LogWarningMessage($"WL Health: WeatherLink API Error: {errObj.code}, {errObj.message}");
-					// Get wl.com status
-					GetSystemStatus();
-					return;
-				}
-
-				if (responseBody == "{}")
-				{
-					cumulus.LogWarningMessage("WL Health: WeatherLink API: No data was returned. Check your Device Id.");
-					cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
-					// Get wl.com status
-					GetSystemStatus();
-					return;
-				}
-
-				if (!responseBody.StartsWith("{\"")) // basic sanity check
-				{
-					// No idea what we got, dump it to the log
-					cumulus.LogErrorMessage("WL Health: Invalid historic message received");
-					cumulus.LogDataMessage("WL Health: Received: " + responseBody);
-					return;
-				}
-
-				histObj = responseBody.FromJson<WlHistory>();
-
-				// get the sensor data
-				if (histObj.sensors.Count == 0)
-				{
-					cumulus.LogMessage("WL Health: No historic data available");
-					return;
-				}
-				else
-				{
-					cumulus.LogDebugMessage($"WL Health: Found {histObj.sensors.Count} sensor records to process");
-				}
-
-
-				try
-				{
-					// Sensor types we are interested in...
-					// 504 = WLL Health - Now in current
-					// 506 = AirLink Health - Now in current
-
-					// Get the LSID of the health station associated with each device
-					//var wllHealthLsid = GetWlHistoricHealthLsid(cumulus.WllParentId, 504);
-					var alInHealthLsid = GetWlHistoricHealthLsid(cumulus.airLinkInLsid, 506);
-					var alOutHealthLsid = GetWlHistoricHealthLsid(cumulus.airLinkOutLsid, 506);
-
-					foreach (var sensor in histObj.sensors)
-					{
-						var sensorType = sensor.sensor_type;
-						var dataStructureType = sensor.data_structure_type;
-						var lsid = sensor.lsid;
-
-						if (sensorType >= 23 && sensorType < 100)
-						{
-							DecodeISSHealth(sensor);
-						}
-					}
-				}
-				catch (Exception ex)
-				{
-					cumulus.LogErrorMessage("WLL Health: exception: " + ex.Message);
-				}
-				cumulus.BatteryLowAlarm.Triggered = TxBatText.Contains("LOW") || wllVoltageLow;
-			}
-			catch (Exception ex)
-			{
-				cumulus.LogErrorMessage("WLL Health: exception: " + ex.Message);
-			}
-
 		}
 
 		// Finds all stations associated with this API
@@ -3485,13 +4543,13 @@ namespace CumulusMX
 		{
 			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
 			{
-				cumulus.LogWarningMessage("WLLStations: Missing WeatherLink API data in the cumulus.ini file, aborting!");
+				cumulus.LogWarningMessage("GetStations: Missing WeatherLink API data in the cumulus.ini file, aborting!");
 				return;
 			}
 
 			var stationsUrl = "https://api.weatherlink.com/v2/stations?api-key=" + cumulus.WllApiKey;
 
-			cumulus.LogDebugMessage($"WLLStations: URL = {stationsUrl.ToString().Replace(cumulus.WllApiKey, "API_KEY")}");
+			cumulus.LogDebugMessage($"GetStations: URL = {stationsUrl.ToString().Replace(cumulus.WllApiKey, "API_KEY")}");
 
 			try
 			{
@@ -3507,13 +4565,13 @@ namespace CumulusMX
 					responseBody = response.Content.ReadAsStringAsync().Result;
 					responseCode = (int) response.StatusCode;
 					var resp = System.Text.RegularExpressions.Regex.Replace(responseBody, "user_email\":\"[^\"]*\"", "user_email\":\"<<email>>\"");
-					cumulus.LogDebugMessage($"WLLStations: WeatherLink API Response: {responseCode}: {resp}");
+					cumulus.LogDebugMessage($"GetStations: WeatherLink API Response: {responseCode}: {resp}");
 				}
 
 				if (responseCode != 200)
 				{
 					var errObj = responseBody.FromJson<WlErrorResponse>();
-					cumulus.LogErrorMessage($"WLLStations: WeatherLink API Error: {errObj.code} - {errObj.message}");
+					cumulus.LogErrorMessage($"GetStations: WeatherLink API Error: {errObj.code} - {errObj.message}");
 					return;
 				}
 
@@ -3521,19 +4579,19 @@ namespace CumulusMX
 
 				foreach (var station in stationsObj.stations)
 				{
-					cumulus.LogMessage($"WLLStations: Found WeatherLink station id = {station.station_id}, name = {station.station_name}");
+					cumulus.LogMessage($"GetStations: Found WeatherLink station id = {station.station_id}, name = {station.station_name}");
 					if (stationsObj.stations.Count > 1 && logToConsole)
 					{
 						Cumulus.LogConsoleMessage($" - Found WeatherLink station id = {station.station_id}, name = {station.station_name}, active = {station.active}");
 					}
 					if (station.station_id == cumulus.WllStationId)
 					{
-						cumulus.LogDebugMessage($"WLLStations: Setting WLL parent ID = {station.gateway_id}");
+						cumulus.LogDebugMessage($"GetStations: Setting WLL parent ID = {station.gateway_id}");
 						cumulus.WllParentId = station.gateway_id;
 
 						if (station.recording_interval != cumulus.logints[cumulus.DataLogInterval])
 						{
-							cumulus.LogWarningMessage($"WLLStations: - Cumulus log interval {cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {station.recording_interval}");
+							cumulus.LogWarningMessage($"GetStations: - Cumulus log interval {cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {station.recording_interval}");
 						}
 
 						wlStationArchiveInterval = station.recording_interval;
@@ -3547,12 +4605,12 @@ namespace CumulusMX
 				}
 				else if (stationsObj.stations.Count == 1 && cumulus.WllStationId != stationsObj.stations[0].station_id)
 				{
-					cumulus.LogMessage($"WLLStations: Only found 1 WeatherLink station, using id = {stationsObj.stations[0].station_id}");
+					cumulus.LogMessage($"GetStations: Only found 1 WeatherLink station, using id = {stationsObj.stations[0].station_id}");
 					cumulus.WllStationId = stationsObj.stations[0].station_id;
 					// And save it to the config file
 					cumulus.WriteIniFile();
 
-					cumulus.LogDebugMessage($"WLLStations: Setting WLL parent ID = {stationsObj.stations[0].gateway_id}");
+					cumulus.LogDebugMessage($"GetStations: Setting WLL parent ID = {stationsObj.stations[0].gateway_id}");
 					cumulus.WllParentId = stationsObj.stations[0].gateway_id;
 					wlStationArchiveInterval = stationsObj.stations[0].recording_interval;
 					return;
@@ -3560,7 +4618,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogDebugMessage("WLLStations: WeatherLink API exception: " + ex.Message);
+				cumulus.LogDebugMessage("GetStations: WeatherLink API exception: " + ex.Message);
 			}
 			return;
 		}
@@ -3623,6 +4681,17 @@ namespace CumulusMX
 				{
 					cumulus.LogDebugMessage($"GetAvailableSensors: Found WeatherLink Sensor type={sensor.sensor_type}, lsid={sensor.lsid}, station_id={sensor.station_id}, name={sensor.product_name}, parentId={sensor.parent_device_id}, parent={sensor.parent_device_name}");
 
+					// we need a lookup of LSID to TX_ID for Soil/Leaf transmitters as they do not contain the tx_id in Current data
+					if (sensor.station_id == cumulus.WllStationId)
+					{
+						if (sensor.tx_id.HasValue)
+						{
+							lsidToTx.Add(sensor.lsid, sensor.tx_id.Value);
+						}
+
+						lsidLastUpdate.Add(sensor.lsid, 0);
+					}
+
 					if (sensor.sensor_type == 323 && sensor.station_id == cumulus.AirLinkOutStationId)
 					{
 						cumulus.LogDebugMessage($"GetAvailableSensors: Setting AirLink Outdoor LSID to {sensor.lsid}");
@@ -3641,25 +4710,6 @@ namespace CumulusMX
 			}
 
 			return;
-		}
-
-		private int GetWlHistoricHealthLsid(int id, int type)
-		{
-			try
-			{
-				var sensor = sensorList.FirstOrDefault(i => i.lsid == id || i.parent_device_id == id);
-				if (sensor != null)
-				{
-					var health = sensorList.FirstOrDefault(i => i.parent_device_id == sensor.parent_device_id && i.sensor_type == type);
-					if (health != null)
-					{
-						return health.lsid;
-					}
-				}
-			}
-			catch
-			{ }
-			return 0;
 		}
 
 		private void GetSystemStatus()

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -863,8 +863,7 @@ namespace CumulusMX
 									if (CheckHighGust(gustCal, gustDirCal, dateTime))
 									{
 										cumulus.LogDebugMessage("Setting max gust from current value: " + gustCal.ToString(cumulus.WindFormat) + " was: " + RecentMaxGust.ToString(cumulus.WindFormat));
-										AddValuesToRecentWind(gust, WindAverage, gustDir, dateTime, dateTime);
-										RecentMaxGust = gustCal;
+										DoWind(gust, gustDir, -1, dateTime);
 									}
 								}
 								catch (Exception ex)

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -2734,6 +2734,8 @@ namespace CumulusMX
 					{
 						cumulus.LogDebugMessage($"WLL Input Voltage = {inpV:0.##}V");
 					}
+
+					StationRuntime = (int)data15.uptime;
 					var upt = TimeSpan.FromSeconds(data15.uptime);
 					var uptStr = string.Format("{0}d:{1:D2}h:{2:D2}m:{3:D2}s",
 							(int) upt.TotalDays,

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -2710,6 +2710,8 @@ namespace CumulusMX
 					var dat = Utils.FromUnixTime(data15.firmware_version);
 					DavisFirmwareVersion = dat.ToUniversalTime().ToString("yyyy-MM-dd");
 
+					StationRuntime = data15.uptime;
+
 					var battV = data15.battery_voltage / 1000.0;
 					ConBatText = battV.ToString("F2");
 					// Allow voltage to drop to 1.35V per cell before triggering the alarm. This should leave a good reserve without changing them too often
@@ -2735,7 +2737,6 @@ namespace CumulusMX
 						cumulus.LogDebugMessage($"WLL Input Voltage = {inpV:0.##}V");
 					}
 
-					StationRuntime = (int)data15.uptime;
 					var upt = TimeSpan.FromSeconds(data15.uptime);
 					var uptStr = string.Format("{0}d:{1:D2}h:{2:D2}m:{3:D2}s",
 							(int) upt.TotalDays,
@@ -3035,8 +3036,6 @@ namespace CumulusMX
 		// Return true if only 1 result is found, else return false
 		private void GetAvailableStationIds(bool logToConsole = false)
 		{
-			var unixDateTime = Utils.ToUnixTime(DateTime.Now);
-
 			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
 			{
 				cumulus.LogWarningMessage("WLLStations: Missing WeatherLink API data in the cumulus.ini file, aborting!");
@@ -3117,8 +3116,6 @@ namespace CumulusMX
 
 		private void GetAvailableSensors()
 		{
-			var unixDateTime = Utils.ToUnixTime(DateTime.Now);
-
 			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
 			{
 				cumulus.LogWarningMessage("GetAvailableSensors: WeatherLink API data is missing in the configuration, aborting!");
@@ -3135,7 +3132,7 @@ namespace CumulusMX
 
 			cumulus.LogDebugMessage($"GetAvailableSensors: URL = {stationsUrl.Replace(cumulus.WllApiKey, "API_KEY")}");
 
-			WlSensorList sensorsObj = new WlSensorList();
+			WlSensorList sensorsObj;
 
 			try
 			{

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -168,12 +168,16 @@ namespace CumulusMX
 				"leaf_ch6",
 				"leaf_ch7",
 				"leaf_ch8",
-				"indoor_co2",
-				"co2_aqi_combo",
 				"pm25_ch1",
 				"pm25_ch2",
 				"pm25_ch3",
-				"pm25_ch4"
+				"pm25_ch4",
+				"indoor_co2",
+				"co2_aqi_combo",
+				"pm1_aqi_combo",
+				"pm25_aqi_combo",
+				"pm10_aqi_combo",
+				"t_rh_aqi_combo"
 			};
 
 			sb.Append("&call_back=");
@@ -314,7 +318,7 @@ namespace CumulusMX
 		private void ProcessHistoryData(EcowittHistoricData data, CancellationToken token)
 		{
 			// allocate a dictionary of data objects, keyed on the timestamp
-			var buffer = new SortedDictionary<DateTime, EcowittApi.HistoricData>();
+			var buffer = new SortedDictionary<DateTime, HistoricData>();
 
 			// process each sensor type, and store them for adding to the system later
 			// Indoor Data
@@ -339,7 +343,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ IndoorTemp = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -361,7 +365,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ IndoorHum = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -395,7 +399,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ Temp = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -418,7 +422,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ Humidity = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -441,12 +445,59 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ DewPoint = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
 						}
 					}
+
+					// Feels like
+					if (data.outdoor.feels_like != null && data.outdoor.feels_like.list != null)
+					{
+						foreach (var item in data.outdoor.feels_like.list)
+						{
+							var itemDate = item.Key.AddMinutes(EcowittApiFudgeFactor);
+
+							if (!item.Value.HasValue || itemDate <= cumulus.LastUpdateTime)
+								continue;
+
+							if (buffer.TryGetValue(itemDate, out var value))
+							{
+								value.FeelsLike = item.Value;
+							}
+							else
+							{
+								var newItem = new HistoricData()
+								{ FeelsLike = item.Value };
+								buffer.Add(itemDate, newItem);
+							}
+						}
+					}
+
+					// Apparent
+					if (data.outdoor.app_temp != null && data.outdoor.app_temp.list != null)
+					{
+						foreach (var item in data.outdoor.app_temp.list)
+						{
+							var itemDate = item.Key.AddMinutes(EcowittApiFudgeFactor);
+
+							if (!item.Value.HasValue || itemDate <= cumulus.LastUpdateTime)
+								continue;
+
+							if (buffer.TryGetValue(itemDate, out var value))
+							{
+								value.Apparent = item.Value;
+							}
+							else
+							{
+								var newItem = new HistoricData()
+								{ Apparent = item.Value };
+								buffer.Add(itemDate, newItem);
+							}
+						}
+					}
+
 				}
 				catch (Exception ex)
 				{
@@ -474,7 +525,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ WindSpd = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -497,7 +548,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ WindGust = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -520,7 +571,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ WindDir = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -553,7 +604,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ Pressure = item.Value};
 								buffer.Add(itemDate, newItem);
 							}
@@ -588,7 +639,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									var newItem = new EcowittApi.HistoricData()
+									var newItem = new HistoricData()
 									{ RainRate = item.Value };
 									buffer.Add(itemDate, newItem);
 								}
@@ -611,7 +662,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									var newItem = new EcowittApi.HistoricData()
+									var newItem = new HistoricData()
 									{ RainYear = item.Value };
 									buffer.Add(itemDate, newItem);
 								}
@@ -636,7 +687,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									var newItem = new EcowittApi.HistoricData()
+									var newItem = new HistoricData()
 									{ RainRate = item.Value };
 									buffer.Add(itemDate, newItem);
 								}
@@ -659,7 +710,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									var newItem = new EcowittApi.HistoricData()
+									var newItem = new HistoricData()
 									{ RainYear = item.Value };
 									buffer.Add(itemDate, newItem);
 								}
@@ -693,7 +744,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ Solar = (int) item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -716,7 +767,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ UVI = (int) item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -731,10 +782,10 @@ namespace CumulusMX
 			// Extra 8 channel sensors
 			for (var i = 1; i <= 8; i++)
 			{
-				EcowittApi.HistoricTempHum srcTH = null;
-				EcowittApi.HistoricDataSoil srcSoil = null;
-				EcowittApi.HistoricDataTemp srcTemp = null;
-				EcowittApi.HistoricDataLeaf srcLeaf = null;
+				HistoricTempHum srcTH = null;
+				HistoricDataSoil srcSoil = null;
+				HistoricDataTemp srcTemp = null;
+				HistoricDataLeaf srcLeaf = null;
 				switch (i)
 				{
 					case 1:
@@ -808,7 +859,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									var newItem = new EcowittApi.HistoricData();
+									var newItem = new HistoricData();
 									newItem.ExtraTemp[i] = item.Value;
 									buffer.Add(itemDate, newItem);
 								}
@@ -831,7 +882,7 @@ namespace CumulusMX
 								}
 								else
 								{
-									var newItem = new EcowittApi.HistoricData();
+									var newItem = new HistoricData();
 									newItem.ExtraHumidity[i] = item.Value;
 									buffer.Add(itemDate, newItem);
 								}
@@ -863,7 +914,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData();
+								var newItem = new HistoricData();
 								newItem.SoilMoist[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
@@ -893,7 +944,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData();
+								var newItem = new HistoricData();
 								newItem.UserTemp[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
@@ -923,7 +974,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData();
+								var newItem = new HistoricData();
 								newItem.LeafWetness[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
@@ -956,7 +1007,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ IndoorCo2 = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -979,7 +1030,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ IndoorCo2hr24 = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -1008,12 +1059,12 @@ namespace CumulusMX
 
 							if (buffer.TryGetValue(itemDate, out var value))
 							{
-								value.CO2pm2p5 = item.Value;
+								value.AqiComboCO2 = item.Value;
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
-								{ CO2pm2p5 = item.Value };
+								var newItem = new HistoricData()
+								{ AqiComboCO2 = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
 						}
@@ -1031,12 +1082,12 @@ namespace CumulusMX
 
 							if (buffer.TryGetValue(itemDate, out var value))
 							{
-								value.CO2pm2p5hr24 = item.Value;
+								value.AqiComboCO2hr24 = item.Value;
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
-								{ CO2pm2p5hr24 = item.Value };
+								var newItem = new HistoricData()
+								{ AqiComboCO2hr24 = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
 						}
@@ -1067,7 +1118,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ AqiComboPm25 = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -1099,7 +1150,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData()
+								var newItem = new HistoricData()
 								{ AqiComboPm10 = item.Value };
 								buffer.Add(itemDate, newItem);
 							}
@@ -1111,6 +1162,62 @@ namespace CumulusMX
 					cumulus.LogErrorMessage("API.ProcessHistoryData: Error in pre-processing pm 10 combo data. Exception: " + ex.Message);
 				}
 			}
+			// temp/hum Combo
+			if (data.t_rh_aqi_combo != null)
+			{
+				try
+				{
+					if (data.t_rh_aqi_combo.temperature != null && data.t_rh_aqi_combo.temperature.list != null)
+					{
+						foreach (var item in data.t_rh_aqi_combo.temperature.list)
+						{
+							var itemDate = item.Key.AddMinutes(EcowittApiFudgeFactor);
+
+							if (!item.Value.HasValue || itemDate <= cumulus.LastUpdateTime)
+								continue;
+
+							if (buffer.TryGetValue(itemDate, out var value))
+							{
+								value.AqiComboTemp = item.Value;
+							}
+							else
+							{
+								var newItem = new HistoricData()
+								{ AqiComboTemp = item.Value };
+								buffer.Add(itemDate, newItem);
+							}
+						}
+					}
+
+					if (data.t_rh_aqi_combo.humidity != null && data.t_rh_aqi_combo.humidity.list != null)
+					{
+						foreach (var item in data.t_rh_aqi_combo.humidity.list)
+						{
+							var itemDate = item.Key.AddMinutes(EcowittApiFudgeFactor);
+
+							if (!item.Value.HasValue || itemDate <= cumulus.LastUpdateTime)
+								continue;
+
+							if (buffer.TryGetValue(itemDate, out var value))
+							{
+								value.AqiComboHum = item.Value;
+							}
+							else
+							{
+								var newItem = new HistoricData()
+								{ AqiComboHum = item.Value };
+								buffer.Add(itemDate, newItem);
+							}
+						}
+					}
+
+				}
+				catch (Exception ex)
+				{
+					cumulus.LogErrorMessage("API.ProcessHistoryData: Error in pre-processing temp/hum combo data. Exception: " + ex.Message);
+				}
+			}
+
 			// 4 channel PM 2.5 sensors
 			for (var i = 1; i <= 4; i++)
 			{
@@ -1148,7 +1255,7 @@ namespace CumulusMX
 							}
 							else
 							{
-								var newItem = new EcowittApi.HistoricData();
+								var newItem = new HistoricData();
 								newItem.pm25[i] = item.Value;
 								buffer.Add(itemDate, newItem);
 							}
@@ -1241,7 +1348,12 @@ namespace CumulusMX
 				cumulus.DoLogFile(rec.Key, false);
 				cumulus.DoCustomIntervalLogs(rec.Key);
 
-				if (cumulus.StationOptions.LogExtraSensors) cumulus.DoExtraLogFile(rec.Key);
+				cumulus.MySqlRealtimeFile(999, false, rec.Key);
+
+				if (cumulus.StationOptions.LogExtraSensors)
+				{
+					cumulus.DoExtraLogFile(rec.Key);
+				}
 
 				//AddRecentDataEntry(timestamp, WindAverage, RecentMaxGust, WindLatest, Bearing, AvgBearing,
 				//    OutdoorTemperature, WindChill, OutdoorDewpoint, HeatIndex,
@@ -1500,6 +1612,11 @@ namespace CumulusMX
 				{
 					cumulus.LogErrorMessage($"ApplyHistoricData: Error in extra humidity data - {ex.Message}");
 				}
+				// === Extra Dewpoint ===
+				if (rec.Value.ExtraTemp[i].HasValue && rec.Value.ExtraHumidity[i].HasValue)
+				{
+					station.DoExtraDP(ConvertUnits.TempCToUser(MeteoLib.DewPoint(ConvertUnits.UserTempToC((double)rec.Value.ExtraTemp[i].Value), rec.Value.ExtraHumidity[i].Value)), i);
+				}
 
 
 				// === User Temperature ===
@@ -1522,6 +1639,7 @@ namespace CumulusMX
 					cumulus.LogErrorMessage($"ApplyHistoricData: Error in extra user temperature data - {ex.Message}");
 				}
 
+
 				// === Soil Moisture ===
 				try
 				{
@@ -1534,6 +1652,20 @@ namespace CumulusMX
 				{
 					cumulus.LogErrorMessage($"ApplyHistoricData: Error in soil moisture data - {ex.Message}");
 				}
+
+				// === Leaf Wetness ===
+				try
+				{
+					if (rec.Value.LeafWetness[i].HasValue)
+					{
+						station.DoLeafWetness((double) rec.Value.LeafWetness[i], i);
+					}
+				}
+				catch (Exception ex)
+				{
+					cumulus.LogErrorMessage($"ApplyHistoricData: Error in leaf wetness data - {ex.Message}");
+				}
+
 			}
 
 			// === Indoor CO2 ===
@@ -1541,7 +1673,7 @@ namespace CumulusMX
 			{
 				if (rec.Value.IndoorCo2.HasValue)
 				{
-					station.CO2_pm2p5 = rec.Value.IndoorCo2.Value;
+					station.CO2 = rec.Value.IndoorCo2.Value;
 				}
 			}
 			catch (Exception ex)
@@ -1554,7 +1686,7 @@ namespace CumulusMX
 			{
 				if (rec.Value.IndoorCo2hr24.HasValue)
 				{
-					station.CO2_pm2p5_24h = rec.Value.CO2pm2p5hr24.Value;
+					station.CO2_24h = rec.Value.IndoorCo2hr24.Value;
 				}
 			}
 			catch (Exception ex)
@@ -1562,7 +1694,33 @@ namespace CumulusMX
 				cumulus.LogErrorMessage("ApplyHistoricData: Error in CO2 24hr avg data - " + ex.Message);
 			}
 
-			// === PM 2.5 Combo
+			// === Combo CO2 ===
+			try
+			{
+				if (rec.Value.AqiComboCO2.HasValue)
+				{
+					station.CO2 = rec.Value.AqiComboCO2.Value;
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in CO2 data - " + ex.Message);
+			}
+
+			// === Combo CO2 24hr avg ===
+			try
+			{
+				if (rec.Value.AqiComboCO2hr24.HasValue)
+				{
+					station.CO2_24h = rec.Value.AqiComboCO2hr24.Value;
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in CO2 24hr avg data - " + ex.Message);
+			}
+
+			// === PM 2.5 Combo ===
 			try
 			{
 				if (rec.Value.AqiComboPm25.HasValue)
@@ -1575,7 +1733,7 @@ namespace CumulusMX
 				cumulus.LogErrorMessage("ApplyHistoricData: Error in AQI Combo pm2.5 data - " + ex.Message);
 			}
 
-			// === PM 10 Combo
+			// === PM 10 Combo ===
 			try
 			{
 				if (rec.Value.AqiComboPm10.HasValue)
@@ -1586,6 +1744,32 @@ namespace CumulusMX
 			catch (Exception ex)
 			{
 				cumulus.LogErrorMessage("ApplyHistoricData: Error in AQI Combo pm10 data - " + ex.Message);
+			}
+
+			// === temp Combo ===
+			try
+			{
+				if (rec.Value.AqiComboTemp.HasValue)
+				{
+					station.CO2_temperature = (double) rec.Value.AqiComboTemp.Value;
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in AQI Combo temp data - " + ex.Message);
+			}
+
+			// === humidity Combo ===
+			try
+			{
+				if (rec.Value.AqiComboHum.HasValue)
+				{
+					station.CO2_humidity = (double) rec.Value.AqiComboHum.Value;
+				}
+			}
+			catch (Exception ex)
+			{
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in AQI Combo temp data - " + ex.Message);
 			}
 
 			// === 4 channel pm 2.5 ===
@@ -2370,11 +2554,11 @@ namespace CumulusMX
 			public HistoricDataCo2 co2_aqi_combo { get; set; }
 			public HistoricDataPm25Aqi pm25_aqi_combo { get; set; }
 			public HistoricDataPm10Aqi pm10_aqi_combo { get; set; }
+			public HistoricTempHum t_rh_aqi_combo { get; set; }
 			public HistoricDataPm25Aqi pm25_ch1 { get; set; }
 			public HistoricDataPm25Aqi pm25_ch2 { get; set; }
 			public HistoricDataPm25Aqi pm25_ch3 { get; set; }
 			public HistoricDataPm25Aqi pm25_ch4 { get; set; }
-
 		}
 
 		internal class HistoricDataTypeInt
@@ -2398,6 +2582,8 @@ namespace CumulusMX
 		internal class HistoricOutdoor : HistoricTempHum
 		{
 			public HistoricDataTypeDbl dew_point { get; set; }
+			public HistoricDataTypeDbl feels_like { get; set; }
+			public HistoricDataTypeInt app_temp { get; set; }
 		}
 
 		internal class HistoricDataPressure
@@ -2470,6 +2656,7 @@ namespace CumulusMX
 			public decimal? Temp { get; set; }
 			public decimal? DewPoint { get; set; }
 			public decimal? FeelsLike { get; set; }
+			public decimal? Apparent {  get; set; }
 			public int? Humidity { get; set; }
 			public decimal? RainRate { get; set; }
 			public decimal? RainYear { get; set; }
@@ -2491,8 +2678,8 @@ namespace CumulusMX
 			public decimal? AqiComboPm10 { get; set; }
 			public decimal? AqiComboTemp { get; set; }
 			public int? AqiComboHum { get; set; }
-			public int? CO2pm2p5 { get; set; }
-			public int? CO2pm2p5hr24 { get; set; }
+			public int? AqiComboCO2 { get; set; }
+			public int? AqiComboCO2hr24 { get; set; }
 			public int? IndoorCo2 { get; set; }
 			public int? IndoorCo2hr24 { get; set; }
 

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -1820,18 +1820,25 @@ namespace CumulusMX
 						LastCurrentDataTime = dataTime;
 
 						// how many seconds to the next update?
-						// the data is updated once a minute, so wait for 5 seonds after the next update
+						// the data is updated once a minute, so wait for 15 seonds after the next update
 
-						var lastUpdate = (DateTime.Now - LastCurrentDataTime).TotalSeconds;
-						if (lastUpdate > 65)
+						var lastUpdateSecs = (int) (DateTime.Now - LastCurrentDataTime).TotalSeconds;
+						if (lastUpdateSecs > 130)
 						{
-							// hum the data is already out of date, query again after a short delay
+							// hmm the data is already out of date, query again after a short delay
 							delay = 10;
 							return null;
 						}
+						else if (lastUpdateSecs < 15)
+						{
+							// we're OK, just update again in an "Ecowitt" minute
+							delay = 64;
+							return currObj.data;
+						}
 						else
 						{
-							delay = (int) (60 - lastUpdate + 3);
+							// lets try and shift the time to be closer to 15 seconds after the next expected update
+							delay = 75 - lastUpdateSecs;
 							return currObj.data;
 						}
 					}
@@ -2598,17 +2605,8 @@ namespace CumulusMX
 			public CurrentSensorValDbl rain_rate { get; set; }
 			public CurrentSensorValDbl daily { get; set; }
 
-			[IgnoreDataMember]
-			public CurrentSensorValDbl Event { get; set; }
-
 			[DataMember(Name = "event")]
-			public CurrentSensorValDbl EventVal
-			{
-				get => Event;
-				set { Event = value; }
-			}
-
-
+			public CurrentSensorValDbl Event { get; set; }
 			public CurrentSensorValDbl hourly { get; set; }
 			public CurrentSensorValDbl yearly { get; set; }
 		}
@@ -2636,15 +2634,8 @@ namespace CumulusMX
 		{
 			public CurrentSensorValInt co2 { get; set; }
 
-			[IgnoreDataMember]
-			public int Avg24h { get; set; }
-
 			[DataMember(Name = "24_hours_average")]
-			public int Average
-			{
-				get => Avg24h;
-				set { Avg24h = value; }
-			}
+			public CurrentSensorValInt Avg24h { get; set; }
 		}
 
 		internal class CurrentPm25
@@ -2652,15 +2643,8 @@ namespace CumulusMX
 			public CurrentSensorValInt real_time_aqi { get; set; }
 			public CurrentSensorValInt pm25 { get; set; }
 
-			[IgnoreDataMember]
-			public CurrentSensorValInt Avg24h { get; set; }
-
 			[DataMember(Name = "24_hours_aqi")]
-			public CurrentSensorValInt AvgVal
-			{
-				get => Avg24h;
-				set { Avg24h = value; }
-			}
+			public CurrentSensorValInt Avg24h { get; set; }
 		}
 
 		internal class CurrentPm10
@@ -2668,15 +2652,8 @@ namespace CumulusMX
 			public CurrentSensorValInt real_time_aqi { get; set; }
 			public CurrentSensorValInt pm10 { get; set; }
 
-			[IgnoreDataMember]
-			public CurrentSensorValInt Avg24h { get; set; }
-
 			[DataMember(Name = "24_hours_aqi")]
-			public CurrentSensorValInt AvgVal
-			{
-				get => Avg24h;
-				set { Avg24h = value; }
-			}
+			public CurrentSensorValInt Avg24h { get; set; }
 		}
 
 		internal class CurrentLeak

--- a/CumulusMX/EcowittCloudStation.cs
+++ b/CumulusMX/EcowittCloudStation.cs
@@ -130,36 +130,40 @@ namespace CumulusMX
 			// main data task
 			liveTask = Task.Run(() =>
 			{
-					var piezoLastRead = DateTime.MinValue;
-					var dataLastRead = DateTime.MinValue;
-					var delay = 0;
-					var nextFetch = DateTime.MinValue;
+				var piezoLastRead = DateTime.MinValue;
+				var dataLastRead = DateTime.MinValue;
+				var delay = 0;
+				var nextFetch = DateTime.MinValue;
 
-					while (!cumulus.cancellationToken.IsCancellationRequested)
+				while (!cumulus.cancellationToken.IsCancellationRequested)
+				{
+					if (DateTime.Now >= nextFetch)
 					{
-						if (DateTime.Now >= nextFetch)
+						try
 						{
-							try
-							{
 
-								var data = ecowittApi.GetCurrentData(ref delay, cumulus.cancellationToken);
+							var data = ecowittApi.GetCurrentData(ref delay, cumulus.cancellationToken);
 
-								if (data != null)
-								{
-									ProcessCurrentData(data, cumulus.cancellationToken);
-								}
-								cumulus.LogDebugMessage($"EcowittCloud; Waiting {delay} seconds before next update");
-								nextFetch = DateTime.Now.AddSeconds(delay);
-							}
-							catch (Exception ex)
+							if (data != null)
 							{
-								cumulus.LogExceptionMessage(ex, "Error running Ecowitt Cloud station");
-								nextFetch = DateTime.Now.AddMinutes(1);
+								ProcessCurrentData(data, cumulus.cancellationToken);
 							}
+							else
+							{
+								cumulus.LogDebugMessage($"EcowittCloud: No new data to process");
+							}
+							cumulus.LogDebugMessage($"EcowittCloud: Waiting {delay} seconds before next update");
+							nextFetch = DateTime.Now.AddSeconds(delay);
 						}
-
-						Thread.Sleep(1000);
+						catch (Exception ex)
+						{
+							cumulus.LogExceptionMessage(ex, "Error running Ecowitt Cloud station");
+							nextFetch = DateTime.Now.AddMinutes(1);
+						}
 					}
+
+					Thread.Sleep(1000);
+				}
 			}, cumulus.cancellationToken);
 		}
 
@@ -569,10 +573,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch1.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch1.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch1.temperature.value, 1);
-				station.DoExtraHum(data.temp_and_humidity_ch1.humidity.value, 1);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[1]), station.ExtraHum[1]);
-				station.ExtraDewPoint[1] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch1.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch1.humidity.value, 1);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[1]), station.ExtraHum[1]);
+					station.ExtraDewPoint[1] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 
 			if (data.temp_and_humidity_ch2 != null)
@@ -583,10 +592,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch2.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch2.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch2.temperature.value, 2);
-				station.DoExtraHum(data.temp_and_humidity_ch2.humidity.value, 2);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[2]), station.ExtraHum[2]);
-				station.ExtraDewPoint[2] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch2.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch2.humidity.value, 2);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[2]), station.ExtraHum[2]);
+					station.ExtraDewPoint[2] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 
 			if (data.temp_and_humidity_ch3 != null)
@@ -597,10 +611,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch3.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch3.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch3.temperature.value, 3);
-				station.DoExtraHum(data.temp_and_humidity_ch3.humidity.value, 3);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[3]), station.ExtraHum[3]);
-				station.ExtraDewPoint[3] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch3.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch3.humidity.value, 3);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[3]), station.ExtraHum[3]);
+					station.ExtraDewPoint[3] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 
 			if (data.temp_and_humidity_ch4 != null)
@@ -611,10 +630,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch4.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch4.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch4.temperature.value, 4);
-				station.DoExtraHum(data.temp_and_humidity_ch4.humidity.value, 4);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[4]), station.ExtraHum[4]);
-				station.ExtraDewPoint[4] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch4.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch4.humidity.value, 4);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[4]), station.ExtraHum[4]);
+					station.ExtraDewPoint[4] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 
 			if (data.temp_and_humidity_ch5 != null)
@@ -625,10 +649,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch5.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch5.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch5.temperature.value, 5);
-				station.DoExtraHum(data.temp_and_humidity_ch5.humidity.value, 5);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[5]), station.ExtraHum[5]);
-				station.ExtraDewPoint[5] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch5.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch5.humidity.value, 5);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[5]), station.ExtraHum[5]);
+					station.ExtraDewPoint[5] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 
 			if (data.temp_and_humidity_ch6 != null)
@@ -639,10 +668,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch6.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch6.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch6.temperature.value, 6);
-				station.DoExtraHum(data.temp_and_humidity_ch6.humidity.value, 6);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[6]), station.ExtraHum[6]);
-				station.ExtraDewPoint[6] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch6.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch6.humidity.value, 6);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[6]), station.ExtraHum[6]);
+					station.ExtraDewPoint[6] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 
 			if (data.temp_and_humidity_ch7 != null)
@@ -653,10 +687,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch7.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch7.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch7.temperature.value, 7);
-				station.DoExtraHum(data.temp_and_humidity_ch7.humidity.value, 7);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[7]), station.ExtraHum[7]);
-				station.ExtraDewPoint[7] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch7.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch7.humidity.value, 7);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[7]), station.ExtraHum[7]);
+					station.ExtraDewPoint[7] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 
 			if (data.temp_and_humidity_ch8 != null)
@@ -667,10 +706,15 @@ namespace CumulusMX
 					station.DoOutdoorHumidity(data.temp_and_humidity_ch8.humidity.value, Utils.FromUnixTime(data.temp_and_humidity_ch8.humidity.time));
 				}
 				station.DoExtraTemp(data.temp_and_humidity_ch8.temperature.value, 8);
-				station.DoExtraHum(data.temp_and_humidity_ch8.humidity.value, 8);
 
-				var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[8]), station.ExtraHum[8]);
-				station.ExtraDewPoint[8] = ConvertUnits.TempCToUser(dp);
+				// Not all sensor types have humidity
+				if (data.temp_and_humidity_ch8.humidity != null)
+				{
+					station.DoExtraHum(data.temp_and_humidity_ch8.humidity.value, 8);
+
+					var dp = MeteoLib.DewPoint(ConvertUnits.UserTempToC(station.ExtraTemp[8]), station.ExtraHum[8]);
+					station.ExtraDewPoint[8] = ConvertUnits.TempCToUser(dp);
+				}
 			}
 		}
 
@@ -889,13 +933,13 @@ namespace CumulusMX
 			if (data.co2_aqi_combo != null)
 			{
 				station.CO2 = data.co2_aqi_combo.co2.value;
-				station.CO2_24h = data.co2_aqi_combo.Avg24h;
+				station.CO2_24h = data.co2_aqi_combo.Avg24h.value;
 			}
 			// indoor overrides the combo
 			if (data.indoor_co2 != null)
 			{
 				station.CO2 = data.indoor_co2.co2.value;
-				station.CO2_24h = data.indoor_co2.Avg24h;
+				station.CO2_24h = data.indoor_co2.Avg24h.value;
 			}
 		}
 

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -875,7 +875,7 @@ namespace CumulusMX
 				{
 					if (data["heap"] != null)
 					{
-						EcowittHeapSize = int.Parse(data["heap"]);
+						StationFreeMemory = int.Parse(data["heap"]);
 					}
 
 					if (data["runtime"] != null)

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -869,6 +869,26 @@ namespace CumulusMX
 					cumulus.LogErrorMessage($"{procName}: Error extracting firmware version - {ex.Message}");
 				}
 
+
+				// === Heap and run time ===
+				try
+				{
+					if (data["heap"] != null)
+					{
+						EcowittHeapSize = int.Parse(data["heap"]);
+					}
+
+					if (data["runtime"] != null)
+					{
+						StationRuntime = int.Parse(data["runtime"]);
+					}
+				}
+				catch (Exception ex)
+				{
+					cumulus.LogErrorMessage($"{procName}: Error extracting heap/runtime - {ex.Message}");
+				}
+
+
 				if (main)
 				{
 					// Do derived values after the primary values

--- a/CumulusMX/MysqlSettings.cs
+++ b/CumulusMX/MysqlSettings.cs
@@ -84,24 +84,36 @@ namespace CumulusMX
 			var customminutes = new JsonSettingsCustomMinutes()
 			{
 				enabled = cumulus.MySqlSettings.CustomMins.Enabled,
-				intervalindex = cumulus.CustomMySqlMinutesIntervalIndex
+				entries = Array.Empty<JsonCustomMinutes>()
 			};
 
-			cmdCnt = 1;
-			for (var i = 1; i < 10; i++)
+			cmdCnt = 0;
+			for (var i = 0; i < 10; i++)
 			{
 				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomMins.Commands[i]))
 					cmdCnt++;
 			}
-			customminutes.command = new string[cmdCnt];
 
-			index = 0;
-			for (var i = 0; i < 10; i++)
+			if (cmdCnt > 0)
 			{
-				if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomMins.Commands[i]))
-					customminutes.command[index++] = cumulus.MySqlSettings.CustomMins.Commands[i];
-			}
+				customminutes.entries = new JsonCustomMinutes[cmdCnt];
 
+				index = 0;
+				for (var i = 0; i < 10; i++)
+				{
+					customminutes.entries[index] = new JsonCustomMinutes();
+
+					if (!string.IsNullOrEmpty(cumulus.MySqlSettings.CustomMins.Commands[i]))
+					{
+						customminutes.entries[index].command = cumulus.MySqlSettings.CustomMins.Commands[i];
+						customminutes.entries[index].intervalidx = cumulus.MySqlSettings.CustomMins.IntervalIndexes[i];
+						index++;
+
+						if (index == cmdCnt)
+							break;
+					}
+				}
+			}
 			var customrollover = new JsonSettingsCustomRolloverStart()
 			{
 				enabled = cumulus.MySqlSettings.CustomRollover.Enabled
@@ -289,7 +301,7 @@ namespace CumulusMX
 				{
 					for (var i = 0; i < 10; i++)
 					{
-						if (settings.customseconds.command == null || i < settings.customseconds.command.Length)
+						if (settings.customseconds.command != null && i < settings.customseconds.command.Length)
 							cumulus.MySqlSettings.CustomSecs.Commands[i] = String.IsNullOrWhiteSpace(settings.customseconds.command[i]) ? null : settings.customseconds.command[i].Trim();
 						else
 							cumulus.MySqlSettings.CustomSecs.Commands[i] = null;
@@ -303,20 +315,26 @@ namespace CumulusMX
 				{
 					for (var i = 0; i < 10; i++)
 					{
-						if (settings.customminutes.command != null && i < settings.customminutes.command.Length)
-							cumulus.MySqlSettings.CustomMins.Commands[i] = String.IsNullOrWhiteSpace(settings.customminutes.command[i]) ? null : settings.customminutes.command[i].Trim();
+						if (i < settings.customminutes.entries.Length)
+						{
+							cumulus.MySqlSettings.CustomMins.Commands[i] = String.IsNullOrWhiteSpace(settings.customminutes.entries[i].command) ? null : settings.customminutes.entries[i].command.Trim();
+							cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] = settings.customminutes.entries[i].intervalidx;
+							if (cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] >= 0 && cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] < cumulus.FactorsOf60.Length)
+							{
+								cumulus.MySqlSettings.CustomMins.Intervals[i] = cumulus.FactorsOf60[cumulus.MySqlSettings.CustomMins.IntervalIndexes[i]];
+							}
+							else
+							{
+								cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] = 6;
+								cumulus.MySqlSettings.CustomMins.Intervals[i] = 10;
+							}
+						}
 						else
+						{
 							cumulus.MySqlSettings.CustomMins.Commands[i] = null;
-					}
-
-					cumulus.CustomMySqlMinutesIntervalIndex = settings.customminutes.intervalindex;
-					if (cumulus.CustomMySqlMinutesIntervalIndex >= 0 && cumulus.CustomMySqlMinutesIntervalIndex < cumulus.FactorsOf60.Length)
-					{
-						cumulus.MySqlSettings.CustomMins.Interval = cumulus.FactorsOf60[cumulus.CustomMySqlMinutesIntervalIndex];
-					}
-					else
-					{
-						cumulus.MySqlSettings.CustomMins.Interval = 10;
+							cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] = 6;
+							cumulus.MySqlSettings.CustomMins.Intervals[i] = 10;
+						}
 					}
 				}
 				// custom roll-over
@@ -344,6 +362,7 @@ namespace CumulusMX
 							if (settings.customtimed.entries[i].repeat)
 							{
 								cumulus.MySqlSettings.CustomTimed.Intervals[i] = settings.customtimed.entries[i].interval == -1 ? 1440 : settings.customtimed.entries[i].interval;
+								cumulus.MySqlSettings.CustomTimed.SetNextInterval(i, DateTime.Now);
 							}
 							else
 							{
@@ -585,8 +604,13 @@ namespace CumulusMX
 		private class JsonSettingsCustomMinutes
 		{
 			public bool enabled { get; set; }
-			public string[] command { get; set; }
-			public int intervalindex { get; set; }
+			public JsonCustomMinutes[] entries { get; set; }
+		}
+
+		private class JsonCustomMinutes
+		{
+			public string command { get; set; }
+			public int intervalidx { get; set; }
 		}
 
 		private class JsonSettingsCustomRolloverStart

--- a/CumulusMX/MysqlSettings.cs
+++ b/CumulusMX/MysqlSettings.cs
@@ -289,7 +289,7 @@ namespace CumulusMX
 				{
 					for (var i = 0; i < 10; i++)
 					{
-						if (i < settings.customseconds.command.Length)
+						if (settings.customseconds.command == null || i < settings.customseconds.command.Length)
 							cumulus.MySqlSettings.CustomSecs.Commands[i] = String.IsNullOrWhiteSpace(settings.customseconds.command[i]) ? null : settings.customseconds.command[i].Trim();
 						else
 							cumulus.MySqlSettings.CustomSecs.Commands[i] = null;
@@ -303,7 +303,7 @@ namespace CumulusMX
 				{
 					for (var i = 0; i < 10; i++)
 					{
-						if (i < settings.customminutes.command.Length)
+						if (settings.customminutes.command != null && i < settings.customminutes.command.Length)
 							cumulus.MySqlSettings.CustomMins.Commands[i] = String.IsNullOrWhiteSpace(settings.customminutes.command[i]) ? null : settings.customminutes.command[i].Trim();
 						else
 							cumulus.MySqlSettings.CustomMins.Commands[i] = null;
@@ -325,7 +325,7 @@ namespace CumulusMX
 				{
 					for (var i = 0; i < 10; i++)
 					{
-						if (i < settings.customrollover.command.Length)
+						if (settings.customrollover.command != null && i < settings.customrollover.command.Length)
 							cumulus.MySqlSettings.CustomRollover.Commands[i] = String.IsNullOrWhiteSpace(settings.customrollover.command[i]) ? null : settings.customrollover.command[i].Trim();
 						else
 							cumulus.MySqlSettings.CustomRollover.Commands[i] = null;

--- a/CumulusMX/WeatherLinkDotCom.cs
+++ b/CumulusMX/WeatherLinkDotCom.cs
@@ -463,7 +463,7 @@ namespace CumulusMX
 		public long espressif_version { get; set; }
 		public int battery_voltage { get; set; }
 		public int input_voltage { get; set; }
-		public double uptime { get; set; }
+		public int uptime { get; set; }
 		public int bgn { get; set; }
 		public int network_type { get; set; }
 		public int ip_address_type { get; set; }
@@ -520,6 +520,7 @@ namespace CumulusMX
 		public double? database_kilobytes { get; set; }
 		public double? battery_cycle_count { get; set; }
 		public string console_os_version { get; set; }
+		public long ts { get; set; }
 	}
 
 
@@ -542,7 +543,7 @@ namespace CumulusMX
 		public int? data_structure_type { get; set; }
 
 		// We have no idea what data structures are going to be in here in advance
-		public string[] data { get; set; }
+		public string data { get; set; }
 	}
 
 
@@ -557,9 +558,13 @@ namespace CumulusMX
 		public double? temp_in { get; set; }
 		public int? hum_in { get; set; }
 		public double? temp_out { get; set; }
+		public double? dew_point { get; set; }
+		public double? heat_index { get; set; }
+		public double? wind_chill { get; set; }
 		public int? wind_speed { get; set; }
-		public int? wind_speed_10_min_avg { get; set; }
 		public int? wind_dir { get; set; }
+		public int? wind_speed_10_min_avg { get; set; }
+		public int? wind_gust_10_min { get; set; }
 		public int? temp_extra_1 { get; set; }
 		public int? temp_extra_2 { get; set; }
 		public int? temp_extra_3 { get; set; }
@@ -586,8 +591,6 @@ namespace CumulusMX
 		public int? rain_rate_clicks { get; set; }
 		public double? rain_rate_in { get; set; }
 		public double? rain_rate_mm { get; set; }
-		public int? uv { get; set; }
-		public int? solar_rad { get; set; }
 		public int? rain_storm_clicks { get; set; }
 		public double? rain_storm_in { get; set; }
 		public double? rain_storm_mm { get; set; }
@@ -601,6 +604,8 @@ namespace CumulusMX
 		public int? rain_year_clicks { get; set; }
 		public double? rain_year_in { get; set; }
 		public double? rain_year_mm { get; set; }
+		public int? uv { get; set; }
+		public int? solar_rad { get; set; }
 		public double? et_day { get; set; }
 		public double? et_month { get; set; }
 		public double? et_year { get; set; }
@@ -614,10 +619,6 @@ namespace CumulusMX
 		public int? wet_leaf_4 { get; set; }
 		public int? forecast_rule { get; set; }
 		public string forescast_desc { get; set; }
-		public double? dew_point { get; set; }
-		public double? heat_index { get; set; }
-		public double? wind_chill { get; set; }
-		public int? wind_gust_10_min { get; set; }
 		public long ts { get; set; }
 	}
 
@@ -647,9 +648,9 @@ namespace CumulusMX
 		public double? wind_speed_hi_last_2_min { get; set; }
 		public int? wind_dir_at_hi_speed_last_2_min { get; set; }
 		public double? wind_speed_avg_last_10_min { get; set; }
-		public double wind_dir_scalar_avg_last_10_min { get; set; }
-		public int? wind_speed_hi_last_10_min { get; set; }
-		public double wind_dir_at_hi_speed_last_10_min { get; set; }
+		public int wind_dir_scalar_avg_last_10_min { get; set; }
+		public double? wind_speed_hi_last_10_min { get; set; }
+		public int wind_dir_at_hi_speed_last_10_min { get; set; }
 		public double? wind_run_day { get; set; }  // Type 23 only
 		public int? rain_size { get; set; }
 		public int? rain_rate_last_clicks { get; set; }
@@ -751,12 +752,13 @@ namespace CumulusMX
 		public int? freq_index { get; set; } // Type 25 only
 		public long? last_packet_received_timestamp { get; set; } // Type 25 only
 		public int? trans_battery_flag { get; set; } // Type 25 only
+		public long ts { get; set; }
 
 		public object this[string name]
 		{
 			get
 			{
-				Type myType = typeof(WlHistorySensorDataType13);
+				Type myType = typeof(WLCurrentSensorDataType12_25);
 				PropertyInfo myPropInfo = myType.GetProperty(name);
 				return myPropInfo.GetValue(this, null);
 			}

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -389,7 +389,7 @@ namespace CumulusMX
 			return string.Empty;
 		}
 
-		public int EcowittHeapSize;
+		public int StationFreeMemory;
 		public int StationRuntime;
 
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -430,6 +430,7 @@ namespace CumulusMX
 			ReadMonthIniFile();
 			ReadYearIniFile();
 			_ = LoadDayFile();
+			CheckMonthlyLogFile(cumulus.LastUpdateTime);
 
 			GetRainCounter();
 			GetRainFallTotals();
@@ -517,6 +518,26 @@ namespace CumulusMX
 					SQLiteOpenFlags flags = SQLiteOpenFlags.Create | SQLiteOpenFlags.ReadWrite;
 					RecentDataDb = new SQLiteConnection(new SQLiteConnectionString(cumulus.dbfile, flags, false, null, null, null, null, "yyyy-MM-dd HH:mm:ss"));
 				}
+			}
+		}
+
+		private void CheckMonthlyLogFile(DateTime logDate)
+		{
+			// A crude check for corruption, just see if the last line starts with nulls
+			// if it does resave the file missing the last line
+			var fileName = cumulus.GetLogFileName(logDate);
+
+			var lines = File.ReadAllLines(fileName);
+
+			//Strip the "null line" from file
+			if (lines[lines.Length - 1].StartsWith("\0\0\0\0\0"))
+			{
+				cumulus.LogMessage($"Monthly log file {fileName} Repaired");
+				File.WriteAllLines(fileName, lines.Take(lines.Length - 1).ToArray());
+			}
+			else
+			{
+				cumulus.LogMessage($"Monthly log file {fileName} OK");
 			}
 		}
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -389,6 +389,9 @@ namespace CumulusMX
 			return string.Empty;
 		}
 
+		public int EcowittHeapSize;
+		public int StationRuntime;
+
 
 		public WeatherStation(Cumulus cumulus, bool extraStation = false)
 		{

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1951,9 +1951,9 @@ namespace CumulusMX
 					}
 
 					// Custom MySQL update - minutes interval
-					if (cumulus.MySqlSettings.CustomMins.Enabled && now.Minute % cumulus.MySqlSettings.CustomMins.Interval == 0)
+					if (cumulus.MySqlSettings.CustomMins.Enabled)
 					{
-						cumulus.CustomMysqlMinutesTimerTick();
+						cumulus.CustomMysqlMinutesUpdate(now);
 					}
 
 					// Custom MySQL Timed interval

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -5387,9 +5387,9 @@ namespace CumulusMX
 			return retVal;
 		}
 
-		private string TagEcowittHeap(Dictionary<string, string> tagParams)
+		private string TagStationFreeMemory(Dictionary<string, string> tagParams)
 		{
-			return station.EcowittHeapSize.ToString();
+			return station.StationFreeMemory.ToString();
 		}
 
 		private string TagStationRuntime(Dictionary<string, string> tagParams)
@@ -6508,7 +6508,7 @@ namespace CumulusMX
 				{ "GW1000FirmwareVersion", TagGw1000FirmwareVersion },
 				{ "EcowittFirmwareVersion", TagGw1000FirmwareVersion },
 				{ "EcowittReception", TagGw1000Reception },
-				{ "EcowittHeap", TagEcowittHeap },
+				{ "StationFreeMemory", TagStationFreeMemory },
 				{ "StationRuntime", TagStationRuntime },
 				{ "DataStopped", TagDataStopped },
 				// Recent history

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -5387,6 +5387,15 @@ namespace CumulusMX
 			return retVal;
 		}
 
+		private string TagEcowittHeap(Dictionary<string, string> tagParams)
+		{
+			return station.EcowittHeapSize.ToString();
+		}
+
+		private string TagStationRuntime(Dictionary<string, string> tagParams)
+		{
+			return station.StationRuntime.ToString();
+		}
 
 		private string Tagdailygraphperiod(Dictionary<string, string> tagparams)
 		{
@@ -6499,6 +6508,8 @@ namespace CumulusMX
 				{ "GW1000FirmwareVersion", TagGw1000FirmwareVersion },
 				{ "EcowittFirmwareVersion", TagGw1000FirmwareVersion },
 				{ "EcowittReception", TagGw1000Reception },
+				{ "EcowittHeap", TagEcowittHeap },
+				{ "StationRuntime", TagStationRuntime },
 				{ "DataStopped", TagDataStopped },
 				// Recent history
 				{ "RecentOutsideTemp", TagRecentOutsideTemp },

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,9 @@
+3.28.2 - b3279
+——————————————
+Fixed
+- Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API
+
+
 3.28.1 - b3278
 ——————————————
 New

--- a/Updates.txt
+++ b/Updates.txt
@@ -15,7 +15,7 @@ Fixed
 - Extra Files using log filename templates missed the last log entry at month rollover as they switched to the new month immediately
 - Fix missing units in alarm email messages
 - Custom Timed MySQL commands sometimes fired immediately after saving the configuration
-
+- Ecowitt historic catch-up was missing CO2, CO2 pm, CO2 T/H, leaf wetness, and extra T/H dewpoint values
 
 
 3.28.1 - b3278

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,12 +1,13 @@
 3.28.2 - b3279
 ——————————————
 New
-- Adds two new web tags <#EcowittHeap> and <#StationRuntime>
-	EcowittHeap: Shows the station free memory for Ecowitt GW1100/20000
-	StationRuntime: Shows the station uptime in seconds for Davis WLL, Ecowitt GW1100/20000
+- Adds two new web tags <#StationFreeMemory> and <#StationRuntime>
+	StationFreeMemory: Shows the station free memory for Davis WLC, Ecowitt GW1100/20000
+	StationRuntime: Shows the station uptime in seconds for Davis WLL/WLC, Ecowitt GW1100/20000
 
 Fixed
-- Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API
+- Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API.
+- Ecowitt Cloud, no longer requires a Pro subscrition to pull current data. Quite an extensive rewrite!
 - Extra Files using log filename templates missed the last log entry at month rollover as they switched to the new month immediately
 - Fix missing units in alarm email messages
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -4,6 +4,7 @@ New
 - Adds two new web tags <#StationFreeMemory> and <#StationRuntime>
 	StationFreeMemory: Shows the station free memory for Davis WLC, Ecowitt GW1100/20000
 	StationRuntime: Shows the station uptime in seconds for Davis WLL/WLC, Ecowitt GW1100/20000
+- Now implements a basic check of the latest monthly log file on start-up to remove any nulls from the end
 
 Fixed
 - Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API.

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,6 +7,8 @@ New
 
 Fixed
 - Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API
+- Extra Files using log filename templates missed the last log entry at month rollover as they switched to the new month immediately
+- Fix missing units in alarm email messages
 
 
 3.28.1 - b3278

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,11 +6,16 @@ New
 	StationRuntime: Shows the station uptime in seconds for Davis WLL/WLC, Ecowitt GW1100/20000
 - Now implements a basic check of the latest monthly log file on start-up to remove any nulls from the end
 
+Changed
+- Custom Minutes MySQL commands can now have the interval defined per command rather than globally
+
 Fixed
 - Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API.
 - Ecowitt Cloud, no longer requires a Pro subscrition to pull current data. Quite an extensive rewrite!
 - Extra Files using log filename templates missed the last log entry at month rollover as they switched to the new month immediately
 - Fix missing units in alarm email messages
+- Custom Timed MySQL commands sometimes fired immediately after saving the configuration
+
 
 
 3.28.1 - b3278

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,8 +2,8 @@
 ——————————————
 New
 - Adds two new web tags <#StationFreeMemory> and <#StationRuntime>
-	StationFreeMemory: Shows the station free memory for Davis WLC, Ecowitt GW1100/20000
-	StationRuntime: Shows the station uptime in seconds for Davis WLL/WLC, Ecowitt GW1100/20000
+	StationFreeMemory: Shows the station free memory for Davis WLC, Ecowitt GW1100/20000 (using HTTP)
+	StationRuntime: Shows the station uptime in seconds for Davis WLL/WLC, Ecowitt GW1100/20000 (using HTTP)
 - Now implements a basic check of the latest monthly log file on start-up to remove any nulls from the end
 
 Changed

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,5 +1,10 @@
 3.28.2 - b3279
 ——————————————
+New
+- Adds two new web tags <#EcowittHeap> and <#StationRuntime>
+	EcowittHeap: Shows the station free memory for Ecowitt GW1100/20000
+	StationRuntime: Shows the station uptime in seconds for Davis WLL, Ecowitt GW1100/20000
+
 Fixed
 - Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API
 


### PR DESCRIPTION
New
- Adds two new web tags <#StationFreeMemory> and <#StationRuntime>
	StationFreeMemory: Shows the station free memory for Davis WLC, Ecowitt GW1100/20000 (using HTTP)
	StationRuntime: Shows the station uptime in seconds for Davis WLL/WLC, Ecowitt GW1100/20000 (using HTTP)
- Now implements a basic check of the latest monthly log file on start-up to remove any nulls from the end

Changed
- Custom Minutes MySQL commands can now have the interval defined per command rather than globally

Fixed
- Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API.
- Ecowitt Cloud, no longer requires a Pro subscrition to pull current data. Quite an extensive rewrite!
- Extra Files using log filename templates missed the last log entry at month rollover as they switched to the new month immediately
- Fix missing units in alarm email messages
- Custom Timed MySQL commands sometimes fired immediately after saving the configuration
- Ecowitt historic catch-up was missing CO2, CO2 pm, CO2 T/H, leaf wetness, and extra T/H dewpoint values