### PR TITLE
v3.28.3

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -7507,7 +7507,8 @@ namespace CumulusMX
 			Trans.CO2_pm2p5_24hrCaption = ini.GetValue("CO2Captions", "CO2-Pm2p5-24hr", "PM 2.5 24h avg");
 			Trans.CO2_pm10Caption = ini.GetValue("CO2Captions", "CO2-Pm10", "PM 10");
 			Trans.CO2_pm10_24hrCaption = ini.GetValue("CO2Captions", "CO2-Pm10-24hr", "PM 10 24h avg");
-
+			Trans.CO2_TemperatureCaption = ini.GetValue("CO2Captions", "CO2-Temperature", "Temperature");
+			Trans.CO2_HumidityCaption = ini.GetValue("CO2Captions", "CO2-Humidity", "Humidity");
 
 			Trans.thereWillBeMinSLessDaylightTomorrow = ini.GetValue("Solar", "LessDaylightTomorrow", "There will be {0}min {1}s less daylight tomorrow");
 			Trans.thereWillBeMinSMoreDaylightTomorrow = ini.GetValue("Solar", "MoreDaylightTomorrow", "There will be {0}min {1}s more daylight tomorrow");
@@ -7700,6 +7701,8 @@ namespace CumulusMX
 			ini.SetValue("CO2Captions", "CO2-Pm2p5-24hr", Trans.CO2_pm2p5_24hrCaption);
 			ini.SetValue("CO2Captions", "CO2-Pm10", Trans.CO2_pm10Caption);
 			ini.SetValue("CO2Captions", "CO2-Pm10-24hr", Trans.CO2_pm10_24hrCaption);
+			ini.SetValue("CO2Captions", "CO2-Temperature", Trans.CO2_TemperatureCaption);
+			ini.SetValue("CO2Captions", "CO2-Humidity", Trans.CO2_HumidityCaption);
 
 
 			ini.SetValue("Solar", "LessDaylightTomorrow", Trans.thereWillBeMinSLessDaylightTomorrow);

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -76,7 +76,7 @@
     <StartupObject>CumulusMX.Program</StartupObject>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
-    <Version>3.28.2.3279</Version>
+    <Version>3.28.3.3280</Version>
     <EnableNETAnalyzers>True</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>
     <RunPostBuildEvent>OnOutputUpdated</RunPostBuildEvent>

--- a/CumulusMX/DataEditor.cs
+++ b/CumulusMX/DataEditor.cs
@@ -1976,8 +1976,8 @@ namespace CumulusMX
 
 			var datefrom = cumulus.RecordsBeganDateTime;
 			datefrom = new DateTime(datefrom.Year, datefrom.Month, 1, 0, 0, 0);
-			var dateto = DateTime.Now;
-			dateto = new DateTime(dateto.Year, dateto.Month, 1, 0, 0, 0);
+			datefrom = datefrom.AddHours(cumulus.GetHourInc());
+			var dateto = DateTime.Now.Date;
 			var filedate = datefrom;
 
 			var logFile = cumulus.GetLogFileName(filedate);
@@ -2097,7 +2097,7 @@ namespace CumulusMX
 			{
 				if (File.Exists(logFile))
 				{
-					cumulus.LogDebugMessage($"GetMonthlyTimeRecLogFile: Processing log file - {logFile}");
+					cumulus.LogDebugMessage($"GetMonthlyRecLogFile: Processing log file - {logFile}");
 					var linenum = 0;
 					try
 					{
@@ -2266,7 +2266,7 @@ namespace CumulusMX
 							// new meteo day
 							if (currentDay.Date != metoDate.Date)
 							{
-								var lastEntryMonthOffset = metoDate.Month - 1;
+								var lastEntryMonthOffset = currentDay.Date.Month - 1;
 								if (dayHighTemp.Value < lowMaxTemp[lastEntryMonthOffset].Value)
 								{
 									lowMaxTemp[lastEntryMonthOffset].Value = dayHighTemp.Value;
@@ -2311,10 +2311,10 @@ namespace CumulusMX
 
 								monthlyRain += dayRain;
 
-								if (monthlyRain > highRainMonth[monthOffset].Value)
+								if (monthlyRain > highRainMonth[lastEntryMonthOffset].Value)
 								{
-									highRainMonth[monthOffset].Value = monthlyRain;
-									highRainMonth[monthOffset].Ts = currentDay;
+									highRainMonth[lastEntryMonthOffset].Value = monthlyRain;
+									highRainMonth[lastEntryMonthOffset].Ts = currentDay;
 								}
 
 								if (currentDay.Month != metoDate.Month)
@@ -2330,10 +2330,10 @@ namespace CumulusMX
 									{
 										currentWetPeriod = 1;
 										isDryNow = false;
-										if (currentDryPeriod > dryPeriod[monthOffset].Value)
+										if (currentDryPeriod > dryPeriod[lastEntryMonthOffset].Value)
 										{
-											dryPeriod[monthOffset].Value = currentDryPeriod;
-											dryPeriod[monthOffset].Ts = thisDateDry;
+											dryPeriod[lastEntryMonthOffset].Value = currentDryPeriod;
+											dryPeriod[lastEntryMonthOffset].Ts = thisDateDry;
 										}
 										currentDryPeriod = 0;
 									}
@@ -2354,10 +2354,10 @@ namespace CumulusMX
 									{
 										currentDryPeriod = 1;
 										isDryNow = true;
-										if (currentWetPeriod > wetPeriod[monthOffset].Value)
+										if (currentWetPeriod > wetPeriod[lastEntryMonthOffset].Value)
 										{
-											wetPeriod[monthOffset].Value = currentWetPeriod;
-											wetPeriod[monthOffset].Ts = thisDateWet;
+											wetPeriod[lastEntryMonthOffset].Value = currentWetPeriod;
+											wetPeriod[lastEntryMonthOffset].Ts = thisDateWet;
 										}
 										currentWetPeriod = 0;
 									}

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -234,8 +234,11 @@ namespace CumulusMX
 					}
 					else if (responseBody.StartsWith("{\"code\":")) // sanity check
 					{
+						// Ecowitt send null values as the string "-", so we have to change all those to null before we parse...
+						var json = responseBody.Replace("\"-\"", "null");
+
 						// get the sensor data
-						var histObj = responseBody.FromJson<HistoricResp>();
+						var histObj = json.FromJson<HistoricResp>();
 
 						if (histObj != null)
 						{
@@ -1678,7 +1681,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage("ApplyHistoricData: Error in CO2 data - " + ex.Message);
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in indoor CO2 data - " + ex.Message);
 			}
 
 			// === Indoor CO2 24hr avg ===
@@ -1691,7 +1694,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage("ApplyHistoricData: Error in CO2 24hr avg data - " + ex.Message);
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in indoor CO2 24hr avg data - " + ex.Message);
 			}
 
 			// === Combo CO2 ===
@@ -1704,7 +1707,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage("ApplyHistoricData: Error in CO2 data - " + ex.Message);
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in combo CO2 data - " + ex.Message);
 			}
 
 			// === Combo CO2 24hr avg ===
@@ -1717,7 +1720,7 @@ namespace CumulusMX
 			}
 			catch (Exception ex)
 			{
-				cumulus.LogErrorMessage("ApplyHistoricData: Error in CO2 24hr avg data - " + ex.Message);
+				cumulus.LogErrorMessage("ApplyHistoricData: Error in combo CO2 24hr avg data - " + ex.Message);
 			}
 
 			// === PM 2.5 Combo ===
@@ -1948,8 +1951,11 @@ namespace CumulusMX
 				}
 				else if (responseBody.StartsWith("{\"code\":")) // sanity check
 				{
+					// Ecowitt send null values as the string "-", so we have to change all those to null before we parse...
+					var json = responseBody.Replace("\"-\"", "null");
+
 					// get the sensor data
-					currObj = responseBody.FromJson<CurrentData>();
+					currObj = json.FromJson<CurrentData>();
 
 					if (currObj != null)
 					{
@@ -2583,7 +2589,7 @@ namespace CumulusMX
 		{
 			public HistoricDataTypeDbl dew_point { get; set; }
 			public HistoricDataTypeDbl feels_like { get; set; }
-			public HistoricDataTypeInt app_temp { get; set; }
+			public HistoricDataTypeDbl app_temp { get; set; }
 		}
 
 		internal class HistoricDataPressure
@@ -2634,6 +2640,7 @@ namespace CumulusMX
 		[DataContract]
 		internal class HistoricDataCo2
 		{
+			[DataMember(Name = "co2")]
 			public HistoricDataTypeInt co2 { get; set; }
 			[DataMember(Name = "24_hours_average")]
 			public HistoricDataTypeInt average24h { get; set; }
@@ -2641,12 +2648,12 @@ namespace CumulusMX
 
 		internal class HistoricDataPm25Aqi
 		{
-			public HistoricDataTypeDbl pm25 { get; set; }
+			public HistoricDataTypeInt pm25 { get; set; }
 		}
 
 		internal class HistoricDataPm10Aqi
 		{
-			public HistoricDataTypeDbl pm10 { get; set; }
+			public HistoricDataTypeInt pm10 { get; set; }
 		}
 
 		internal class HistoricData

--- a/CumulusMX/EcowittCloudStation.cs
+++ b/CumulusMX/EcowittCloudStation.cs
@@ -821,42 +821,42 @@ namespace CumulusMX
 		{
 			if (data.soil_ch1 != null)
 			{
-				station.DoSoilTemp(data.soil_ch1.soilmoisture.value, 1);
+				station.DoSoilMoisture(data.soil_ch1.soilmoisture.value, 1);
 			}
 
 			if (data.soil_ch2 != null)
 			{
-				station.DoSoilTemp(data.soil_ch2.soilmoisture.value, 2);
+				station.DoSoilMoisture(data.soil_ch2.soilmoisture.value, 2);
 			}
 
 			if (data.soil_ch3 != null)
 			{
-				station.DoSoilTemp(data.soil_ch3.soilmoisture.value, 3);
+				station.DoSoilMoisture(data.soil_ch3.soilmoisture.value, 3);
 			}
 
 			if (data.soil_ch4 != null)
 			{
-				station.DoSoilTemp(data.soil_ch4.soilmoisture.value, 4);
+				station.DoSoilMoisture(data.soil_ch4.soilmoisture.value, 4);
 			}
 
 			if (data.soil_ch5 != null)
 			{
-				station.DoSoilTemp(data.soil_ch5.soilmoisture.value, 5);
+				station.DoSoilMoisture(data.soil_ch5.soilmoisture.value, 5);
 			}
 
 			if (data.soil_ch6 != null)
 			{
-				station.DoSoilTemp(data.soil_ch6.soilmoisture.value, 6);
+				station.DoSoilMoisture(data.soil_ch6.soilmoisture.value, 6);
 			}
 
 			if (data.soil_ch7 != null)
 			{
-				station.DoSoilTemp(data.soil_ch7.soilmoisture.value, 7);
+				station.DoSoilMoisture(data.soil_ch7.soilmoisture.value, 7);
 			}
 
 			if (data.soil_ch8 != null)
 			{
-				station.DoSoilTemp(data.soil_ch8.soilmoisture.value, 8);
+				station.DoSoilMoisture(data.soil_ch8.soilmoisture.value, 8);
 			}
 		}
 
@@ -935,6 +935,25 @@ namespace CumulusMX
 				station.CO2 = data.co2_aqi_combo.co2.value;
 				station.CO2_24h = data.co2_aqi_combo.Avg24h.value;
 			}
+
+			if (data.pm25_aqi_combo != null)
+			{
+				station.CO2_pm2p5 = data.pm25_aqi_combo.pm25.value;
+				station.CO2_pm2p5_24h = data.pm25_aqi_combo.Avg24h.value;
+			}
+
+			if (data.pm10_aqi_combo != null)
+			{
+				station.CO2_pm10 = data.pm10_aqi_combo.pm10.value;
+				station.CO2_pm10_24h = data.pm10_aqi_combo.Avg24h.value;
+			}
+
+			if (data.t_rh_aqi_combo != null)
+			{
+				station.CO2_temperature = data.t_rh_aqi_combo.temperature.value;
+				station.CO2_humidity = data.t_rh_aqi_combo.humidity.value;
+			}
+
 			// indoor overrides the combo
 			if (data.indoor_co2 != null)
 			{

--- a/CumulusMX/EmailSender.cs
+++ b/CumulusMX/EmailSender.cs
@@ -29,6 +29,13 @@ namespace CumulusMX
 		public async Task<bool> SendEmail(string[] to, string from, string subject, string message, bool isHTML, bool useBcc)
 		{
 			bool retVal = false;
+
+			if (string.IsNullOrEmpty(cumulus.SmtpOptions.Server) || string.IsNullOrEmpty(cumulus.SmtpOptions.User))
+			{
+				cumulus.LogWarningMessage("SendEmail: You have not configured either the email server, or the email account used to send email");
+				return retVal;
+			}
+
 			try
 			{
 				//cumulus.LogDebugMessage($"SendEmail: Waiting for lock...");
@@ -103,6 +110,12 @@ namespace CumulusMX
 		public string SendTestEmail(string[] to, string from, string subject, string message, bool isHTML)
 		{
 			string retVal;
+
+			if (string.IsNullOrEmpty(cumulus.SmtpOptions.Server) || string.IsNullOrEmpty(cumulus.SmtpOptions.User))
+			{
+				cumulus.LogWarningMessage("SendEmail: You have not configured either the email server, or the email account used to send email");
+				return "You have not configured either the email server, or the email account used to send email";
+			}
 
 			try
 			{

--- a/CumulusMX/EmailSender.cs
+++ b/CumulusMX/EmailSender.cs
@@ -32,7 +32,7 @@ namespace CumulusMX
 
 			if (string.IsNullOrEmpty(cumulus.SmtpOptions.Server) || string.IsNullOrEmpty(cumulus.SmtpOptions.User))
 			{
-				cumulus.LogWarningMessage("SendEmail: You have not configured either the email server, or the email account used to send email");
+				cumulus.LogWarningMessage("SendEmail: You have not configured either the email server or the email account used to send email");
 				return retVal;
 			}
 
@@ -113,8 +113,8 @@ namespace CumulusMX
 
 			if (string.IsNullOrEmpty(cumulus.SmtpOptions.Server) || string.IsNullOrEmpty(cumulus.SmtpOptions.User))
 			{
-				cumulus.LogWarningMessage("SendEmail: You have not configured either the email server, or the email account used to send email");
-				return "You have not configured either the email server, or the email account used to send email";
+				cumulus.LogWarningMessage("SendEmail: You have not configured either the email server or the email account used to send email");
+				return "You have not configured either the email server or the email account used to send email";
 			}
 
 			try

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -942,7 +942,7 @@ namespace CumulusMX
 								}
 								idx += 2;
 								break;
-							case 0x0F: //Rain hour (mm)
+							case 0x0F: //Rain Gain (mm)
 								idx += 2;
 								break;
 							case 0x10: //Rain Day (mm)
@@ -1214,6 +1214,12 @@ namespace CumulusMX
 								DoLeafWetness(data[idx], chan);
 								idx += 1;
 								break;
+							case 0x7A: // Rain Priority
+								idx += 1;
+								break;
+							case 0x7B: // Radiation compensation
+								idx += 1;
+								break;
 							case 0x80: // Piezo Rain Rate
 								if (cumulus.Gw1000PrimaryRainSensor == 1)
 								{
@@ -1228,7 +1234,7 @@ namespace CumulusMX
 								}
 								idx += 2;
 								break;
-							case 0x82: // Piezo Hourly Rain
+							case 0x82: // Piezo Hourly Rain (not used)
 								idx += 2;
 								break;
 							case 0x83: // Piezo Daily Rain

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -1186,6 +1186,10 @@ namespace CumulusMX
 								}
 								idx += 8;
 								break;
+							case 0x6C: // Heap size - has constant offset of +3692 to HTTP value????
+								StationFreeMemory = (int) GW1000Api.ConvertBigEndianUInt32(data, idx);
+								idx += 4;
+								break;
 							case 0x70: // WH45 CO₂
 								batteryLow = batteryLow || DoCO2Decode(data, idx);
 								idx += 16;

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -1186,7 +1186,7 @@ namespace CumulusMX
 								}
 								idx += 8;
 								break;
-							case 0x6C: // Heap size - has constant offset of +3692 to HTTP value????
+							case 0x6C: // Heap size - has constant offset of +3692 to GW1100 HTTP value????
 								StationFreeMemory = (int) GW1000Api.ConvertBigEndianUInt32(data, idx);
 								idx += 4;
 								break;

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -875,7 +875,14 @@ namespace CumulusMX
 				{
 					if (data["heap"] != null)
 					{
-						StationFreeMemory = int.Parse(data["heap"]);
+						if (main)
+						{
+							StationFreeMemory = int.Parse(data["heap"]);
+						}
+						else
+						{
+							ExtraStationFreeMemory = int.Parse(data["heap"]);
+						}
 					}
 
 					if (data["runtime"] != null)

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -102,7 +102,7 @@ namespace CumulusMX
 			{
 				cumulus.LogMessage("Checking Ecowitt Extra Gateway Custom Server configuration...");
 				var api = new GW1000Api(cumulus);
-				api.OpenTcpPort(cumulus.EcowittGatewayAddr, 45000);
+				api.OpenTcpPort(cumulus.EcowittExtraGatewayAddr, 45000);
 				SetCustomServer(api, mainStation);
 				api.CloseTcpPort();
 				cumulus.LogMessage("Ecowitt Extra Gateway Custom Server configuration complete");
@@ -1357,7 +1357,7 @@ namespace CumulusMX
 
 						// Payload
 						// 1    - ID length
-						// n+   - ID
+						// n+   - ID size
 						// 1    - Password length
 						// n+   - Password
 						// 0	- Server length
@@ -1415,6 +1415,11 @@ namespace CumulusMX
 					// does the path need setting as well?
 					if (ecPath != customPath)
 					{
+						// 1 - id
+						// 2 - size
+						// 3-n - Ecowitt Path
+						// n+1-m - Wund Path
+
 						ecPath = customPath;
 						var path = new byte[ecPath.Length + wuPath.Length + 2];
 						path[0] = (byte) ecPath.Length;

--- a/CumulusMX/Lang.cs
+++ b/CumulusMX/Lang.cs
@@ -161,6 +161,8 @@
 		public string CO2_pm2p5_24hrCaption { get; set; }
 		public string CO2_pm10Caption { get; set; }
 		public string CO2_pm10_24hrCaption { get; set; }
+		public string CO2_TemperatureCaption { get; set; }
+		public string CO2_HumidityCaption { get; set; }
 		// daylight
 		public string thereWillBeMinSLessDaylightTomorrow { get; set; }
 		public string thereWillBeMinSMoreDaylightTomorrow { get; set; }

--- a/CumulusMX/LangSettings.cs
+++ b/CumulusMX/LangSettings.cs
@@ -100,7 +100,9 @@ namespace CumulusMX
 				Pm2p5 = cumulus.Trans.CO2_pm2p5Caption,
 				Pm2p5_24hr = cumulus.Trans.CO2_pm2p5_24hrCaption,
 				Pm10 = cumulus.Trans.CO2_pm10Caption,
-				Pm10_24hr = cumulus.Trans.CO2_pm10_24hrCaption
+				Pm10_24hr = cumulus.Trans.CO2_pm10_24hrCaption,
+				Temperature = cumulus.Trans.CO2_TemperatureCaption,
+				Humidity = cumulus.Trans.CO2_HumidityCaption
 			};
 
 			var alarmNames = new AlarmStrings()
@@ -373,6 +375,8 @@ namespace CumulusMX
 					cumulus.Trans.CO2_pm2p5_24hrCaption = settings.co2.Pm2p5_24hr.Trim();
 					cumulus.Trans.CO2_pm10Caption = settings.co2.Pm10.Trim();
 					cumulus.Trans.CO2_pm10_24hrCaption = settings.co2.Pm10_24hr.Trim();
+					cumulus.Trans.CO2_TemperatureCaption = settings.co2.Temperature.Trim();
+					cumulus.Trans.CO2_HumidityCaption = settings.co2.Humidity.Trim();
 				}
 				catch (Exception ex)
 				{
@@ -533,6 +537,8 @@ namespace CumulusMX
 			public string Pm2p5_24hr { get; set; }
 			public string Pm10 { get; set; }
 			public string Pm10_24hr { get; set; }
+			public string Temperature { get; set; }
+			public string Humidity { get; set; }
 		}
 
 		private class AlarmSettings

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -533,7 +533,7 @@ namespace CumulusMX
 				var lines = File.ReadAllLines(fileName);
 
 				//Strip the "null line" from file
-				if (lines[lines.Length - 1].StartsWith("\0\0\0\0\0"))
+				if (lines[lines.Length - 1].StartsWith("\0"))
 				{
 					cumulus.LogMessage($"Monthly log file {fileName} Repaired");
 					File.WriteAllLines(fileName, lines.Take(lines.Length - 1).ToArray());

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -528,17 +528,24 @@ namespace CumulusMX
 			// if it does resave the file missing the last line
 			var fileName = cumulus.GetLogFileName(logDate);
 
-			var lines = File.ReadAllLines(fileName);
-
-			//Strip the "null line" from file
-			if (lines[lines.Length - 1].StartsWith("\0\0\0\0\0"))
+			if (File.Exists(fileName))
 			{
-				cumulus.LogMessage($"Monthly log file {fileName} Repaired");
-				File.WriteAllLines(fileName, lines.Take(lines.Length - 1).ToArray());
+				var lines = File.ReadAllLines(fileName);
+
+				//Strip the "null line" from file
+				if (lines[lines.Length - 1].StartsWith("\0\0\0\0\0"))
+				{
+					cumulus.LogMessage($"Monthly log file {fileName} Repaired");
+					File.WriteAllLines(fileName, lines.Take(lines.Length - 1).ToArray());
+				}
+				else
+				{
+					cumulus.LogMessage($"Monthly log file {fileName} OK");
+				}
 			}
 			else
 			{
-				cumulus.LogMessage($"Monthly log file {fileName} OK");
+				cumulus.LogMessage("Monthly log file check skipped - no file exists");
 			}
 		}
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -23,6 +23,8 @@ using ServiceStack.Text;
 
 using SQLite;
 
+using static System.Net.Mime.MediaTypeNames;
+
 using Timer = System.Timers.Timer;
 
 namespace CumulusMX
@@ -533,14 +535,27 @@ namespace CumulusMX
 				var lines = File.ReadAllLines(fileName);
 
 				//Strip the "null line" from file
-				if (lines[lines.Length - 1].StartsWith("\0"))
+				if (lines[lines.Length - 1][0] < 32)
 				{
 					cumulus.LogMessage($"Monthly log file {fileName} Repaired");
+					var str = new StringBuilder(lines[lines.Length - 1].Length + 50);
+					for (int i = 0; i < lines[lines.Length - 1].Length; i++)
+					{
+						if (Char.ConvertToUtf32(lines[lines.Length - 1], i) < 32)
+						{
+							str.AppendFormat("[{0:X2}]", (byte) lines[lines.Length - 1][i]);
+						}
+						else
+						{
+							str.Append(lines[lines.Length - 1][i]);
+						}
+					}
+					cumulus.LogMessage("Removed line: " + str.ToString());
 					File.WriteAllLines(fileName, lines.Take(lines.Length - 1).ToArray());
 				}
 				else
 				{
-					cumulus.LogMessage($"Monthly log file {fileName} OK");
+					cumulus.LogMessage($"Monthly log file {fileName} Checked OK");
 				}
 			}
 			else

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -12239,7 +12239,11 @@ namespace CumulusMX
 				if (cumulus.GraphOptions.Visible.CO2Sensor.Pm10.IsVisible(local))
 					json.Append($"[\"{cumulus.Trans.CO2_pm10Caption}\",\"{CO2_pm10:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
 				if (cumulus.GraphOptions.Visible.CO2Sensor.Pm10Avg.IsVisible(local))
-					json.Append($"[\"{cumulus.Trans.CO2_pm10_24hrCaption}\",\"{CO2_pm10_24h:F1}\",\"{cumulus.Units.AirQualityUnitText}\"]");
+					json.Append($"[\"{cumulus.Trans.CO2_pm10_24hrCaption}\",\"{CO2_pm10_24h:F1}\",\"{cumulus.Units.AirQualityUnitText}\"],");
+				if (cumulus.GraphOptions.Visible.CO2Sensor.Temp.IsVisible(local))
+					json.Append($"[\"{cumulus.Trans.CO2_TemperatureCaption}\",\"{CO2_temperature:F1}\",\"{cumulus.Units.TempText}\"],");
+				if (cumulus.GraphOptions.Visible.CO2Sensor.Hum.IsVisible(local))
+					json.Append($"[\"{cumulus.Trans.CO2_HumidityCaption}\",\"{CO2_humidity:F1}\",\"%\"]");
 			}
 
 			if (json[json.Length - 1] == ',')

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -390,6 +390,7 @@ namespace CumulusMX
 		}
 
 		public int StationFreeMemory;
+		public int ExtraStationFreeMemory;
 		public int StationRuntime;
 
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -5983,17 +5983,29 @@ namespace CumulusMX
 
 			// Has the rain total in the station been reset?
 			// raindaystart greater than current total, allow for rounding
-			if (Math.Round(RainCounterDayStart, cumulus.RainDPlaces) - Math.Round(RainCounter, cumulus.RainDPlaces) > 0)
+			// or current has jumped by more than 25 mm/1 inch
+			var maxIncrement = cumulus.Units.Rain == 0 ? 1 : 25;
+			var counterReset = Math.Round(RainCounterDayStart, cumulus.RainDPlaces) - Math.Round(RainCounter, cumulus.RainDPlaces) > 0;
+			var counterJumped = Math.Round(RainCounter, cumulus.RainDPlaces) - previoustotal > maxIncrement;
+
+			if (counterReset || counterJumped)
 			{
-				if (FirstChanceRainReset)
-				// second consecutive reading with reset value
+				// third consecutive reading with reset value
+				if (SecondChanceRainReset)
 				{
-					cumulus.LogWarningMessage(" ****Rain counter reset confirmed: raindaystart = " + RainCounterDayStart + ", Raincounter = " + RainCounter);
+					if (counterReset)
+					{
+						cumulus.LogWarningMessage(" ****Rain counter reset confirmed: RaindayStart = " + RainCounterDayStart + ", Raincounter = " + RainCounter);
+					}
+					else
+					{
+						cumulus.LogWarningMessage(" ****Rain counter jump confirmed: Previous Value = " + previoustotal + ", Raincounter = " + RainCounter);
+					}
 
 					// set the start of day figure so it reflects the rain
 					// so far today
 					RainCounterDayStart = RainCounter - (RainToday / cumulus.Calib.Rain.Mult);
-					cumulus.LogMessage("Setting raindaystart to " + RainCounterDayStart);
+					cumulus.LogMessage("Setting RaindayStart to " + RainCounterDayStart);
 
 					MidnightRainCount = RainCounter;
 					previoustotal = total;
@@ -6002,11 +6014,19 @@ namespace CumulusMX
 					var counterChange = RainCounter - prevraincounter;
 					RecentDataDb.Execute("update RecentData set raincounter=raincounter+?", counterChange);
 
-					FirstChanceRainReset = false;
+					SecondChanceRainReset = false;
+					rainResetCount = 0;
 				}
 				else
 				{
-					cumulus.LogMessage(" ****Rain reset? First chance: raindaystart = " + RainCounterDayStart + ", Raincounter = " + RainCounter);
+					if (counterReset)
+					{
+						cumulus.LogMessage(" ****Rain reset? RaindayStart = " + RainCounterDayStart + ", Raincounter = " + RainCounter);
+					}
+					else
+					{
+						cumulus.LogWarningMessage(" ****Rain counter jump? Previous Value = " + previoustotal + ", Raincounter = " + RainCounter);
+					}
 
 					// reset the counter to ignore this reading
 					RainCounter = previoustotal;
@@ -6015,12 +6035,18 @@ namespace CumulusMX
 					// stash the previous rain counter
 					prevraincounter = RainCounter;
 
-					FirstChanceRainReset = true;
+					rainResetCount++;
+
+					if (rainResetCount >= 2)
+					{
+						SecondChanceRainReset = true;
+					}
 				}
 			}
 			else
 			{
-				FirstChanceRainReset = false;
+				SecondChanceRainReset = false;
+				rainResetCount = 0;
 			}
 
 			if (rate > -1)
@@ -6064,7 +6090,7 @@ namespace CumulusMX
 				}
 			}
 
-			if (!FirstChanceRainReset)
+			if (rainResetCount == 0)
 			{
 				// Has a tip occurred?
 				if (Math.Round(total, cumulus.RainDPlaces) - Math.Round(previoustotal, cumulus.RainDPlaces) > 0)
@@ -6861,7 +6887,8 @@ namespace CumulusMX
 
 
 		//private bool first_rain = true;
-		private bool FirstChanceRainReset = false;
+		private int rainResetCount = 0;
+		private bool SecondChanceRainReset = false;
 		private bool initialiseRainDayStart = true;
 		private bool initialiseMidnightRain = true;
 		private bool initialiseRainCounter = true;

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -5392,6 +5392,11 @@ namespace CumulusMX
 			return station.StationFreeMemory.ToString();
 		}
 
+		private string TagExtraStationFreeMemory(Dictionary<string, string> tagParams)
+		{
+			return station.ExtraStationFreeMemory.ToString();
+		}
+
 		private string TagStationRuntime(Dictionary<string, string> tagParams)
 		{
 			return station.StationRuntime.ToString();
@@ -6509,6 +6514,7 @@ namespace CumulusMX
 				{ "EcowittFirmwareVersion", TagGw1000FirmwareVersion },
 				{ "EcowittReception", TagGw1000Reception },
 				{ "StationFreeMemory", TagStationFreeMemory },
+				{ "ExtraStationFreeMemory", TagExtraStationFreeMemory },
 				{ "StationRuntime", TagStationRuntime },
 				{ "DataStopped", TagDataStopped },
 				// Recent history

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,7 +7,8 @@ New
 Fixed
 - Ecowitt Cloud decoding of Soil Moisture values
 - Ecowitt Cloud add missing decode of CO2 temp/humidity values
-- Fix crash for new installs when the monthly log file does not exist
+- Crash for new installs when the monthly log file does not exist
+- Setting Ecowitt custom server settings when used as an Extra Sensor station
 
 
 3.28.2 - b3279

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,11 @@
+3.28.3 - b3280
+——————————————
+Fixed
+- Ecowitt Cloud decoding of Soil Moisture values
+- Ecowitt Cloud add missing decode of CO2 temp/humidity values
+
+
+
 3.28.2 - b3279
 ——————————————
 New
@@ -11,7 +19,7 @@ Changed
 
 Fixed
 - Ecowitt Cloud station: Fix some errors decoding Ecowitt cloud API.
-- Ecowitt Cloud, no longer requires a Pro subscrition to pull current data. Quite an extensive rewrite!
+- Ecowitt Cloud, no longer requires a Pro subscription to pull current data. Quite an extensive rewrite!
 - Extra Files using log filename templates missed the last log entry at month rollover as they switched to the new month immediately
 - Fix missing units in alarm email messages
 - Custom Timed MySQL commands sometimes fired immediately after saving the configuration

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,5 +1,8 @@
 3.28.3 - b3280
 ——————————————
+New
+- Adds Ecowitt local GW1000 API to the web tag <#StationFreeMemory>. Known to work with GW1100 (v2.3.1) and GW2000 (v3.1.1) so far
+
 Fixed
 - Ecowitt Cloud decoding of Soil Moisture values
 - Ecowitt Cloud add missing decode of CO2 temp/humidity values

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,7 +7,7 @@ New
 Fixed
 - Ecowitt Cloud decoding of Soil Moisture values
 - Ecowitt Cloud add missing decode of CO2 temp/humidity values
-
+- Fix crash for new installs when the monthly log file does not exist
 
 
 3.28.2 - b3279

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,12 +3,14 @@
 New
 - Adds Ecowitt local GW1000 API to the web tag <#StationFreeMemory>. Known to work with GW1100 (v2.3.1) and GW2000 (v3.1.1) so far
 - Adds a new web tag <#ExtraStationFreeMemory> to avoid clashes with the main station and a Ecowitt HTTP station used for extra sensors
+- Adds a check for the raincounter suddenly increasing (more than 25mm or 1 inch)
 
 Fixed
 - Ecowitt Cloud decoding of Soil Moisture values
 - Ecowitt Cloud add missing decode of CO2 temp/humidity values
 - Crash for new installs when the monthly log file does not exist
 - Setting Ecowitt custom server settings when used as an Extra Sensor station
+- The Monthly Records editor values from the log file showed the previous months values for monthly totals like Total Rainfall etc.
 
 
 3.28.2 - b3279

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,6 +2,7 @@
 ——————————————
 New
 - Adds Ecowitt local GW1000 API to the web tag <#StationFreeMemory>. Known to work with GW1100 (v2.3.1) and GW2000 (v3.1.1) so far
+- Adds a new web tag <#ExtraStationFreeMemory> to avoid clashes with the main station and a Ecowitt HTTP station used for extra sensors
 
 Fixed
 - Ecowitt Cloud decoding of Soil Moisture values


### PR DESCRIPTION
- Adds Ecowitt local GW1000 API to the web tag <#StationFreeMemory>. Known to work with GW1100 (v2.3.1) and GW2000 (v3.1.1) so far
- Adds a new web tag <#ExtraStationFreeMemory> to avoid clashes with the main station and a Ecowitt HTTP station used for extra sensors
- Adds a check for the raincounter suddenly increasing (more than 25mm or 1 inch)
- - Ecowitt Cloud decoding of Soil Moisture values
- Ecowitt Cloud add missing decode of CO2 temp/humidity values
- Crash for new installs when the monthly log file does not exist
- Setting Ecowitt custom server settings when used as an Extra Sensor station
- The Monthly Records editor values from the log file showed the previous months values for monthly totals like Total Rainfall etc.