### PR TITLE
b4018

### DIFF
--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3948,7 +3948,8 @@ namespace CumulusMX
 			EcowittApplicationKey = ini.GetValue("GW1000", "EcowittAppKey", string.Empty);
 			EcowittUserApiKey = ini.GetValue("GW1000", "EcowittUserKey", string.Empty);
 			EcowittMacAddress = ini.GetValue("GW1000", "EcowittMacAddress", string.Empty);
-			if (string.IsNullOrEmpty(EcowittMacAddress) && !string.IsNullOrEmpty(Gw1000MacAddress))
+			// For GW1000 stations, the Ecowitt MAC must be the same as the device MAC
+			if (StationType == 12)
 			{
 				EcowittMacAddress = Gw1000MacAddress;
 			}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -12519,7 +12519,7 @@ namespace CumulusMX
 				}
 				else if (int.Parse(latestBuild.tag_name[1..]) < cmxBuild)
 				{
-					LogWarningMessage($"This Cumulus MX instance appears to be running a test version. This build = {Build}, latest available build = {veryLatest}");
+					LogWarningMessage($"This Cumulus MX instance appears to be running a test version. This build={Build}, latest available build={veryLatest}");
 				}
 			}
 			catch (Exception ex)

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -12483,14 +12483,14 @@ namespace CumulusMX
 				var cmxBuild = int.Parse(Build);
 				var veryLatest = Math.Max(int.Parse(latestBuild.tag_name[1..]), int.Parse(latestLive.tag_name[1..]));
 
-				if (latestLive == null)
+				if (string.IsNullOrEmpty(latestLive.name))
 				{
 					if (releases.Count == 0)
 					{
 						LogMessage("Failed to get the latest build version from GitHub");
 					}
 				}
-				else if (latestBuild == null)
+				else if (string.IsNullOrEmpty(latestBuild.name))
 				{
 					LogMessage($"Failed to get the latest {(beta ? "beta" : "release")} build version from GitHub");
 				}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -44,8 +44,10 @@ using ServiceStack.Text;
 using SQLite;
 
 using Swan;
+using Swan.Formatters;
 
 using static CumulusMX.EmailSender;
+using static CumulusMX.NoaaConfig;
 
 using Timer = System.Timers.Timer;
 
@@ -12467,29 +12469,55 @@ namespace CumulusMX
 		{
 			try
 			{
-				using var retVal = await MyHttpClient.GetAsync("https://github.com/cumulusmx/CumulusMX/releases/latest");
-				var latestUri = retVal.RequestMessage.RequestUri.AbsolutePath;
-				LatestBuild = new string(latestUri.Split('/')[^1].Where(char.IsDigit).ToArray());
-				if (int.Parse(Build) < int.Parse(LatestBuild))
+				bool beta = Program.debug;
+				var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/repos/cumulusmx/CumulusMX/releases");
+				request.Headers.Add("User-Agent", "CumulusMX");
+
+				using var retval = await MyHttpClient.SendAsync(request);
+
+				var body = await retval.Content.ReadAsStringAsync();
+				var releases = body.FromJson<List<GithubRelease>>();
+
+				var latestBuild = releases.Find(x => !x.draft && x.prerelease == beta);
+				var latestLive = releases.Find(x => !x.draft && !x.prerelease);
+				var cmxBuild = int.Parse(Build);
+
+
+				if (latestLive == null)
 				{
-					var msg = $"You are not running the latest version of Cumulus MX, build {LatestBuild} is available.";
+					if (releases.Count == 0)
+					{
+						LogMessage("Failed to get the latest build version from GitHub");
+					}
+				}
+				else if (latestBuild == null)
+				{
+					LogMessage($"Failed to get the latest {(beta ? "beta" : "release")} build version from GitHub");
+				}
+				else if (beta && int.Parse(latestLive.tag_name[1..]) > cmxBuild)
+				{
+					var msg = $"You are not running a beta version of Cumulus MX, and a later release build {latestLive.name} is available.";
 					LogConsoleMessage(msg, ConsoleColor.Cyan);
 					LogWarningMessage(msg);
-					UpgradeAlarm.LastMessage = $"Build {LatestBuild} is available";
+					UpgradeAlarm.LastMessage = $"Release build {latestLive.name} is available";
 					UpgradeAlarm.Triggered = true;
 				}
-				else if (int.Parse(Build) == int.Parse(LatestBuild))
+				else if (int.Parse(latestBuild.tag_name[1..]) > cmxBuild)
 				{
-					LogMessage("This Cumulus MX instance is running the latest version");
+					var msg = $"You are not running the latest {(beta ? "beta" : "release")} version of Cumulus MX, build {latestBuild.name} is available.";
+					LogConsoleMessage(msg, ConsoleColor.Cyan);
+					LogWarningMessage(msg);
+					UpgradeAlarm.LastMessage = $"{(beta ? "Beta" : "Release")} build {latestBuild.name} is available";
+					UpgradeAlarm.Triggered = true;
+				}
+				else if (int.Parse(latestBuild.tag_name[1..]) == cmxBuild)
+				{
+					LogMessage($"This Cumulus MX instance is running the latest {(beta ? "beta" : "release")} version");
 					UpgradeAlarm.Triggered = false;
 				}
-				else if (int.Parse(Build) > int.Parse(LatestBuild))
+				else if (int.Parse(latestBuild.tag_name[1..]) < cmxBuild)
 				{
-					LogWarningMessage($"This Cumulus MX instance appears to be running a beta/test version. This build = {Build}, latest released build = {LatestBuild}");
-				}
-				else
-				{
-					LogMessage($"Could not determine if you are running the latest Cumulus MX build or not. This build = {Build}, latest build = {LatestBuild}");
+					LogWarningMessage($"This Cumulus MX instance appears to be running a test version. This build = {Build}, latest released build = {LatestBuild}");
 				}
 			}
 			catch (Exception ex)
@@ -13458,5 +13486,13 @@ namespace CumulusMX
 			TempNorms = new double[13];
 			RainNorms = new double[13];
 		}
+	}
+
+	sealed class GithubRelease
+	{
+		public string tag_name { get; set; }
+		public string name { get; set; }
+		public bool draft { get; set; }
+		public bool prerelease { get; set; }
 	}
 }

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4464,6 +4464,7 @@ namespace CumulusMX
 			}
 			APRS.HumidityCutoff = ini.GetValue("APRS", "APRSHumidityCutoff", false);
 			APRS.SendSolar = ini.GetValue("APRS", "SendSR", false);
+			APRS.UseUtcInWxNowFile = ini.GetValue("APRS", "UseUtcInWxNowFile", false);
 
 			OpenWeatherMap.Enabled = ini.GetValue("OpenWeatherMap", "Enabled", false);
 			OpenWeatherMap.CatchUp = ini.GetValue("OpenWeatherMap", "CatchUp", true);
@@ -5893,6 +5894,7 @@ namespace CumulusMX
 			ini.SetValue("APRS", "Interval", APRS.Interval);
 			ini.SetValue("APRS", "SendSR", APRS.SendSolar);
 			ini.SetValue("APRS", "APRSHumidityCutoff", APRS.HumidityCutoff);
+			ini.SetValue("APRS", "UseUtcInWxNowFile", APRS.UseUtcInWxNowFile);
 
 			ini.SetValue("OpenWeatherMap", "Enabled", OpenWeatherMap.Enabled);
 			ini.SetValue("OpenWeatherMap", "CatchUp", OpenWeatherMap.CatchUp);

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3916,7 +3916,7 @@ namespace CumulusMX
 
 			// GW1000 settings
 			Gw1000IpAddress = ini.GetValue("GW1000", "IPAddress", "0.0.0.0");
-			Gw1000MacAddress = ini.GetValue("GW1000", "MACAddress", string.Empty);
+			Gw1000MacAddress = ini.GetValue("GW1000", "MACAddress", string.Empty).ToUpper();
 			Gw1000AutoUpdateIpAddress = ini.GetValue("GW1000", "AutoUpdateIpAddress", true);
 			Gw1000PrimaryTHSensor = ini.GetValue("GW1000", "PrimaryTHSensor", 0);  // 0=default, 1-8=extra t/h sensor number, 99=use indoor sensor
 			Gw1000PrimaryRainSensor = ini.GetValue("GW1000", "PrimaryRainSensor", 0); //0=main station (tipping bucket) 1=piezo
@@ -3947,7 +3947,7 @@ namespace CumulusMX
 			// api
 			EcowittApplicationKey = ini.GetValue("GW1000", "EcowittAppKey", string.Empty);
 			EcowittUserApiKey = ini.GetValue("GW1000", "EcowittUserKey", string.Empty);
-			EcowittMacAddress = ini.GetValue("GW1000", "EcowittMacAddress", string.Empty);
+			EcowittMacAddress = ini.GetValue("GW1000", "EcowittMacAddress", string.Empty).ToUpper();
 			// For GW1000 stations, the Ecowitt MAC must be the same as the device MAC
 			if (StationType == 12)
 			{

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -8234,17 +8234,17 @@ namespace CumulusMX
 							try
 							{
 								LogDebugMessage("Archiving the database");
-								archive.CreateEntryFromFile(dbfile, dbBackup);
-								if (File.Exists(dbfile + "-journal"))
-								{
-									archive.CreateEntryFromFile(dbfile + "-journal", dbBackup + "-journal");
-								}
+								if (File.Exists(dbfile))
+									archive.CreateEntryFromFile(dbfile, dbBackup);
 
-								archive.CreateEntryFromFile(diaryfile, diarybackup);
+								if (File.Exists(dbfile + "-journal"))
+									archive.CreateEntryFromFile(dbfile + "-journal", dbBackup + "-journal");
+
+								if (File.Exists(diaryfile))
+									archive.CreateEntryFromFile(diaryfile, diarybackup);
+
 								if (File.Exists(diaryfile + "-journal"))
-								{
 									archive.CreateEntryFromFile(diaryfile + "-journal", diarybackup + "-journal");
-								}
 
 								LogDebugMessage("Completed archive of the database");
 							}
@@ -12481,7 +12481,7 @@ namespace CumulusMX
 				var latestBuild = releases.Find(x => !x.draft && x.prerelease == beta);
 				var latestLive = releases.Find(x => !x.draft && !x.prerelease);
 				var cmxBuild = int.Parse(Build);
-
+				var veryLatest = Math.Max(int.Parse(latestBuild.tag_name[1..]), int.Parse(latestLive.tag_name[1..]));
 
 				if (latestLive == null)
 				{
@@ -12496,7 +12496,7 @@ namespace CumulusMX
 				}
 				else if (beta && int.Parse(latestLive.tag_name[1..]) > cmxBuild)
 				{
-					var msg = $"You are not running a beta version of Cumulus MX, and a later release build {latestLive.name} is available.";
+					var msg = $"You are running a beta version of Cumulus MX, and a later release build {latestLive.name} is available.";
 					LogConsoleMessage(msg, ConsoleColor.Cyan);
 					LogWarningMessage(msg);
 					UpgradeAlarm.LastMessage = $"Release build {latestLive.name} is available";
@@ -12517,7 +12517,7 @@ namespace CumulusMX
 				}
 				else if (int.Parse(latestBuild.tag_name[1..]) < cmxBuild)
 				{
-					LogWarningMessage($"This Cumulus MX instance appears to be running a test version. This build = {Build}, latest released build = {LatestBuild}");
+					LogWarningMessage($"This Cumulus MX instance appears to be running a test version. This build = {Build}, latest available build = {veryLatest}");
 				}
 			}
 			catch (Exception ex)

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -37,7 +37,7 @@
 
   <PropertyGroup>
     <ServerGarbageCollection>true</ServerGarbageCollection>
-    <Version>4.000.0.4017</Version>
+    <Version>4.000.0.4018</Version>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
   </PropertyGroup>
 

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -80,7 +80,7 @@
     <PackageReference Include="HidSharp" Version="2.1.0" />
     <PackageReference Include="MailKit" Version="4.4.0" />
     <PackageReference Include="MQTTnet" Version="4.3.3.952" />
-    <PackageReference Include="MySqlConnector" Version="2.3.5" />
+    <PackageReference Include="MySqlConnector" Version="2.3.6" />
     <PackageReference Include="ServiceStack.Text" Version="8.2.2" />
     <PackageReference Include="SSH.NET" Version="2024.0.0" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -519,8 +519,8 @@ namespace CumulusMX
 					int idxOfSensorWithMostRecs = 0;
 					for (var i = 0; i < histObj.sensors.Count; i++)
 					{
-						// Find the WLL baro, or internal temp/hum sensors
-						if (histObj.sensors[i].sensor_type == 242 && histObj.sensors[i].data_structure_type == 13)
+						// Find the WLL/WLC baro, oth use sensor type=242, WLL structure=13, WLC structure=20
+						if (histObj.sensors[i].sensor_type == 242 && (histObj.sensors[i].data_structure_type == 13 || histObj.sensors[i].data_structure_type == 20))
 						{
 							var recs = histObj.sensors[i].data.Count;
 							if (recs > noOfRecs)
@@ -2061,6 +2061,7 @@ namespace CumulusMX
 				{
 					case 3: // VP2 ISS archive revision A
 					case 4: // VP2 ISS archive revision B
+					case 7: // EnviroMonitor ISS Archive Record
 						{
 							var data = json.FromJsv<WlHistorySensorDataType3_4>();
 							lastRecordTime = Utils.FromUnixTime(data.ts);
@@ -2962,7 +2963,9 @@ namespace CumulusMX
 						break;
 
 					case 13: // WeatherLink Live Non-ISS data
-					case 26:
+					case 20: // WL console Baro
+					case 22: // WL console internal T/H
+					case 26: // WL console Soil/Leaf data
 						switch (sensorType)
 						{
 							case 56: // Soil + Leaf
@@ -3245,7 +3248,8 @@ namespace CumulusMX
 								}
 								break;
 
-							case 243: // Inside temp/hum
+							case 243: // WeatherLink Live Inside temp/hum
+							case 365: // WL console Inside temp/hum
 								/*
 								 * Available fields
 								 * "dew_point_in"

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -2334,7 +2334,7 @@ namespace CumulusMX
 
 		internal string[] GetStationList(bool CheckCamera, string macAddress, CancellationToken token)
 		{
-			cumulus.LogMessage("API.GetStationList: Get Ecowitt Station List");
+			cumulus.LogMessage("API.GetStationList: Get Ecowitt Station List - mac=" + macAddress);
 
 			if (string.IsNullOrEmpty(cumulus.EcowittApplicationKey) || string.IsNullOrEmpty(cumulus.EcowittUserApiKey))
 			{

--- a/CumulusMX/ExtraSensorSettings.cs
+++ b/CumulusMX/ExtraSensorSettings.cs
@@ -403,7 +403,7 @@ namespace CumulusMX
 					{
 						cumulus.EcowittApplicationKey = string.IsNullOrWhiteSpace(settings.httpSensors.ecowittapi.applicationkey) ? null : settings.httpSensors.ecowittapi.applicationkey.Trim();
 						cumulus.EcowittUserApiKey = string.IsNullOrWhiteSpace(settings.httpSensors.ecowittapi.userkey) ? null : settings.httpSensors.ecowittapi.userkey.Trim();
-						cumulus.EcowittMacAddress = string.IsNullOrWhiteSpace(settings.httpSensors.ecowittapi.mac) ? null : settings.httpSensors.ecowittapi.mac.Trim();
+						cumulus.EcowittMacAddress = string.IsNullOrWhiteSpace(settings.httpSensors.ecowittapi.mac) ? null : settings.httpSensors.ecowittapi.mac.Trim().ToUpper();
 					}
 				}
 				catch (Exception ex)

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -496,7 +496,7 @@ namespace CumulusMX
 						deviceFirmware = discoveredDevices.Name[0].Split('-')[1].Split(' ')[1];
 						if (discoveredDevices.Mac[0] != macaddr)
 						{
-							cumulus.Gw1000MacAddress = discoveredDevices.Mac[0];
+							cumulus.Gw1000MacAddress = discoveredDevices.Mac[0].ToUpper();
 						}
 						cumulus.WriteIniFile();
 					}

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -130,26 +130,45 @@ namespace CumulusMX
 			if (mainStation)
 			{
 				Task.Run(getAndProcessHistoryData);
-				var retVal = ecowittApi.GetStationList(true, cumulus.EcowittMacAddress, cumulus.cancellationToken);
-				if (retVal.Length == 2 && !retVal[1].StartsWith("EasyWeather"))
+
+				if (string.IsNullOrEmpty(cumulus.EcowittMacAddress))
 				{
-					deviceFirmware = new Version(retVal[0]);
-					deviceModel = retVal[1];
+					cumulus.LogMessage("No MAC/IMEI address is configured, skipping device model check");
+				}
+				else
+				{
+					var retVal = ecowittApi.GetStationList(true, cumulus.EcowittMacAddress, cumulus.cancellationToken);
+					if (retVal.Length == 2 && !retVal[1].StartsWith("EasyWeather") && !string.IsNullOrEmpty(retVal[0]))
+					{
+						deviceFirmware = new Version(retVal[0]);
+						deviceModel = retVal[1];
+					}
 				}
 			}
 			else
 			{
 				// see if we have a camera attached
-				var retVal = ecowittApi.GetStationList(cumulus.EcowittExtraUseCamera, cumulus.EcowittMacAddress, cumulus.cancellationToken);
-				if (retVal.Length == 2 && !retVal[1].StartsWith("EasyWeather"))
+				if (string.IsNullOrEmpty(cumulus.EcowittMacAddress))
 				{
-					deviceFirmware = new Version(retVal[0]);
-					deviceModel = retVal[1];
+					cumulus.LogMessage("No MAC/IMEI address is configured, skipping device model check");
+				}
+				else
+				{
+					var retVal = ecowittApi.GetStationList(cumulus.EcowittExtraUseCamera, cumulus.EcowittMacAddress, cumulus.cancellationToken);
+					if (retVal.Length == 2 && !retVal[1].StartsWith("EasyWeather") && !string.IsNullOrEmpty(retVal[0]))
+					{
+						deviceFirmware = new Version(retVal[0]);
+						deviceModel = retVal[1];
+					}
 				}
 				cumulus.LogMessage("Extra Sensors - HTTP Station (Ecowitt) - Waiting for data...");
 			}
 
-			if (!string.IsNullOrEmpty(deviceModel))
+			if (string.IsNullOrEmpty(deviceModel))
+			{
+				cumulus.LogMessage("No device model found, skipping firmware version check");
+			}
+			else
 			{
 				_= CheckAvailableFirmware(deviceModel);
 			}

--- a/CumulusMX/InternetSettings.cs
+++ b/CumulusMX/InternetSettings.cs
@@ -164,6 +164,7 @@ namespace CumulusMX
 						}
 
 						cumulus.WxnowComment = settings.websettings.interval.stdfiles.wxnowcomment;
+						cumulus.APRS.UseUtcInWxNowFile = settings.websettings.interval.stdfiles.wxnowutc;
 
 						for (var i = 0; i < cumulus.GraphDataFiles.Length; i++)
 						{
@@ -382,7 +383,8 @@ namespace CumulusMX
 			var websettingsintervalstd = new JsonInternetSettingsWebSettingsIntervalFiles()
 			{
 				files = new JsonInternetSettingsFileSettings[cumulus.StdWebFiles.Length],
-				wxnowcomment = cumulus.WxnowComment
+				wxnowcomment = cumulus.WxnowComment,
+				wxnowutc = cumulus.APRS.UseUtcInWxNowFile
 			};
 
 			var websettingsintervalgraph = new JsonInternetSettingsWebSettingsIntervalFiles()
@@ -766,6 +768,7 @@ namespace CumulusMX
 	{
 		public JsonInternetSettingsFileSettings[] files { get; set; }
 		public string wxnowcomment { get; set; }
+		public bool wxnowutc { get; set; }
 	}
 
 	public class JsonInternetSettingsWebSettingsRealtime

--- a/CumulusMX/Program.cs
+++ b/CumulusMX/Program.cs
@@ -362,9 +362,17 @@ namespace CumulusMX
 					txt = sr.ReadLine();
 
 				// Check the length, and ends in "="
-				if (txt.Length > 30 || txt[^1] == '=')
+				if (txt != null && (txt.Length > 30 || txt[^1] == '='))
 				{
 					InstanceId = Convert.FromBase64String(txt);
+					return true;
+				}
+
+				if (create && string.IsNullOrEmpty(txt))
+				{
+					// otherwise, create it with a newly generated id
+					InstanceId = Crypto.GenerateKey();
+					File.WriteAllText("UniqueId.txt", Convert.ToBase64String(InstanceId));
 					return true;
 				}
 			}

--- a/CumulusMX/Program.cs
+++ b/CumulusMX/Program.cs
@@ -214,7 +214,7 @@ namespace CumulusMX
 
 					}
 
-					if (SelfInstaller.InstallLinux(user, group, lang, Httpport, ))
+					if (SelfInstaller.InstallLinux(user, group, lang, Httpport, servicename))
 					{
 						Console.ForegroundColor = ConsoleColor.Green;
 						Console.WriteLine("\nCumulus MX is now installed to run as service\n");

--- a/CumulusMX/Program.cs
+++ b/CumulusMX/Program.cs
@@ -125,6 +125,7 @@ namespace CumulusMX
 			var user = string.Empty;
 			var group = string.Empty;
 			var lang = string.Empty;
+			var servicename = string.Empty;
 
 			for (int i = 0; i < args.Length; i++)
 			{
@@ -172,6 +173,9 @@ namespace CumulusMX
 						case "-service":
 							service = true;
 							break;
+						case "-servicename":
+							servicename = args[++i];
+							break;
 						default:
 							Console.WriteLine($"Invalid command line argument \"{args[i]}\"");
 							svcTextListener.WriteLine($"Invalid command line argument \"{args[i]}\"");
@@ -210,7 +214,7 @@ namespace CumulusMX
 
 					}
 
-					if (SelfInstaller.InstallLinux(user, group, lang, Httpport))
+					if (SelfInstaller.InstallLinux(user, group, lang, Httpport, ))
 					{
 						Console.ForegroundColor = ConsoleColor.Green;
 						Console.WriteLine("\nCumulus MX is now installed to run as service\n");
@@ -240,7 +244,7 @@ namespace CumulusMX
 				}
 				else
 				{
-					if (SelfInstaller.UninstallLinux())
+					if (SelfInstaller.UninstallLinux(servicename))
 					{
 						Console.ForegroundColor = ConsoleColor.Green;
 						Console.WriteLine("\nCumulus MX is no longer installed to run as service\n");

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -869,7 +869,7 @@ namespace CumulusMX
 					{
 						cumulus.Gw1000IpAddress = string.IsNullOrWhiteSpace(settings.gw1000.ipaddress) ? null : settings.gw1000.ipaddress.Trim();
 						cumulus.Gw1000AutoUpdateIpAddress = settings.gw1000.autoDiscover;
-						cumulus.Gw1000MacAddress = string.IsNullOrWhiteSpace(settings.gw1000.macaddress) ? null : settings.gw1000.macaddress.Trim();
+						cumulus.Gw1000MacAddress = string.IsNullOrWhiteSpace(settings.gw1000.macaddress) ? null : settings.gw1000.macaddress.Trim().ToUpper();
 					}
 				}
 				catch (Exception ex)
@@ -1122,7 +1122,7 @@ namespace CumulusMX
 						else
 						{
 							// For all others, there is no local MAC, so we have to define it in the API
-							cumulus.EcowittMacAddress = string.IsNullOrWhiteSpace(settings.ecowittapi.mac) ? null : settings.ecowittapi.mac.Trim();
+							cumulus.EcowittMacAddress = string.IsNullOrWhiteSpace(settings.ecowittapi.mac) ? null : settings.ecowittapi.mac.Trim().ToUpper();
 						}
 					}
 				}

--- a/CumulusMX/ThirdParty/WebUploadAprs.cs
+++ b/CumulusMX/ThirdParty/WebUploadAprs.cs
@@ -10,6 +10,7 @@ namespace CumulusMX.ThirdParty
 	internal class WebUploadAprs : WebUploadServiceBase
 	{
 		public bool HumidityCutoff;
+		public bool UseUtcInWxNowFile;
 
 		internal WebUploadAprs(Cumulus cumulus, string name) : base(cumulus, name)
 		{

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -4803,7 +4803,7 @@ namespace CumulusMX
 			// b10153 - barometric pressure in tenths of a millibar - 1015.3 millibars
 			// CommentString - free format information text
 
-			var timestamp = DateTime.Now.ToString(@"MMM dd yyyy HH\:mm");
+			var timestamp = cumulus.APRS.UseUtcInWxNowFile ? DateTime.Now.ToUniversalTime().ToString(@"MMM dd yyyy HH\:mm") : DateTime.Now.ToString(@"MMM dd yyyy HH\:mm");
 
 			int mphwind = Convert.ToInt32(ConvertUnits.UserWindToMPH(WindAverage));
 			int mphgust = Convert.ToInt32(ConvertUnits.UserWindToMPH(RecentMaxGust));

--- a/CumulusMX/Wizard.cs
+++ b/CumulusMX/Wizard.cs
@@ -560,7 +560,7 @@ namespace CumulusMX
 					{
 						cumulus.Gw1000IpAddress = string.IsNullOrWhiteSpace(settings.station.gw1000.ipaddress) ? string.Empty : settings.station.gw1000.ipaddress.Trim();
 						cumulus.Gw1000AutoUpdateIpAddress = settings.station.gw1000.autoDiscover;
-						cumulus.Gw1000MacAddress = string.IsNullOrWhiteSpace(settings.station.gw1000.macaddress) ? string.Empty : settings.station.gw1000.macaddress.Trim();
+						cumulus.Gw1000MacAddress = string.IsNullOrWhiteSpace(settings.station.gw1000.macaddress) ? string.Empty : settings.station.gw1000.macaddress.Trim().ToUpper();
 					}
 				}
 				catch (Exception ex)
@@ -664,7 +664,7 @@ namespace CumulusMX
 					{
 						cumulus.EcowittApplicationKey = string.IsNullOrWhiteSpace(settings.station.ecowittapi.applicationkey) ? null : settings.station.ecowittapi.applicationkey.Trim();
 						cumulus.EcowittUserApiKey = string.IsNullOrWhiteSpace(settings.station.ecowittapi.userkey) ? null : settings.station.ecowittapi.userkey.Trim();
-						cumulus.EcowittMacAddress = string.IsNullOrWhiteSpace(settings.station.ecowittapi.mac) ? null : settings.station.ecowittapi.mac.Trim();
+						cumulus.EcowittMacAddress = string.IsNullOrWhiteSpace(settings.station.ecowittapi.mac) ? null : settings.station.ecowittapi.mac.Trim().ToUpper();
 					}
 				}
 				catch (Exception ex)

--- a/Updates.txt
+++ b/Updates.txt
@@ -5,6 +5,7 @@
 - Change uniqueid.txt file handling to allow for zero length files
 - wxnow.txt file now has the option to force UTC timestamps
 - Fix WLL not binding to broadcast port in shared mode
+- Add optional parameter "-servicename xxxx" to Linux service -install and -uninstall, it defaults to "cumulusmx"
 
 
 4.0.0 - b4017

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,7 @@
+4.0.0 - b4018
+—————————————
+- Reworked GetVersion() to account for published beta builds
+
 4.0.0 - b4017
 —————————————
 - First public beta
@@ -11,7 +15,7 @@ New
 - Moon Image now supports transparent shadows
 - The -install/-unistall command line switches now support both Windows and Linux
 	- Under Linux run > sudo dotnet CumulusMX.dll -install -user <username> [-port <port_number>] [-lang <lang-code>]
-	- Windows install as a service now self elevates and requests UAC
+	- Windows install as a service now self-elevates and requests UAC
 - Implements encryption of the credentials in the cumulus.ini file
 - Experimental Gmail OATH 2.0 authentication
 - New web tag for the average temperature of the previous 24 hours from now: <#TempAvg24Hrs>
@@ -27,7 +31,7 @@ New
 
 Changed
 - Now requires Microsoft .Net 8.0 rather than mono to run under Linux and MacOS
-- All data files are now written/read as invariant - dayfile, monthly log files, extra log files, AirLink, and  custom log files
+- All data files are now written/read as invariant - dayfile, monthly log files, extra log files, AirLink, and custom log files
 	- NOTE: Custom log files may require the user to alter their configuration to use comma separators and add the rc=y parameter to numeric web tags
 - Monthly log files now renamed to "[yyyyMM]log.txt" to remove localised month name - and now sortable in the file system!
 - Added MigrateData3to4 utility.

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,8 @@
 4.0.0 - b4018
 —————————————
 - Reworked GetVersion() to account for published beta builds
+- Fix backup error on first start-up
+
 
 4.0.0 - b4017
 —————————————

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,6 +3,7 @@
 - Reworked GetVersion() to account for published beta builds
 - Fix backup error on first start-up
 - Change uniqueid.txt file handling to allow for zero length files
+- wxnow.txt file now has the option to force UTC timestamps
 
 
 4.0.0 - b4017

--- a/Updates.txt
+++ b/Updates.txt
@@ -4,6 +4,7 @@
 - Fix backup error on first start-up
 - Change uniqueid.txt file handling to allow for zero length files
 - wxnow.txt file now has the option to force UTC timestamps
+- Fix WLL not binding to broadcast port in shared mode
 
 
 4.0.0 - b4017

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,6 +6,7 @@
 - wxnow.txt file now has the option to force UTC timestamps
 - Fix WLL not binding to broadcast port in shared mode
 - Add optional parameter "-servicename xxxx" to Linux service -install and -uninstall, it defaults to "cumulusmx"
+- Fix error/crash in Ecowitt GetStationList() processing
 
 
 4.0.0 - b4017

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,6 +2,7 @@
 —————————————
 - Reworked GetVersion() to account for published beta builds
 - Fix backup error on first start-up
+- Change uniqueid.txt file handling to allow for zero length files
 
 
 4.0.0 - b4017

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,6 +7,7 @@
 - Fix WLL not binding to broadcast port in shared mode
 - Add optional parameter "-servicename xxxx" to Linux service -install and -uninstall, it defaults to "cumulusmx"
 - Fix error/crash in Ecowitt GetStationList() processing
+- Add Davis WeatherLink Console archive decodes for historic: baro, internal T/H, soil/leaf, enviro-monitor
 
 
 4.0.0 - b4017


### PR DESCRIPTION
- Reworked GetVersion() to account for published beta builds
- Fix backup error on first start-up
- Change uniqueid.txt file handling to allow for zero length files
- wxnow.txt file now has the option to force UTC timestamps
- Fix WLL not binding to broadcast port in shared mode
- Add optional parameter "-servicename xxxx" to Linux service -install and -uninstall, it defaults to "cumulusmx"
- Fix error/crash in Ecowitt GetStationList() processing
- Add Davis WeatherLink Console archive decodes for historic: baro, internal T/H, soil/leaf