### PR TITLE
v4.1.0

### DIFF
--- a/CumulusMX/Alarm.cs
+++ b/CumulusMX/Alarm.cs
@@ -47,6 +47,7 @@ namespace CumulusMX
 		public bool Email { get; set; }
 		public string Action { get; set; }
 		public string ActionParams { get; set; }
+		public bool ShowWindow { get; set; }
 		public bool Latch { get; set; }
 		public double LatchHours { get; set; }
 		public string EmailMsg { get; set; }
@@ -119,14 +120,18 @@ namespace CumulusMX
 						{
 							try
 							{
+								var args = string.Empty;
 								// Prepare the process to run
-								var parser = new TokenParser(cumulus.TokenParserOnToken)
+								if (!string.IsNullOrEmpty(ActionParams))
 								{
-									InputText = ActionParams
-								};
-								var args = parser.ToStringFromString();
+									var parser = new TokenParser(cumulus.TokenParserOnToken)
+									{
+										InputText = ActionParams
+									};
+									args = parser.ToStringFromString();
+								}
 								cumulus.LogMessage($"Alarm ({Name}): Starting external program: '{Action}', with parameters: {args}");
-								Utils.RunExternalTask(Action, args, false);
+								Utils.RunExternalTask(Action, args, false, false, ShowWindow);
 							}
 							catch (Exception ex)
 							{
@@ -289,14 +294,18 @@ namespace CumulusMX
 					{
 						try
 						{
+							var args = string.Empty;
 							// Prepare the process to run
-							var parser = new TokenParser(cumulus.TokenParserOnToken)
+							if (!string.IsNullOrEmpty(ActionParams))
 							{
-								InputText = ActionParams
-							};
-							var args = parser.ToStringFromString();
+								var parser = new TokenParser(cumulus.TokenParserOnToken)
+								{
+									InputText = ActionParams
+								};
+								args = parser.ToStringFromString();
+							}
 							cumulus.LogMessage($"Alarm ({NameUp}): Starting external program: '{Action}', with parameters: {args}");
-							Utils.RunExternalTask(Action, args, false);
+							Utils.RunExternalTask(Action, args, false, false, ShowWindow);
 						}
 						catch (Exception ex)
 						{
@@ -365,14 +374,18 @@ namespace CumulusMX
 					{
 						try
 						{
+							var args = string.Empty;
 							// Prepare the process to run
-							var parser = new TokenParser(cumulus.TokenParserOnToken)
+							if (!string.IsNullOrEmpty(ActionParams))
 							{
-								InputText = ActionParams
-							};
-							var args = parser.ToStringFromString();
+								var parser = new TokenParser(cumulus.TokenParserOnToken)
+								{
+									InputText = ActionParams
+								};
+								args = parser.ToStringFromString();
+							}
 							cumulus.LogMessage($"Alarm ({NameDown}): Starting external program: '{Action}', with parameters: {args}");
-							Utils.RunExternalTask(Action, args, false);
+							Utils.RunExternalTask(Action, args, false, false, ShowWindow);
 						}
 						catch (Exception ex)
 						{

--- a/CumulusMX/AlarmsUser.cs
+++ b/CumulusMX/AlarmsUser.cs
@@ -45,6 +45,7 @@ namespace CumulusMX
 		public bool Email { get; set; }
 		public string Action { get; set; }
 		public string ActionParams { get; set; }
+		public bool ShowWindow { get; set; }
 		public bool Latch { get; set; }
 		public double LatchHours { get; set; }
 		public string EmailMsg { get; set; }
@@ -155,14 +156,18 @@ namespace CumulusMX
 						{
 							try
 							{
+								var args = string.Empty;
 								// Prepare the process to run
-								var parser = new TokenParser(cumulus.TokenParserOnToken)
+								if (!string.IsNullOrEmpty(ActionParams))
 								{
-									InputText = ActionParams
-								};
-								var args = parser.ToStringFromString();
+									var parser = new TokenParser(cumulus.TokenParserOnToken)
+									{
+										InputText = ActionParams
+									};
+									args = parser.ToStringFromString();
+								}
 								cumulus.LogMessage($"User Alarm ({Name}): Starting external program: '{Action}', with parameters: {args}");
-								Utils.RunExternalTask(Action, args, false);
+								Utils.RunExternalTask(Action, args, false, false, ShowWindow);
 							}
 							catch (Exception ex)
 							{

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -39,6 +39,7 @@ namespace CumulusMX
 		internal static HttpStationEcowitt stationEcowittExtra { get; set; }
 		internal static HttpStationAmbient stationAmbient {  get; set; }
 		internal static HttpStationAmbient stationAmbientExtra {  get; set; }
+		internal static JsonStation stationJson { get; set; }
 		private static readonly char[] separator = [':'];
 
 
@@ -1458,6 +1459,17 @@ namespace CumulusMX
 							{
 								Response.StatusCode = 503;
 								await writer.WriteAsync("{\"Error\":\"HTTP Station (Ecowitt) is not running}\"");
+							}
+							break;
+						case "json":
+							if (stationJson != null)
+							{
+								await writer.WriteAsync(stationJson.GetDataFromApi(HttpContext, false));
+							}
+							else
+							{
+								Response.StatusCode = 503;
+								await writer.WriteAsync("{\"Error\":\"JSON Station is not running}\"");
 							}
 							break;
 						default:

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -1464,7 +1464,7 @@ namespace CumulusMX
 						case "json":
 							if (stationJson != null)
 							{
-								await writer.WriteAsync(stationJson.GetDataFromApi(HttpContext, false));
+								await writer.WriteAsync(stationJson.ReceiveDataFromApi(HttpContext, false));
 							}
 							else
 							{

--- a/CumulusMX/Api.cs
+++ b/CumulusMX/Api.cs
@@ -1518,6 +1518,28 @@ namespace CumulusMX
 								await writer.WriteAsync("HTTP Station (Ambient) is not running");
 							}
 							break;
+						case "ecowitt":
+							if (stationEcowitt != null)
+							{
+								await writer.WriteAsync(stationEcowitt.ProcessData(HttpContext, true));
+							}
+							else
+							{
+								Response.StatusCode = 503;
+								await writer.WriteAsync("{\"Error\":\"HTTP Station (Ecowitt) is not running}\"");
+							}
+							break;
+						case "ecowittextra":
+							if (stationEcowittExtra != null)
+							{
+								await writer.WriteAsync(stationEcowittExtra.ProcessData(HttpContext, false));
+							}
+							else
+							{
+								Response.StatusCode = 503;
+								await writer.WriteAsync("{\"Error\":\"HTTP Station (Ecowitt) is not running}\"");
+							}
+							break;
 						default:
 							Response.StatusCode = 404;
 							break;

--- a/CumulusMX/ConvertUnits.cs
+++ b/CumulusMX/ConvertUnits.cs
@@ -1,7 +1,13 @@
 ﻿namespace CumulusMX
 {
+
 	internal static class ConvertUnits
 	{
+		private const double inHg2hPa = 33.8638866667;
+		private const double inHg2kPa = 3.38638866667;
+		private const int kPa2hPa = 10;
+		private const double mm2in = 25.4;
+
 		/// <summary>
 		///  Convert temp supplied in C to units in use
 		/// </summary>
@@ -282,7 +288,7 @@
 		/// <returns>Rain in configured units</returns>
 		public static double RainMMToUser(double value)
 		{
-			return Program.cumulus.Units.Rain == 1 ? value * 0.0393700787 : value;
+			return Program.cumulus.Units.Rain == 1 ? value / mm2in : value;
 		}
 
 		/// <summary>
@@ -292,7 +298,7 @@
 		/// <returns>Rain in configured units</returns>
 		public static double RainINToUser(double value)
 		{
-			return Program.cumulus.Units.Rain == 1 ? value : value * 25.4;
+			return Program.cumulus.Units.Rain == 1 ? value : value * mm2in;
 		}
 
 		/// <summary>
@@ -302,12 +308,12 @@
 		/// <returns>Rain in mm</returns>
 		public static double UserRainToMM(double value)
 		{
-			return Program.cumulus.Units.Rain == 1 ? value / 0.0393700787 : value;
+			return Program.cumulus.Units.Rain == 1 ? value * mm2in : value;
 		}
 
 		public static double UserRainToIN(double rain)
 		{
-			return Program.cumulus.Units.Rain == 0 ? rain * 0.0393700787 : rain;
+			return Program.cumulus.Units.Rain == 0 ? rain / mm2in : rain;
 		}
 
 
@@ -318,7 +324,14 @@
 		/// <returns>pressure in configured units</returns>
 		public static double PressMBToUser(double value)
 		{
-			return Program.cumulus.Units.Press == 2 ? value * 0.0295333727 : value;
+			return Program.cumulus.Units.Press switch
+			{
+				0 => value,
+				1 => value,
+				2 => value / inHg2hPa,
+				3 => value / kPa2hPa,
+				_ => 0,
+			};
 		}
 
 		/// <summary>
@@ -328,7 +341,14 @@
 		/// <returns>pressure in configured units</returns>
 		public static double PressINHGToUser(double value)
 		{
-			return Program.cumulus.Units.Press == 2 ? value : value * 33.8638866667;
+			return Program.cumulus.Units.Press switch
+			{
+				0 => value * inHg2hPa,
+				1 => value * inHg2hPa,
+				2 => value,
+				3 => value * inHg2kPa,
+				_ => 0,
+			};
 		}
 
 		/// <summary>
@@ -338,7 +358,7 @@
 		/// <returns>pressure in hPa</returns>
 		public static double PressINHGToHpa(double value)
 		{
-			return value * 33.8638866667;
+			return value * inHg2hPa;
 		}
 
 		/// <summary>
@@ -348,7 +368,14 @@
 		/// <returns>pressure in mb</returns>
 		public static double UserPressToMB(double value)
 		{
-			return Program.cumulus.Units.Press == 2 ? value / 0.0295333727 : value;
+			return Program.cumulus.Units.Press switch
+			{
+				0 => value,
+				1 => value,
+				2 => value * inHg2hPa,
+				3 => value * kPa2hPa,
+				_ => 0,
+			};
 		}
 
 		/// <summary>
@@ -358,7 +385,31 @@
 		/// <returns></returns>
 		public static double UserPressToHpa(double value)
 		{
-			return Program.cumulus.Units.Press == 2 ? value / 0.0295333727 : value;
+			return Program.cumulus.Units.Press switch
+			{
+				0 => value,
+				1 => value,
+				2 => value * inHg2hPa,
+				3 => value * kPa2hPa,
+				_ => 0,
+			};
+		}
+
+		/// <summary>
+		/// Convert pressure from user units to kPa
+		/// </summary>
+		/// <param name="value"></param>
+		/// <returns></returns>
+		public static double UserPressToKpa(double value)
+		{
+			return Program.cumulus.Units.Press switch
+			{
+				0 => value / kPa2hPa,
+				1 => value / kPa2hPa,
+				2 => value * inHg2kPa,
+				3 => value,
+				_ => 0,
+			};
 		}
 
 		/// <summary>
@@ -368,7 +419,14 @@
 		/// <returns>pressure in mb</returns>
 		public static double UserPressToIN(double value)
 		{
-			return Program.cumulus.Units.Press == 2 ? value : value * 0.0295333727;
+			return Program.cumulus.Units.Press switch
+			{
+				0 => value / inHg2hPa,
+				1 => value / inHg2hPa,
+				2 => value,
+				3 => value / inHg2kPa,
+				_ => 0,
+			};
 		}
 
 		/// <summary>

--- a/CumulusMX/ConvertUnits.cs
+++ b/CumulusMX/ConvertUnits.cs
@@ -109,6 +109,23 @@
 		}
 
 		/// <summary>
+		///  Converts wind supplied in kph to user units
+		/// </summary>
+		/// <param name="value">Wind in kph</param>
+		/// <returns>Wind in configured units</returns>
+		public static double WindKPHToUser(double value)
+		{
+			return Program.cumulus.Units.Wind switch
+			{
+				0 => value * 0.2777778,
+				1 => value * 0.6213712,
+				2 => value,
+				3 => value * 0.5399568,
+				_ => 0,
+			};
+		}
+
+		/// <summary>
 		/// Converts wind in user units to m/s
 		/// </summary>
 		/// <param name="value"></param>

--- a/CumulusMX/ConvertUnits.cs
+++ b/CumulusMX/ConvertUnits.cs
@@ -335,6 +335,23 @@
 		}
 
 		/// <summary>
+		/// Convert pressure in kPa to units in use
+		/// </summary>
+		/// <param name="value">pressure in kPa</param>
+		/// <returns>pressure in configured units</returns>
+		public static double PressKPAToUser(double value)
+		{
+			return Program.cumulus.Units.Press switch
+			{
+				0 => value * kPa2hPa,
+				1 => value * kPa2hPa,
+				2 => value / inHg2kPa,
+				3 => value,
+				_ => 0,
+			};
+		}
+
+		/// <summary>
 		/// Convert pressure in inHg to units in use
 		/// </summary>
 		/// <param name="value">pressure in mb</param>

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1975,6 +1975,10 @@ namespace CumulusMX
 
 			if (isSet)
 			{
+				if (FtpLoggerRT == null || FtpLoggerIN == null || FtpLoggerMX == null)
+				{
+					SetupFtpLogging(true);
+				}
 				RealtimeFTP.Logger = new FtpLogAdapter(FtpLoggerRT);
 			}
 			else

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -12445,7 +12445,6 @@ namespace CumulusMX
 
 			if (FtpOptions.Enabled)
 			{
-				LogMessage($"RealtimeFTPLogin: Attempting realtime FTP connect to host {FtpOptions.Hostname} on port {FtpOptions.Port}");
 				try
 				{
 					if (FtpOptions.AutoDetect)
@@ -12470,14 +12469,6 @@ namespace CumulusMX
 					RealtimeFTP.Disconnect();
 				}
 			}
-
-			// OK we are reconnected or failed to connect, let the FTP recommence
-			RealtimeFtpReconnecting = false;
-			RealtimeFtpInProgress = false;
-			realtimeFTPRetries = 0;
-			RealtimeCopyInProgress = false;
-			FtpAlarm.Triggered = false;
-
 		}
 
 		private void RealtimeSSHLogin()

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -2605,7 +2605,7 @@ namespace CumulusMX
 
 						if (RealtimeFiles[i].LocalFileName == "realtimegauges.txt")
 						{
-							data = ProcessTemplateFile2String(RealtimeFiles[i].TemplateFileName, true, true);
+							data = await ProcessTemplateFile2StringAsync(RealtimeFiles[i].TemplateFileName, true, true);
 						}
 
 						using var dataStream = GenerateStreamFromString(data);
@@ -2734,7 +2734,7 @@ namespace CumulusMX
 					{
 #if DEBUG
 						LogDebugMessage($"RealtimePHP[{cycle}]: Extra File {uploadfile} waiting for semaphore [{uploadCountLimitSemaphoreSlim.CurrentCount}]");
-						uploadCountLimitSemaphoreSlim.Wait(cancellationToken);
+						await uploadCountLimitSemaphoreSlim.WaitAsync(cancellationToken);
 						LogDebugMessage($"RealtimePHP[{cycle}]: Extra File {uploadfile} has a semaphore [{uploadCountLimitSemaphoreSlim.CurrentCount}]");
 #else
 						uploadCountLimitSemaphoreSlim.Wait(cancellationToken);
@@ -2918,7 +2918,7 @@ namespace CumulusMX
 					else if (item.process) // does the file require processing first
 					{
 						LogDebugMessage($"Realtime[{cycle}]: Processing extra web {uploadfile}");
-						var data = ProcessTemplateFile2String(uploadfile, false, item.UTF8);
+						var data = await ProcessTemplateFile2StringAsync(uploadfile, false, item.UTF8);
 
 						using var strm = GenerateStreamFromString(data);
 						if (FtpOptions.FtpMode == FtpProtocols.SFTP)
@@ -8624,8 +8624,8 @@ namespace CumulusMX
 							if (item.process)
 							{
 								LogDebugMessage($"Interval: Processing extra file {uploadfile}");
-								var data = ProcessTemplateFile2String(uploadfile, false, item.UTF8);
-								File.WriteAllText(remotefile, data);
+								var data = await ProcessTemplateFile2StringAsync(uploadfile, false, item.UTF8);
+								await File.WriteAllTextAsync(remotefile, data);
 							}
 							else
 							{
@@ -9387,7 +9387,7 @@ namespace CumulusMX
 								else if (item.process)
 								{
 									LogFtpDebugMessage("SFTP[Int]: Processing Extra web file: " + uploadfile);
-									var data = ProcessTemplateFile2String(uploadfile, false, item.UTF8);
+									var data = await ProcessTemplateFile2StringAsync(uploadfile, false, item.UTF8);
 									using var strm = GenerateStreamFromString(data);
 									UploadStream(conn, remotefile, strm, -1);
 								}
@@ -9429,7 +9429,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										data = ProcessTemplateFile2String(StdWebFiles[i].TemplateFileName, true, true);
+										data = await ProcessTemplateFile2StringAsync(StdWebFiles[i].TemplateFileName, true, true);
 									}
 
 									using var dataStream = GenerateStreamFromString(data);
@@ -9721,7 +9721,7 @@ namespace CumulusMX
 								else if (item.process)
 								{
 									LogFtpDebugMessage("FTP[Int]: Processing Extra web file: " + uploadfile);
-									var data = ProcessTemplateFile2String(uploadfile, false, item.UTF8);
+									var data = await ProcessTemplateFile2StringAsync(uploadfile, false, item.UTF8);
 									using var strm = GenerateStreamFromString(data);
 									UploadStream(conn, remotefile, strm, -1);
 								}
@@ -9761,7 +9761,7 @@ namespace CumulusMX
 									}
 									else
 									{
-										data = ProcessTemplateFile2String(StdWebFiles[i].TemplateFileName, true, true);
+										data = await ProcessTemplateFile2StringAsync(StdWebFiles[i].TemplateFileName, true, true);
 									}
 
 									using (var dataStream = GenerateStreamFromString(data))
@@ -10056,7 +10056,7 @@ namespace CumulusMX
 					{
 #if DEBUG
 						LogDebugMessage($"PHP[Int]: Extra file: {uploadfile} waiting for semaphore [{uploadCountLimitSemaphoreSlim.CurrentCount}]");
-						uploadCountLimitSemaphoreSlim.Wait(cancellationToken);
+						await uploadCountLimitSemaphoreSlim.WaitAsync(cancellationToken);
 						LogDebugMessage($"PHP[Int]: Extra file: {uploadfile} has a semaphore [{uploadCountLimitSemaphoreSlim.CurrentCount}]");
 #else
 						uploadCountLimitSemaphoreSlim.Wait(cancellationToken);
@@ -11127,17 +11127,17 @@ namespace CumulusMX
 							if (FtpOptions.PhpCompression == "gzip")
 							{
 								using var zipped = new System.IO.Compression.GZipStream(ms, System.IO.Compression.CompressionMode.Compress, true);
-								zipped.Write(byteData, 0, byteData.Length);
+								await zipped.WriteAsync(byteData, 0, byteData.Length);
 							}
 							else if (FtpOptions.PhpCompression == "deflate")
 							{
 								using var zipped = new System.IO.Compression.DeflateStream(ms, System.IO.Compression.CompressionMode.Compress, true);
-								zipped.Write(byteData, 0, byteData.Length);
+								await zipped.WriteAsync(byteData, 0, byteData.Length);
 							}
 
 							ms.Position = 0;
 							byte[] compressed = new byte[ms.Length];
-							ms.Read(compressed, 0, compressed.Length);
+							await ms.ReadAsync(compressed, 0, compressed.Length);
 
 							outStream = new MemoryStream(compressed);
 							streamContent = new StreamContent(outStream);
@@ -11246,7 +11246,7 @@ namespace CumulusMX
 				finally
 				{
 					if (outStream != null)
-						outStream.Dispose();
+						await outStream.DisposeAsync();
 
 					if (streamContent != null)
 						streamContent.Dispose();
@@ -12312,7 +12312,7 @@ namespace CumulusMX
 
 		public async Task CheckMySQLFailedUploads(string callingFunction, string cmd)
 		{
-			await CheckMySQLFailedUploads(callingFunction, new List<string>() { cmd });
+			await CheckMySQLFailedUploads(callingFunction, [cmd]);
 		}
 
 		public async Task CheckMySQLFailedUploads(string callingFunction, List<string> cmds)

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -1885,6 +1885,10 @@ namespace CumulusMX
 					Units.PressText = "in";
 					Units.PressTrendText = "in/hr";
 					break;
+				case 3:
+					Units.PressText = "kPa";
+					Units.PressTrendText = "kPa/hr";
+					break;
 			}
 
 			switch (Units.Wind)
@@ -1946,8 +1950,14 @@ namespace CumulusMX
 		{
 			SetupUnitText();
 
-			FCPressureThreshold = Units.Press == 2 ? 0.00295333727 : 0.1;
-
+			FCPressureThreshold = Units.Press switch
+			{
+				0 => 0.1,
+				1 => 0.1,
+				2 => 0.00295333727,
+				3 => 0.01,
+				_ => 0
+			};
 			PressChangeAlarm.Units = Units.PressTrendText;
 			HighPressAlarm.Units = Units.PressText;
 			LowPressAlarm.Units = Units.PressText;
@@ -3697,7 +3707,7 @@ namespace CumulusMX
 
 
 			Units.Wind = ini.GetValue("Station", "WindUnit", 2, 0, 3);
-			Units.Press = ini.GetValue("Station", "PressureUnit", 1, 0, 2);
+			Units.Press = ini.GetValue("Station", "PressureUnit", 1, 0, 3);
 
 			Units.Rain = ini.GetValue("Station", "RainUnit", 0, 0, 1);
 			Units.Temp = ini.GetValue("Station", "TempUnit", 0, 0 , 1);
@@ -3861,7 +3871,14 @@ namespace CumulusMX
 
 			if (FCPressureThreshold < 0)
 			{
-				FCPressureThreshold = Units.Press == 2 ? 0.00295333727 : 0.1;
+				FCPressureThreshold = Units.Press switch
+				{
+					0 => 0.1,
+					1 => 0.1,
+					2 => 0.00295333727,
+					3 => 0.01,
+					_ => 0
+				};
 			}
 
 			WMR928TempChannel = ini.GetValue("Station", "WMR928TempChannel", 0, 0);
@@ -7144,7 +7161,7 @@ namespace CumulusMX
 
 		public int[] WindDPlaceDefaults { get; } = [1, 0, 0, 0]; // m/s, mph, km/h, knots
 		public int[] TempDPlaceDefaults { get; } = [1, 1];
-		public int[] PressDPlaceDefaults { get; } = [1, 1, 2];
+		public int[] PressDPlaceDefaults { get; } = [1, 1, 2, 2];
 		public int[] RainDPlaceDefaults { get; } = [1, 2];
 		public const int numextrafiles = 99;
 		public const int numOfSelectaChartSeries = 6;
@@ -13325,7 +13342,7 @@ namespace CumulusMX
 	{
 		/// <value> 0=m/s, 1=mph, 2=km/h, 3=knots</value>
 		public int Wind { get; set; }
-		/// <value> 0=mb, 1=hPa, 2=inHg </value>
+		/// <value> 0=mb, 1=hPa, 2=inHg, 3=kPa</value>
 		public int Press { get; set; }
 		/// <value> 0=mm, 1=in </value>
 		public int Rain { get; set; }

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4507,6 +4507,7 @@ namespace CumulusMX
 			LowTempAlarm.LatchHours = ini.GetValue("Alarms", "LowTempAlarmLatchHours", 24.0, 0.0);
 			LowTempAlarm.Action = ini.GetValue("Alarms", "LowTempAlarmAction", string.Empty);
 			LowTempAlarm.ActionParams = ini.GetValue("Alarms", "LowTempAlarmActionParams", string.Empty);
+			LowTempAlarm.ShowWindow = ini.GetValue("Alarms", "LowTempAlarmActionWindow", false);
 
 			HighTempAlarm.Value = ini.GetValue("Alarms", "alarmhightemp", 0.0);
 			HighTempAlarm.Enabled = ini.GetValue("Alarms", "HighTempAlarmSet", false);
@@ -4523,6 +4524,7 @@ namespace CumulusMX
 			HighTempAlarm.LatchHours = ini.GetValue("Alarms", "HighTempAlarmLatchHours", 24.0, 0.0);
 			HighTempAlarm.Action = ini.GetValue("Alarms", "HighTempAlarmAction", string.Empty);
 			HighTempAlarm.ActionParams = ini.GetValue("Alarms", "HighTempAlarmActionParams", string.Empty);
+			HighTempAlarm.ShowWindow = ini.GetValue("Alarms", "HighTempAlarmActionWindow", false);
 
 			TempChangeAlarm.Value = ini.GetValue("Alarms", "alarmtempchange", 0.0);
 			TempChangeAlarm.Enabled = ini.GetValue("Alarms", "TempChangeAlarmSet", false);
@@ -4539,6 +4541,7 @@ namespace CumulusMX
 			TempChangeAlarm.LatchHours = ini.GetValue("Alarms", "TempChangeAlarmLatchHours", 24.0, 0.0);
 			TempChangeAlarm.Action = ini.GetValue("Alarms", "TempChangeAlarmAction", string.Empty);
 			TempChangeAlarm.ActionParams = ini.GetValue("Alarms", "TempChangeAlarmActionParams", string.Empty);
+			TempChangeAlarm.ShowWindow = ini.GetValue("Alarms", "TempChangeAlarmActionWindow", false);
 
 			LowPressAlarm.Value = ini.GetValue("Alarms", "alarmlowpress", 0.0);
 			LowPressAlarm.Enabled = ini.GetValue("Alarms", "LowPressAlarmSet", false);
@@ -4555,6 +4558,7 @@ namespace CumulusMX
 			LowPressAlarm.LatchHours = ini.GetValue("Alarms", "LowPressAlarmLatchHours", 24.0, 0.0);
 			LowPressAlarm.Action = ini.GetValue("Alarms", "LowPressAlarmAction", string.Empty);
 			LowPressAlarm.ActionParams = ini.GetValue("Alarms", "LowPressAlarmActionParams", string.Empty);
+			LowPressAlarm.ShowWindow = ini.GetValue("Alarms", "LowPressAlarmActionWindow", false);
 
 			HighPressAlarm.Value = ini.GetValue("Alarms", "alarmhighpress", 0.0, 0.0);
 			HighPressAlarm.Enabled = ini.GetValue("Alarms", "HighPressAlarmSet", false);
@@ -4571,6 +4575,7 @@ namespace CumulusMX
 			HighPressAlarm.LatchHours = ini.GetValue("Alarms", "HighPressAlarmLatchHours", 24.0, 0.0);
 			HighPressAlarm.Action = ini.GetValue("Alarms", "HighPressAlarmAction", string.Empty);
 			HighPressAlarm.ActionParams = ini.GetValue("Alarms", "HighPressAlarmActionParams", string.Empty);
+			HighPressAlarm.ShowWindow = ini.GetValue("Alarms", "HighPressAlarmAlarmActionWindow", false);
 
 			PressChangeAlarm.Value = ini.GetValue("Alarms", "alarmpresschange", 0.0, 0.0);
 			PressChangeAlarm.Enabled = ini.GetValue("Alarms", "PressChangeAlarmSet", false);
@@ -4587,6 +4592,7 @@ namespace CumulusMX
 			PressChangeAlarm.LatchHours = ini.GetValue("Alarms", "PressChangeAlarmLatchHours", 24.0, 0.0);
 			PressChangeAlarm.Action = ini.GetValue("Alarms", "PressChangeAlarmAction", string.Empty);
 			PressChangeAlarm.ActionParams = ini.GetValue("Alarms", "PressChangeAlarmActionParams", string.Empty);
+			PressChangeAlarm.ShowWindow = ini.GetValue("Alarms", "PressChangeAlarmActionWindow", false);
 
 			HighRainTodayAlarm.Value = ini.GetValue("Alarms", "alarmhighraintoday", 0.0, 0.0);
 			HighRainTodayAlarm.Enabled = ini.GetValue("Alarms", "HighRainTodayAlarmSet", false);
@@ -4603,6 +4609,7 @@ namespace CumulusMX
 			HighRainTodayAlarm.LatchHours = ini.GetValue("Alarms", "HighRainTodayAlarmLatchHours", 24.0, 0.0);
 			HighRainTodayAlarm.Action = ini.GetValue("Alarms", "HighRainTodayAlarmAction", string.Empty);
 			HighRainTodayAlarm.ActionParams = ini.GetValue("Alarms", "HighRainTodayAlarmActionParams", string.Empty);
+			HighRainTodayAlarm.ShowWindow = ini.GetValue("Alarms", "HighRainTodayAlarmActionWindow", false);
 
 			HighRainRateAlarm.Value = ini.GetValue("Alarms", "alarmhighrainrate", 0.0, 0.0);
 			HighRainRateAlarm.Enabled = ini.GetValue("Alarms", "HighRainRateAlarmSet", false);
@@ -4619,6 +4626,7 @@ namespace CumulusMX
 			HighRainRateAlarm.LatchHours = ini.GetValue("Alarms", "HighRainRateAlarmLatchHours", 24.0, 0.0);
 			HighRainRateAlarm.Action = ini.GetValue("Alarms", "HighRainRateAlarmAction", string.Empty);
 			HighRainRateAlarm.ActionParams = ini.GetValue("Alarms", "HighRainRateAlarmActionParams", string.Empty);
+			HighRainRateAlarm.ShowWindow = ini.GetValue("Alarms", "HighRainRateAlarmActionWindow", false);
 
 			IsRainingAlarm.Enabled = ini.GetValue("Alarms", "IsRainingAlarmSet", false);
 			IsRainingAlarm.Sound = ini.GetValue("Alarms", "IsRainingAlarmSound", false);
@@ -4629,6 +4637,7 @@ namespace CumulusMX
 			IsRainingAlarm.LatchHours = ini.GetValue("Alarms", "IsRainingAlarmLatchHours", 1.0, 0.0);
 			IsRainingAlarm.Action = ini.GetValue("Alarms", "IsRainingAlarmAction", string.Empty);
 			IsRainingAlarm.ActionParams = ini.GetValue("Alarms", "IsRainingAlarmActionParams", string.Empty);
+			IsRainingAlarm.ShowWindow = ini.GetValue("Alarms", "IsRainingAlarmActionWindow", false);
 
 			HighGustAlarm.Value = ini.GetValue("Alarms", "alarmhighgust", 0.0, 0.0);
 			HighGustAlarm.Enabled = ini.GetValue("Alarms", "HighGustAlarmSet", false);
@@ -4645,6 +4654,7 @@ namespace CumulusMX
 			HighGustAlarm.LatchHours = ini.GetValue("Alarms", "HighGustAlarmLatchHours", 24.0, 0.0);
 			HighGustAlarm.Action = ini.GetValue("Alarms", "HighGustAlarmAction", string.Empty);
 			HighGustAlarm.ActionParams = ini.GetValue("Alarms", "HighGustAlarmActionParams", string.Empty);
+			HighGustAlarm.ShowWindow = ini.GetValue("Alarms", "HighGustActionWindow", false);
 
 			HighWindAlarm.Value = ini.GetValue("Alarms", "alarmhighwind", 0.0, 0.0);
 			HighWindAlarm.Enabled = ini.GetValue("Alarms", "HighWindAlarmSet", false);
@@ -4661,6 +4671,7 @@ namespace CumulusMX
 			HighWindAlarm.LatchHours = ini.GetValue("Alarms", "HighWindAlarmLatchHours", 24.0, 0.0);
 			HighWindAlarm.Action = ini.GetValue("Alarms", "HighWindAlarmAction", string.Empty);
 			HighWindAlarm.ActionParams = ini.GetValue("Alarms", "HighWindAlarmActionParams", string.Empty);
+			HighWindAlarm.ShowWindow = ini.GetValue("Alarms", "HighWindAlarmActionWindow", false);
 
 			SensorAlarm.Enabled = ini.GetValue("Alarms", "SensorAlarmSet", true);
 			SensorAlarm.Sound = ini.GetValue("Alarms", "SensorAlarmSound", false);
@@ -4677,6 +4688,7 @@ namespace CumulusMX
 			SensorAlarm.TriggerThreshold = ini.GetValue("Alarms", "SensorAlarmTriggerCount", 2, 0);
 			SensorAlarm.Action = ini.GetValue("Alarms", "SensorAlarmAction", string.Empty);
 			SensorAlarm.ActionParams = ini.GetValue("Alarms", "SensorAlarmActionParams", string.Empty);
+			SensorAlarm.ShowWindow = ini.GetValue("Alarms", "SensorAlarmActionWindow", false);
 
 			DataStoppedAlarm.Enabled = ini.GetValue("Alarms", "DataStoppedAlarmSet", true);
 			DataStoppedAlarm.Sound = ini.GetValue("Alarms", "DataStoppedAlarmSound", false);
@@ -4693,6 +4705,7 @@ namespace CumulusMX
 			DataStoppedAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataStoppedAlarmTriggerCount", 2, 0);
 			DataStoppedAlarm.Action = ini.GetValue("Alarms", "DataStoppedAlarmAction", string.Empty);
 			DataStoppedAlarm.ActionParams = ini.GetValue("Alarms", "DataStoppedAlarmActionParams", string.Empty);
+			DataStoppedAlarm.ShowWindow = ini.GetValue("Alarms", "DataStoppedAlarmActionWindow", false);
 
 			// Alarms below here were created after the change in default sound file, so no check required
 			BatteryLowAlarm.Enabled = ini.GetValue("Alarms", "BatteryLowAlarmSet", false);
@@ -4705,6 +4718,7 @@ namespace CumulusMX
 			BatteryLowAlarm.TriggerThreshold = ini.GetValue("Alarms", "BatteryLowAlarmTriggerCount", 1, 0);
 			BatteryLowAlarm.Action = ini.GetValue("Alarms", "BatteryLowAlarmAction", string.Empty);
 			BatteryLowAlarm.ActionParams = ini.GetValue("Alarms", "BatteryLowAlarmActionParams", string.Empty);
+			BatteryLowAlarm.ShowWindow = ini.GetValue("Alarms", "BatteryLowAlarmActionWindow", false);
 
 			SpikeAlarm.Enabled = ini.GetValue("Alarms", "DataSpikeAlarmSet", false);
 			SpikeAlarm.Sound = ini.GetValue("Alarms", "DataSpikeAlarmSound", false);
@@ -4716,6 +4730,7 @@ namespace CumulusMX
 			SpikeAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataSpikeAlarmTriggerCount", 1, 0);
 			SpikeAlarm.Action = ini.GetValue("Alarms", "DataSpikeAlarmAction", string.Empty);
 			SpikeAlarm.ActionParams = ini.GetValue("Alarms", "DataSpikeAlarmActionParams", string.Empty);
+			SpikeAlarm.ShowWindow = ini.GetValue("Alarms", "DataSpikeAlarmActionWindow", false);
 
 			UpgradeAlarm.Enabled = ini.GetValue("Alarms", "UpgradeAlarmSet", true);
 			UpgradeAlarm.Sound = ini.GetValue("Alarms", "UpgradeAlarmSound", false);
@@ -4726,6 +4741,7 @@ namespace CumulusMX
 			UpgradeAlarm.LatchHours = ini.GetValue("Alarms", "UpgradeAlarmLatchHours", 24.0, 0.0);
 			UpgradeAlarm.Action = ini.GetValue("Alarms", "UpgradeAlarmAction", string.Empty);
 			UpgradeAlarm.ActionParams = ini.GetValue("Alarms", "UpgradeAlarmActionParams", string.Empty);
+			UpgradeAlarm.ShowWindow = ini.GetValue("Alarms", "UpgradeAlarmActionWindow", false);
 
 			FirmwareAlarm.Enabled = ini.GetValue("Alarms", "FirmwareAlarmSet", true);
 			FirmwareAlarm.Sound = ini.GetValue("Alarms", "FirmwareAlarmSound", false);
@@ -4736,6 +4752,7 @@ namespace CumulusMX
 			FirmwareAlarm.LatchHours = ini.GetValue("Alarms", "FirmwareAlarmLatchHours", 24.0, 0.0);
 			FirmwareAlarm.Action = ini.GetValue("Alarms", "FirmwareAlarmAction", string.Empty);
 			FirmwareAlarm.ActionParams = ini.GetValue("Alarms", "FirmwareAlarmActionParams", string.Empty);
+			FirmwareAlarm.ShowWindow = ini.GetValue("Alarms", "FirmwareAlarmActionWindow", false);
 
 			ThirdPartyAlarm.Enabled = ini.GetValue("Alarms", "HttpUploadAlarmSet", false);
 			ThirdPartyAlarm.Sound = ini.GetValue("Alarms", "HttpUploadAlarmSound", false);
@@ -4747,6 +4764,7 @@ namespace CumulusMX
 			ThirdPartyAlarm.TriggerThreshold = ini.GetValue("Alarms", "HttpUploadAlarmTriggerCount", 1, 0);
 			ThirdPartyAlarm.Action = ini.GetValue("Alarms", "HttpUploadAlarmAction", string.Empty);
 			ThirdPartyAlarm.ActionParams = ini.GetValue("Alarms", "HttpUploadAlarmActionParams", string.Empty);
+			ThirdPartyAlarm.ShowWindow = ini.GetValue("Alarms", "HttpUploadAlarmActionWindow", false);
 
 			MySqlUploadAlarm.Enabled = ini.GetValue("Alarms", "MySqlUploadAlarmSet", false);
 			MySqlUploadAlarm.Sound = ini.GetValue("Alarms", "MySqlUploadAlarmSound", false);
@@ -4768,6 +4786,7 @@ namespace CumulusMX
 			NewRecordAlarm.LatchHours = ini.GetValue("Alarms", "NewRecordAlarmLatchHours", 24.0, 0.0);
 			NewRecordAlarm.Action = ini.GetValue("Alarms", "NewRecordAlarmAction", string.Empty);
 			NewRecordAlarm.ActionParams = ini.GetValue("Alarms", "NewRecordAlarmActionParams", string.Empty);
+			NewRecordAlarm.ShowWindow = ini.GetValue("Alarms", "NewRecordAlarmActionWindow", false);
 
 			FtpAlarm.Enabled = ini.GetValue("Alarms", "FtpAlarmSet", false);
 			FtpAlarm.Sound = ini.GetValue("Alarms", "FtpAlarmSound", false);
@@ -4778,6 +4797,7 @@ namespace CumulusMX
 			FtpAlarm.LatchHours = ini.GetValue("Alarms", "FtpAlarmLatchHours", 24.0, 0.0);
 			FtpAlarm.Action = ini.GetValue("Alarms", "FtpAlarmAction", string.Empty);
 			FtpAlarm.ActionParams = ini.GetValue("Alarms", "FtpAlarmActionParams", string.Empty);
+			FtpAlarm.ShowWindow = ini.GetValue("Alarms", "FtpAlarmActionWindow", false);
 
 			AlarmFromEmail = ini.GetValue("Alarms", "FromEmail", string.Empty);
 			AlarmDestEmail = ini.GetValue("Alarms", "DestEmail", string.Empty).Split(';');
@@ -4800,6 +4820,7 @@ namespace CumulusMX
 					var latchHours = ini.GetValue("UserAlarms", "AlarmLatchHours" + i, 24.0, 0.0);
 					var action = ini.GetValue("UserAlarms", "AlarmAction" + i, string.Empty);
 					var actionParams = ini.GetValue("UserAlarms", "AlarmActionParams" + i, string.Empty);
+					var showWindow = ini.GetValue("UserAlarms", "AlarmActionWindow" + i, false);
 
 					if (name != string.Empty && tag != string.Empty && type != string.Empty)
 					{
@@ -4814,7 +4835,8 @@ namespace CumulusMX
 								Latch = latch,
 								LatchHours = latchHours,
 								Action = action,
-								ActionParams = actionParams
+								ActionParams = actionParams,
+								ShowWindow = showWindow
 							});
 						}
 						catch (Exception ex)

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -12926,6 +12926,7 @@ namespace CumulusMX
 					LogWarningMessage(msg);
 					UpgradeAlarm.LastMessage = $"Release build {latestLive.name} is available";
 					UpgradeAlarm.Triggered = true;
+					LatestBuild = latestLive.tag_name[1..];
 				}
 				else if (int.Parse(latestBuild.tag_name[1..]) > cmxBuild)
 				{
@@ -12934,15 +12935,18 @@ namespace CumulusMX
 					LogWarningMessage(msg);
 					UpgradeAlarm.LastMessage = $"{(beta ? "Beta" : "Release")} build {latestBuild.name} is available";
 					UpgradeAlarm.Triggered = true;
+					LatestBuild = latestBuild.tag_name[1..];
 				}
 				else if (int.Parse(latestBuild.tag_name[1..]) == cmxBuild)
 				{
 					LogMessage($"This Cumulus MX instance is running the latest {(beta ? "beta" : "release")} version");
 					UpgradeAlarm.Triggered = false;
+					LatestBuild = latestBuild.tag_name[1..];
 				}
 				else if (int.Parse(latestBuild.tag_name[1..]) < cmxBuild)
 				{
 					LogWarningMessage($"This Cumulus MX instance appears to be running a test version. This build={Build}, latest available build={veryLatest}");
+					LatestBuild = veryLatest.ToString();
 				}
 			}
 			catch (Exception ex)

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3498,7 +3498,7 @@ namespace CumulusMX
 			IniFile ini = new IniFile("Cumulus.ini");
 
 			// check for Cumulus 1 [FTP Site] and correct it
-			if (ini.GetValue("FTP Site", "Port", -999) != -999 && File.Exists("Cumulus.ini"))
+			if (ini.ValueExists("FTP Site", "Port"))
 			{
 				var contents = File.ReadAllText("Cumulus.ini");
 				contents = contents.Replace("[FTP Site]", "[FTP site]");
@@ -3510,9 +3510,9 @@ namespace CumulusMX
 
 			ProgramOptions.StartupPingHost = ini.GetValue("Program", "StartupPingHost", string.Empty);
 
-			ProgramOptions.StartupPingEscapeTime = ini.GetValue("Program", "StartupPingEscapeTime", 999);
-			ProgramOptions.StartupDelaySecs = ini.GetValue("Program", "StartupDelaySecs", 0);
-			ProgramOptions.StartupDelayMaxUptime = ini.GetValue("Program", "StartupDelayMaxUptime", 300);
+			ProgramOptions.StartupPingEscapeTime = ini.GetValue("Program", "StartupPingEscapeTime", 999, 0);
+			ProgramOptions.StartupDelaySecs = ini.GetValue("Program", "StartupDelaySecs", 0, 0);
+			ProgramOptions.StartupDelayMaxUptime = ini.GetValue("Program", "StartupDelayMaxUptime", 300, 0);
 
 			ProgramOptions.StartupTask = ini.GetValue("Program", "StartupTask", string.Empty);
 			ProgramOptions.StartupTaskParams = ini.GetValue("Program", "StartupTaskParams", string.Empty);
@@ -3522,7 +3522,7 @@ namespace CumulusMX
 			ProgramOptions.ShutdownTaskParams = ini.GetValue("Program", "ShutdownTaskParams", string.Empty);
 
 			ProgramOptions.DataStoppedExit = ini.GetValue("Program", "DataStoppedExit", false);
-			ProgramOptions.DataStoppedMins = ini.GetValue("Program", "DataStoppedMins", 10);
+			ProgramOptions.DataStoppedMins = ini.GetValue("Program", "DataStoppedMins", 10, 0);
 			ProgramOptions.Culture.RemoveSpaceFromDateSeparator = ini.GetValue("Culture", "RemoveSpaceFromDateSeparator", false);
 			// if the culture names match, then we apply the new date separator if change is enabled and it contains a space
 			if (ProgramOptions.Culture.RemoveSpaceFromDateSeparator && CultureInfo.CurrentCulture.DateTimeFormat.DateSeparator.Contains(' '))
@@ -3584,15 +3584,15 @@ namespace CumulusMX
 			DavisOptions.UseLoop2 = ini.GetValue("Station", "UseDavisLoop2", true);
 			DavisOptions.ReadReceptionStats = ini.GetValue("Station", "DavisReadReceptionStats", true);
 			DavisOptions.SetLoggerInterval = ini.GetValue("Station", "DavisSetLoggerInterval", false);
-			DavisOptions.InitWaitTime = ini.GetValue("Station", "DavisInitWaitTime", 2000);
-			DavisOptions.IPResponseTime = ini.GetValue("Station", "DavisIPResponseTime", 500);
+			DavisOptions.InitWaitTime = ini.GetValue("Station", "DavisInitWaitTime", 2000, 0);
+			DavisOptions.IPResponseTime = ini.GetValue("Station", "DavisIPResponseTime", 500, 0);
 			DavisOptions.IncrementPressureDP = ini.GetValue("Station", "DavisIncrementPressureDP", false);
 			if (StationType == StationTypes.VantagePro && DavisOptions.UseLoop2)
 			{
 				DavisOptions.UseLoop2 = false;
 				rewriteRequired = true;
 			}
-			DavisOptions.BaudRate = ini.GetValue("Station", "DavisBaudRate", 19200);
+			DavisOptions.BaudRate = ini.GetValue("Station", "DavisBaudRate", 19200, 1200, 19200);
 			// Check we have a valid value
 			if (!DavisBaudRates.Contains(DavisOptions.BaudRate))
 			{
@@ -3608,16 +3608,16 @@ namespace CumulusMX
 				DavisOptions.RainGaugeType = -1;
 				rewriteRequired = true;
 			}
-			DavisOptions.ConnectionType = ini.GetValue("Station", "VP2ConnectionType", 0);
-			DavisOptions.TCPPort = ini.GetValue("Station", "VP2TCPPort", 22222);
+			DavisOptions.ConnectionType = ini.GetValue("Station", "VP2ConnectionType", 0, 0, 1);
+			DavisOptions.TCPPort = ini.GetValue("Station", "VP2TCPPort", 22222, 1, 65535);
 			DavisOptions.IPAddr = ini.GetValue("Station", "VP2IPAddr", "0.0.0.0");
 
 			WeatherFlowOptions.WFDeviceId = ini.GetValue("Station", "WeatherFlowDeviceId", 0);
-			WeatherFlowOptions.WFTcpPort = ini.GetValue("Station", "WeatherFlowTcpPort", 50222);
+			WeatherFlowOptions.WFTcpPort = ini.GetValue("Station", "WeatherFlowTcpPort", 50222, 1, 65535);
 			WeatherFlowOptions.WFToken = ini.GetValue("Station", "WeatherFlowToken", "api token");
-			WeatherFlowOptions.WFDaysHist = ini.GetValue("Station", "WeatherFlowDaysHist", 0);
+			WeatherFlowOptions.WFDaysHist = ini.GetValue("Station", "WeatherFlowDaysHist", 0, 0);
 
-			DavisOptions.PeriodicDisconnectInterval = ini.GetValue("Station", "VP2PeriodicDisconnectInterval", 0);
+			DavisOptions.PeriodicDisconnectInterval = ini.GetValue("Station", "VP2PeriodicDisconnectInterval", 0, 0);
 
 			Latitude = ini.GetValue("Station", "Latitude", (decimal) 0.0);
 			if (Latitude > 90 || Latitude < -90)
@@ -3648,52 +3648,21 @@ namespace CumulusMX
 			StationOptions.CalcuateAverageWindSpeed = ini.GetValue("Station", "Wind10MinAverage", false);
 			StationOptions.UseSpeedForAvgCalc = ini.GetValue("Station", "UseSpeedForAvgCalc", false);
 			StationOptions.UseSpeedForLatest = ini.GetValue("Station", "UseSpeedForLatest", false);
-			StationOptions.UseRainForIsRaining = ini.GetValue("Station", "UseRainForIsRaining", 1);  // 0=station, 1=rain sensor, 2=haptic sensor
+			StationOptions.UseRainForIsRaining = ini.GetValue("Station", "UseRainForIsRaining", 1, 0, 2);  // 0=station, 1=rain sensor, 2=haptic sensor
 			StationOptions.LeafWetnessIsRainingIdx = ini.GetValue("Station", "LeafWetnessIsRainingIdx", -1);
-			StationOptions.LeafWetnessIsRainingThrsh = ini.GetValue("Station", "LeafWetnessIsRainingVal", 0.0);
+			StationOptions.LeafWetnessIsRainingThrsh = ini.GetValue("Station", "LeafWetnessIsRainingVal", 0.0, 0);
 
-			StationOptions.AvgBearingMinutes = ini.GetValue("Station", "AvgBearingMinutes", 10);
-			if (StationOptions.AvgBearingMinutes > 120)
-			{
-				StationOptions.AvgBearingMinutes = 120;
-				rewriteRequired = true;
-			}
-			if (StationOptions.AvgBearingMinutes == 0)
-			{
-				StationOptions.AvgBearingMinutes = 1;
-				rewriteRequired = true;
-			}
+			StationOptions.AvgBearingMinutes = ini.GetValue("Station", "AvgBearingMinutes", 10, 1, 120);
 
 			AvgBearingTime = new TimeSpan(StationOptions.AvgBearingMinutes / 60, StationOptions.AvgBearingMinutes % 60, 0);
 
-			StationOptions.AvgSpeedMinutes = ini.GetValue("Station", "AvgSpeedMinutes", 10);
-			if (StationOptions.AvgSpeedMinutes > 120)
-			{
-				StationOptions.AvgSpeedMinutes = 120;
-				rewriteRequired = true;
-			}
-			if (StationOptions.AvgSpeedMinutes == 0)
-			{
-				StationOptions.AvgSpeedMinutes = 1;
-				rewriteRequired = true;
-			}
+			StationOptions.AvgSpeedMinutes = ini.GetValue("Station", "AvgSpeedMinutes", 10, 1, 120);
 
 			AvgSpeedTime = new TimeSpan(StationOptions.AvgSpeedMinutes / 60, StationOptions.AvgSpeedMinutes % 60, 0);
 
 			LogMessage("AvgSpdMins=" + StationOptions.AvgSpeedMinutes + " AvgSpdTime=" + AvgSpeedTime.ToString());
 
-			StationOptions.PeakGustMinutes = ini.GetValue("Station", "PeakGustMinutes", 10);
-			if (StationOptions.PeakGustMinutes > 120)
-			{
-				StationOptions.PeakGustMinutes = 120;
-				rewriteRequired = true;
-			}
-
-			if (StationOptions.PeakGustMinutes == 0)
-			{
-				StationOptions.PeakGustMinutes = 1;
-				rewriteRequired = true;
-			}
+			StationOptions.PeakGustMinutes = ini.GetValue("Station", "PeakGustMinutes", 10, 1, 120);
 
 			PeakGustTime = new TimeSpan(StationOptions.PeakGustMinutes / 60, StationOptions.PeakGustMinutes % 60, 0);
 
@@ -3710,36 +3679,31 @@ namespace CumulusMX
 			//RestartIfUnplugged = ini.GetValue("Station", "RestartIfUnplugged", false)
 			//RestartIfDataStops = ini.GetValue("Station", "RestartIfDataStops", false)
 			StationOptions.SyncTime = ini.GetValue("Station", "SyncDavisClock", false);
-			StationOptions.ClockSettingHour = ini.GetValue("Station", "ClockSettingHour", 4);
+			StationOptions.ClockSettingHour = ini.GetValue("Station", "ClockSettingHour", 4, 0, 23);
 			StationOptions.WS2300IgnoreStationClock = ini.GetValue("Station", "WS2300IgnoreStationClock", false);
 			StationOptions.LogExtraSensors = ini.GetValue("Station", "LogExtraSensors", false);
 			ReportDataStoppedErrors = ini.GetValue("Station", "ReportDataStoppedErrors", true);
 			ReportLostSensorContact = ini.GetValue("Station", "ReportLostSensorContact", true);
 			ErrorLogSpikeRemoval = ini.GetValue("Station", "ErrorLogSpikeRemoval", true);
-			DataLogInterval = ini.GetValue("Station", "DataLogInterval", 2);
 			// this is now an index
-			if (DataLogInterval > 5)
-			{
-				DataLogInterval = 2;
-				rewriteRequired = true;
-			}
-
+			DataLogInterval = ini.GetValue("Station", "DataLogInterval", 2, 0, 5);
+#
 			FineOffsetOptions.SyncReads = ini.GetValue("Station", "SyncFOReads", true);
-			FineOffsetOptions.ReadAvoidPeriod = ini.GetValue("Station", "FOReadAvoidPeriod", 3);
-			FineOffsetOptions.ReadTime = ini.GetValue("Station", "FineOffsetReadTime", 150);
+			FineOffsetOptions.ReadAvoidPeriod = ini.GetValue("Station", "FOReadAvoidPeriod", 3, 0);
+			FineOffsetOptions.ReadTime = ini.GetValue("Station", "FineOffsetReadTime", 150, 0);
 			FineOffsetOptions.SetLoggerInterval = ini.GetValue("Station", "FineOffsetSetLoggerInterval", false);
-			FineOffsetOptions.VendorID = ini.GetValue("Station", "VendorID", -1);
-			FineOffsetOptions.ProductID = ini.GetValue("Station", "ProductID", -1);
+			FineOffsetOptions.VendorID = ini.GetValue("Station", "VendorID", -1, -1);
+			FineOffsetOptions.ProductID = ini.GetValue("Station", "ProductID", -1, -1);
 
 
-			Units.Wind = ini.GetValue("Station", "WindUnit", 2);
-			Units.Press = ini.GetValue("Station", "PressureUnit", 1);
+			Units.Wind = ini.GetValue("Station", "WindUnit", 2, 0, 3);
+			Units.Press = ini.GetValue("Station", "PressureUnit", 1, 0, 2);
 
-			Units.Rain = ini.GetValue("Station", "RainUnit", 0);
-			Units.Temp = ini.GetValue("Station", "TempUnit", 0);
+			Units.Rain = ini.GetValue("Station", "RainUnit", 0, 0, 1);
+			Units.Temp = ini.GetValue("Station", "TempUnit", 0, 0 , 1);
 
 			StationOptions.RoundWindSpeed = ini.GetValue("Station", "RoundWindSpeed", false);
-			StationOptions.PrimaryAqSensor = ini.GetValue("Station", "PrimaryAqSensor", -1);
+			StationOptions.PrimaryAqSensor = ini.GetValue("Station", "PrimaryAqSensor", -1, -1);
 
 
 			// Unit decimals
@@ -3751,15 +3715,15 @@ namespace CumulusMX
 			AirQualityDPlaces = 1;
 
 			// Unit decimal overrides
-			WindDPlaces = ini.GetValue("Station", "WindSpeedDecimals", WindDPlaces);
-			WindAvgDPlaces = ini.GetValue("Station", "WindSpeedAvgDecimals", WindAvgDPlaces);
-			WindRunDPlaces = ini.GetValue("Station", "WindRunDecimals", WindRunDPlaces);
-			SunshineDPlaces = ini.GetValue("Station", "SunshineHrsDecimals", 1);
-			PressDPlaces = ini.GetValue("Station", "PressDecimals", PressDPlaces);
-			RainDPlaces = ini.GetValue("Station", "RainDecimals", RainDPlaces);
-			TempDPlaces = ini.GetValue("Station", "TempDecimals", TempDPlaces);
-			UVDPlaces = ini.GetValue("Station", "UVDecimals", UVDPlaces);
-			AirQualityDPlaces = ini.GetValue("Station", "AirQualityDecimals", AirQualityDPlaces);
+			WindDPlaces = ini.GetValue("Station", "WindSpeedDecimals", WindDPlaces, 0);
+			WindAvgDPlaces = ini.GetValue("Station", "WindSpeedAvgDecimals", WindAvgDPlaces, 0);
+			WindRunDPlaces = ini.GetValue("Station", "WindRunDecimals", WindRunDPlaces, 0);
+			SunshineDPlaces = ini.GetValue("Station", "SunshineHrsDecimals", 1, 0);
+			PressDPlaces = ini.GetValue("Station", "PressDecimals", PressDPlaces, 0);
+			RainDPlaces = ini.GetValue("Station", "RainDecimals", RainDPlaces, 0);
+			TempDPlaces = ini.GetValue("Station", "TempDecimals", TempDPlaces, 0);
+			UVDPlaces = ini.GetValue("Station", "UVDecimals", UVDPlaces, 0);
+			AirQualityDPlaces = ini.GetValue("Station", "AirQualityDecimals", AirQualityDPlaces, 0);
 
 			if ((StationType == StationTypes.VantagePro || StationType == StationTypes.VantagePro2) && DavisOptions.IncrementPressureDP)
 			{
@@ -3770,10 +3734,10 @@ namespace CumulusMX
 			LocationName = ini.GetValue("Station", "LocName", string.Empty);
 			LocationDesc = ini.GetValue("Station", "LocDesc", string.Empty);
 
-			YTDrain = ini.GetValue("Station", "YTDrain", 0.0);
-			YTDrainyear = ini.GetValue("Station", "YTDrainyear", 0);
+			YTDrain = ini.GetValue("Station", "YTDrain", 0.0, 0.0);
+			YTDrainyear = ini.GetValue("Station", "YTDrainyear", 0, 0);
 
-			EwOptions.Interval = ini.GetValue("Station", "EWInterval", 1.0);
+			EwOptions.Interval = ini.GetValue("Station", "EWInterval", 1.0, 0.01);
 			EwOptions.Filename = ini.GetValue("Station", "EWFile", string.Empty);
 			EwOptions.MinPressMB = ini.GetValue("Station", "EWminpressureMB", 900);
 			EwOptions.MaxPressMB = ini.GetValue("Station", "EWmaxpressureMB", 1200);
@@ -3841,10 +3805,10 @@ namespace CumulusMX
 
 			LogMessage($"Cumulus start date Parsed: {RecordsBeganDateTime:yyyy-MM-dd}");
 
-			ImetOptions.WaitTime = ini.GetValue("Station", "ImetWaitTime", 500);
-			ImetOptions.ReadDelay = ini.GetValue("Station", "ImetReadDelay", 500);
+			ImetOptions.WaitTime = ini.GetValue("Station", "ImetWaitTime", 500, 0);
+			ImetOptions.ReadDelay = ini.GetValue("Station", "ImetReadDelay", 500, 0);
 			ImetOptions.UpdateLogPointer = ini.GetValue("Station", "ImetUpdateLogPointer", true);
-			ImetOptions.BaudRate = ini.GetValue("Station", "ImetBaudRate", 19200);
+			ImetOptions.BaudRate = ini.GetValue("Station", "ImetBaudRate", 19200, 19200, 115200);
 			// Check we have a valid value
 			if (!ImetOptions.BaudRates.Contains(ImetOptions.BaudRate))
 			{
@@ -3859,31 +3823,21 @@ namespace CumulusMX
 			HourlyForecast = ini.GetValue("Station", "HourlyForecast", false);
 			StationOptions.UseCumulusPresstrendstr = ini.GetValue("Station", "UseCumulusPresstrendstr", false);
 			//UseWindChillCutoff = ini.GetValue("Station", "UseWindChillCutoff", false)
-			RecordSetTimeoutHrs = ini.GetValue("Station", "RecordSetTimeoutHrs", 24);
+			RecordSetTimeoutHrs = ini.GetValue("Station", "RecordSetTimeoutHrs", 24, 0);
 
-			SnowDepthHour = ini.GetValue("Station", "SnowDepthHour", 0);
+			SnowDepthHour = ini.GetValue("Station", "SnowDepthHour", 0, 0, 23);
 
 			StationOptions.UseZeroBearing = ini.GetValue("Station", "UseZeroBearing", false);
 
-			RainDayThreshold = ini.GetValue("Station", "RainDayThreshold", -1.0);
+			RainDayThreshold = ini.GetValue("Station", "RainDayThreshold", -1.0, -1.0);
 
 			FCpressinMB = ini.GetValue("Station", "FCpressinMB", true);
 			FClowpress = ini.GetValue("Station", "FClowpress", DEFAULTFCLOWPRESS);
 			FChighpress = ini.GetValue("Station", "FChighpress", DEFAULTFCHIGHPRESS);
-			FCPressureThreshold = ini.GetValue("Station", "FCPressureThreshold", -1.0);
+			FCPressureThreshold = ini.GetValue("Station", "FCPressureThreshold", -1.0, -1.0);
 
-			RainSeasonStart = ini.GetValue("Station", "RainSeasonStart", 1);
-			if (RainSeasonStart < 1 || RainSeasonStart > 12)
-			{
-				RainSeasonStart = 1;
-				rewriteRequired = true;
-			}
-			ChillHourSeasonStart = ini.GetValue("Station", "ChillHourSeasonStart", Latitude >= 0 ? 10 : 4);
-			if (ChillHourSeasonStart < 1 || ChillHourSeasonStart > 12)
-			{
-				ChillHourSeasonStart = 1;
-				rewriteRequired = true;
-			}
+			RainSeasonStart = ini.GetValue("Station", "RainSeasonStart", 1, 1, 12);
+			ChillHourSeasonStart = ini.GetValue("Station", "ChillHourSeasonStart", Latitude >= 0 ? 10 : 4, 1, 12);
 			ChillHourThreshold = ini.GetValue("Station", "ChillHourThreshold", -999.0);
 			if (ChillHourThreshold < -998)
 			{
@@ -3894,14 +3848,14 @@ namespace CumulusMX
 			RG11Enabled = ini.GetValue("Station", "RG11Enabled", false);
 			RG11Port = ini.GetValue("Station", "RG11portName", DefaultComportName);
 			RG11TBRmode = ini.GetValue("Station", "RG11TBRmode", false);
-			RG11tipsize = ini.GetValue("Station", "RG11tipsize", 0.0);
+			RG11tipsize = ini.GetValue("Station", "RG11tipsize", 0.0, 0.0);
 			RG11IgnoreFirst = ini.GetValue("Station", "RG11IgnoreFirst", false);
 			RG11DTRmode = ini.GetValue("Station", "RG11DTRmode", true);
 
 			RG11Enabled2 = ini.GetValue("Station", "RG11Enabled2", false);
 			RG11Port2 = ini.GetValue("Station", "RG11port2Name", DefaultComportName);
 			RG11TBRmode2 = ini.GetValue("Station", "RG11TBRmode2", false);
-			RG11tipsize2 = ini.GetValue("Station", "RG11tipsize2", 0.0);
+			RG11tipsize2 = ini.GetValue("Station", "RG11tipsize2", 0.0, 0.0);
 			RG11IgnoreFirst2 = ini.GetValue("Station", "RG11IgnoreFirst2", false);
 			RG11DTRmode2 = ini.GetValue("Station", "RG11DTRmode2", true);
 
@@ -3910,48 +3864,48 @@ namespace CumulusMX
 				FCPressureThreshold = Units.Press == 2 ? 0.00295333727 : 0.1;
 			}
 
-			WMR928TempChannel = ini.GetValue("Station", "WMR928TempChannel", 0);
-			WMR200TempChannel = ini.GetValue("Station", "WMR200TempChannel", 1);
+			WMR928TempChannel = ini.GetValue("Station", "WMR928TempChannel", 0, 0);
+			WMR200TempChannel = ini.GetValue("Station", "WMR200TempChannel", 1, 0);
 
 			WxnowComment = ini.GetValue("Station", "WxnowComment.txt", string.Empty);
 
 			// WeatherLink Live device settings
 			WllApiKey = ini.GetValue("WLL", "WLv2ApiKey", string.Empty);
 			WllApiSecret = ini.GetValue("WLL", "WLv2ApiSecret", string.Empty);
-			WllStationId = ini.GetValue("WLL", "WLStationId", -1);
+			WllStationId = ini.GetValue("WLL", "WLStationId", -1, -1);
 			WllTriggerDataStoppedOnBroadcast = ini.GetValue("WLL", "DataStoppedOnBroadcast", true);
 			WLLAutoUpdateIpAddress = ini.GetValue("WLL", "AutoUpdateIpAddress", true);
 			WllBroadcastDuration = ini.GetValue("WLL", "BroadcastDuration", WllBroadcastDuration);
 			WllBroadcastPort = ini.GetValue("WLL", "BroadcastPort", WllBroadcastPort);
-			WllPrimaryRain = ini.GetValue("WLL", "PrimaryRainTxId", 1);
-			WllPrimaryTempHum = ini.GetValue("WLL", "PrimaryTempHumTxId", 1);
-			WllPrimaryWind = ini.GetValue("WLL", "PrimaryWindTxId", 1);
-			WllPrimaryRain = ini.GetValue("WLL", "PrimaryRainTxId", 1);
-			WllPrimarySolar = ini.GetValue("WLL", "PrimarySolarTxId", 0);
-			WllPrimaryUV = ini.GetValue("WLL", "PrimaryUvTxId", 0);
-			WllExtraSoilTempTx1 = ini.GetValue("WLL", "ExtraSoilTempTxId1", 0);
-			WllExtraSoilTempIdx1 = ini.GetValue("WLL", "ExtraSoilTempIdx1", 1);
-			WllExtraSoilTempTx2 = ini.GetValue("WLL", "ExtraSoilTempTxId2", 0);
-			WllExtraSoilTempIdx2 = ini.GetValue("WLL", "ExtraSoilTempIdx2", 2);
-			WllExtraSoilTempTx3 = ini.GetValue("WLL", "ExtraSoilTempTxId3", 0);
-			WllExtraSoilTempIdx3 = ini.GetValue("WLL", "ExtraSoilTempIdx3", 3);
-			WllExtraSoilTempTx4 = ini.GetValue("WLL", "ExtraSoilTempTxId4", 0);
-			WllExtraSoilTempIdx4 = ini.GetValue("WLL", "ExtraSoilTempIdx4", 4);
-			WllExtraSoilMoistureTx1 = ini.GetValue("WLL", "ExtraSoilMoistureTxId1", 0);
-			WllExtraSoilMoistureIdx1 = ini.GetValue("WLL", "ExtraSoilMoistureIdx1", 1);
-			WllExtraSoilMoistureTx2 = ini.GetValue("WLL", "ExtraSoilMoistureTxId2", 0);
-			WllExtraSoilMoistureIdx2 = ini.GetValue("WLL", "ExtraSoilMoistureIdx2", 2);
-			WllExtraSoilMoistureTx3 = ini.GetValue("WLL", "ExtraSoilMoistureTxId3", 0);
-			WllExtraSoilMoistureIdx3 = ini.GetValue("WLL", "ExtraSoilMoistureIdx3", 3);
-			WllExtraSoilMoistureTx4 = ini.GetValue("WLL", "ExtraSoilMoistureTxId4", 0);
-			WllExtraSoilMoistureIdx4 = ini.GetValue("WLL", "ExtraSoilMoistureIdx4", 4);
-			WllExtraLeafTx1 = ini.GetValue("WLL", "ExtraLeafTxId1", 0);
-			WllExtraLeafIdx1 = ini.GetValue("WLL", "ExtraLeafIdx1", 1);
-			WllExtraLeafTx2 = ini.GetValue("WLL", "ExtraLeafTxId2", 0);
-			WllExtraLeafIdx2 = ini.GetValue("WLL", "ExtraLeafIdx2", 2);
+			WllPrimaryRain = ini.GetValue("WLL", "PrimaryRainTxId", 1, 1, 8);
+			WllPrimaryTempHum = ini.GetValue("WLL", "PrimaryTempHumTxId", 1, 1, 8);
+			WllPrimaryWind = ini.GetValue("WLL", "PrimaryWindTxId", 1, 1, 8);
+			WllPrimaryRain = ini.GetValue("WLL", "PrimaryRainTxId", 1, 1, 8);
+			WllPrimarySolar = ini.GetValue("WLL", "PrimarySolarTxId", 0, 0, 8);
+			WllPrimaryUV = ini.GetValue("WLL", "PrimaryUvTxId", 0, 0, 8);
+			WllExtraSoilTempTx1 = ini.GetValue("WLL", "ExtraSoilTempTxId1", 0, 0, 8);
+			WllExtraSoilTempIdx1 = ini.GetValue("WLL", "ExtraSoilTempIdx1", 1, 1, 4);
+			WllExtraSoilTempTx2 = ini.GetValue("WLL", "ExtraSoilTempTxId2", 0, 0, 8);
+			WllExtraSoilTempIdx2 = ini.GetValue("WLL", "ExtraSoilTempIdx2", 2, 1, 4);
+			WllExtraSoilTempTx3 = ini.GetValue("WLL", "ExtraSoilTempTxId3", 0, 0, 8);
+			WllExtraSoilTempIdx3 = ini.GetValue("WLL", "ExtraSoilTempIdx3", 3, 1, 4);
+			WllExtraSoilTempTx4 = ini.GetValue("WLL", "ExtraSoilTempTxId4", 0, 0, 8);
+			WllExtraSoilTempIdx4 = ini.GetValue("WLL", "ExtraSoilTempIdx4", 4, 1, 4);
+			WllExtraSoilMoistureTx1 = ini.GetValue("WLL", "ExtraSoilMoistureTxId1", 0, 0, 8);
+			WllExtraSoilMoistureIdx1 = ini.GetValue("WLL", "ExtraSoilMoistureIdx1", 1, 1, 4);
+			WllExtraSoilMoistureTx2 = ini.GetValue("WLL", "ExtraSoilMoistureTxId2", 0, 0, 8);
+			WllExtraSoilMoistureIdx2 = ini.GetValue("WLL", "ExtraSoilMoistureIdx2", 2, 1, 4);
+			WllExtraSoilMoistureTx3 = ini.GetValue("WLL", "ExtraSoilMoistureTxId3", 0, 0, 8);
+			WllExtraSoilMoistureIdx3 = ini.GetValue("WLL", "ExtraSoilMoistureIdx3", 3, 1, 4);
+			WllExtraSoilMoistureTx4 = ini.GetValue("WLL", "ExtraSoilMoistureTxId4", 0, 0, 8);
+			WllExtraSoilMoistureIdx4 = ini.GetValue("WLL", "ExtraSoilMoistureIdx4", 4, 1, 4);
+			WllExtraLeafTx1 = ini.GetValue("WLL", "ExtraLeafTxId1", 0, 0, 8);
+			WllExtraLeafIdx1 = ini.GetValue("WLL", "ExtraLeafIdx1", 1, 1, 2);
+			WllExtraLeafTx2 = ini.GetValue("WLL", "ExtraLeafTxId2", 0, 0, 8);
+			WllExtraLeafIdx2 = ini.GetValue("WLL", "ExtraLeafIdx2", 2, 1, 2);
 			for (int i = 1; i <= 8; i++)
 			{
-				WllExtraTempTx[i] = ini.GetValue("WLL", "ExtraTempTxId" + i, 0);
+				WllExtraTempTx[i] = ini.GetValue("WLL", "ExtraTempTxId" + i, 0, 0, 8);
 				WllExtraHumTx[i] = ini.GetValue("WLL", "ExtraHumOnTxId" + i, false);
 			}
 
@@ -3959,8 +3913,8 @@ namespace CumulusMX
 			Gw1000IpAddress = ini.GetValue("GW1000", "IPAddress", "0.0.0.0");
 			Gw1000MacAddress = ini.GetValue("GW1000", "MACAddress", string.Empty).ToUpper();
 			Gw1000AutoUpdateIpAddress = ini.GetValue("GW1000", "AutoUpdateIpAddress", true);
-			Gw1000PrimaryTHSensor = ini.GetValue("GW1000", "PrimaryTHSensor", 0);  // 0=default, 1-8=extra t/h sensor number, 99=use indoor sensor
-			Gw1000PrimaryRainSensor = ini.GetValue("GW1000", "PrimaryRainSensor", 0); //0=main station (tipping bucket) 1=piezo
+			Gw1000PrimaryTHSensor = ini.GetValue("GW1000", "PrimaryTHSensor", 0, 0, 99);  // 0=default, 1-8=extra t/h sensor number, 99=use indoor sensor
+			Gw1000PrimaryRainSensor = ini.GetValue("GW1000", "PrimaryRainSensor", 0, 0, 1); //0=main station (tipping bucket) 1=piezo
 			EcowittExtraEnabled = ini.GetValue("GW1000", "ExtraSensorDataEnabled", false);
 			EcowittCloudExtraEnabled = ini.GetValue("GW1000", "ExtraCloudSensorDataEnabled", false);
 			EcowittExtraUseSolar = ini.GetValue("GW1000", "ExtraSensorUseSolar", true);
@@ -3979,12 +3933,12 @@ namespace CumulusMX
 			EcowittGatewayAddr = ini.GetValue("GW1000", "EcowittGwAddr", "0.0.0.0");
 			var localIp = Utils.GetIpWithDefaultGateway();
 			EcowittLocalAddr = ini.GetValue("GW1000", "EcowittLocalAddr", localIp.ToString());
-			EcowittCustomInterval = ini.GetValue("GW1000", "EcowittCustomInterval", 16);
+			EcowittCustomInterval = ini.GetValue("GW1000", "EcowittCustomInterval", 16, 1);
 
 			EcowittExtraSetCustomServer = ini.GetValue("GW1000", "ExtraSetCustomServer", false);
 			EcowittExtraGatewayAddr = ini.GetValue("GW1000", "EcowittExtraGwAddr", "0.0.0.0");
 			EcowittExtraLocalAddr = ini.GetValue("GW1000", "EcowittExtraLocalAddr", localIp.ToString());
-			EcowittExtraCustomInterval = ini.GetValue("GW1000", "EcowittExtraCustomInterval", 16);
+			EcowittExtraCustomInterval = ini.GetValue("GW1000", "EcowittExtraCustomInterval", 16, 1);
 			// api
 			EcowittApplicationKey = ini.GetValue("GW1000", "EcowittAppKey", string.Empty);
 			EcowittUserApiKey = ini.GetValue("GW1000", "EcowittUserKey", string.Empty);
@@ -4040,7 +3994,7 @@ namespace CumulusMX
 			AirLinkAutoUpdateIpAddress = ini.GetValue("AirLink", "AutoUpdateIpAddress", true);
 			AirLinkInEnabled = ini.GetValue("AirLink", "In-Enabled", false);
 			AirLinkInIPAddr = ini.GetValue("AirLink", "In-IPAddress", "0.0.0.0");
-			AirLinkInStationId = ini.GetValue("AirLink", "In-WLStationId", -1);
+			AirLinkInStationId = ini.GetValue("AirLink", "In-WLStationId", -1, -1);
 			if (AirLinkInStationId == -1 && AirLinkIsNode)
 			{
 				AirLinkInStationId = WllStationId;
@@ -4050,7 +4004,7 @@ namespace CumulusMX
 
 			AirLinkOutEnabled = ini.GetValue("AirLink", "Out-Enabled", false);
 			AirLinkOutIPAddr = ini.GetValue("AirLink", "Out-IPAddress", "0.0.0.0");
-			AirLinkOutStationId = ini.GetValue("AirLink", "Out-WLStationId", -1);
+			AirLinkOutStationId = ini.GetValue("AirLink", "Out-WLStationId", -1, -1);
 			if (AirLinkOutStationId == -1 && AirLinkIsNode)
 			{
 				AirLinkOutStationId = WllStationId;
@@ -4062,11 +4016,11 @@ namespace CumulusMX
 
 			FtpOptions.Enabled = ini.GetValue("FTP site", "Enabled", true);
 			FtpOptions.Hostname = ini.GetValue("FTP site", "Host", string.Empty);
-			FtpOptions.Port = ini.GetValue("FTP site", "Port", 21);
+			FtpOptions.Port = ini.GetValue("FTP site", "Port", 21, 1, 65535);
 			FtpOptions.Username = ini.GetValue("FTP site", "Username", string.Empty);
 			FtpOptions.Password = ini.GetValue("FTP site", "Password", string.Empty);
 			FtpOptions.Directory = ini.GetValue("FTP site", "Directory", string.Empty);
-			FtpOptions.FtpMode = (FtpProtocols) ini.GetValue("FTP site", "Sslftp", 0);
+			FtpOptions.FtpMode = (FtpProtocols) ini.GetValue("FTP site", "Sslftp", 0, 0, 3);
 			if (FtpOptions.Enabled && FtpOptions.Hostname == string.Empty && FtpOptions.FtpMode != FtpProtocols.PHP)
 			{
 				FtpOptions.Enabled = false;
@@ -4117,7 +4071,7 @@ namespace CumulusMX
 			if (FtpOptions.PhpSecret == string.Empty)
 				FtpOptions.PhpSecret = Guid.NewGuid().ToString();
 			FtpOptions.PhpIgnoreCertErrors = ini.GetValue("FTP site", "PHP-IgnoreCertErrors", false);
-			FtpOptions.MaxConcurrentUploads = ini.GetValue("FTP site", "MaxConcurrentUploads", 2);
+			FtpOptions.MaxConcurrentUploads = ini.GetValue("FTP site", "MaxConcurrentUploads", 2, 1);
 			FtpOptions.PhpUseGet = ini.GetValue("FTP site", "PHP-UseGet", true);
 
 			if (FtpOptions.Enabled && FtpOptions.PhpUrl == string.Empty && FtpOptions.FtpMode == FtpProtocols.PHP)
@@ -4137,12 +4091,7 @@ namespace CumulusMX
 			RealtimeFiles[1].FTP = ini.GetValue("FTP site", "RealtimeGaugesTxtFTP", false);
 			RealtimeFiles[1].Copy = ini.GetValue("FTP site", "RealtimeGaugesTxtCopy", false);
 
-			RealtimeInterval = ini.GetValue("FTP site", "RealtimeInterval", 30000);
-			if (RealtimeInterval < 1)
-			{
-				RealtimeInterval = 1;
-				rewriteRequired = true;
-			}
+			RealtimeInterval = ini.GetValue("FTP site", "RealtimeInterval", 30000, 1);
 
 			WebAutoUpdate = ini.GetValue("FTP site", "AutoUpdate", false);  // Deprecated, to be remove at some future date
 																			// Have to allow for upgrade, set interval enabled to old WebAutoUpdate
@@ -4266,40 +4215,35 @@ namespace CumulusMX
 
 			CloudBaseInFeet = ini.GetValue("Station", "CloudBaseInFeet", true);
 
-			GraphDays = ini.GetValue("Graphs", "ChartMaxDays", 31);
-			GraphHours = ini.GetValue("Graphs", "GraphHours", 72);
+			GraphDays = ini.GetValue("Graphs", "ChartMaxDays", 31, 1);
+			GraphHours = ini.GetValue("Graphs", "GraphHours", 72, 1);
 			RecentDataDays = (int) Math.Ceiling(Math.Max(7, GraphHours / 24.0));
 			MoonImage.Enabled = ini.GetValue("Graphs", "MoonImageEnabled", false);
-			MoonImage.Size = ini.GetValue("Graphs", "MoonImageSize", 100);
-			if (MoonImage.Size < 10)
-			{
-				MoonImage.Size = 10;
-				rewriteRequired = true;
-			}
+			MoonImage.Size = ini.GetValue("Graphs", "MoonImageSize", 100, 10);
 			MoonImage.Transparent = ini.GetValue("Graphs", "MoonImageShadeTransparent", false);
 			MoonImage.FtpDest = ini.GetValue("Graphs", "MoonImageFtpDest", "images/moon.png");
 			MoonImage.CopyDest = ini.GetValue("Graphs", "MoonImageCopyDest", FtpOptions.LocalCopyFolder + "images" + sep1 + "moon.png");
-			GraphOptions.Visible.Temp.Val = ini.GetValue("Graphs", "TempVisible", 1);
-			GraphOptions.Visible.InTemp.Val = ini.GetValue("Graphs", "InTempVisible", 1);
-			GraphOptions.Visible.HeatIndex.Val = ini.GetValue("Graphs", "HIVisible", 1);
-			GraphOptions.Visible.DewPoint.Val = ini.GetValue("Graphs", "DPVisible", 1);
-			GraphOptions.Visible.WindChill.Val = ini.GetValue("Graphs", "WCVisible", 1);
-			GraphOptions.Visible.AppTemp.Val = ini.GetValue("Graphs", "AppTempVisible", 1);
-			GraphOptions.Visible.FeelsLike.Val = ini.GetValue("Graphs", "FeelsLikeVisible", 1);
-			GraphOptions.Visible.Humidex.Val = ini.GetValue("Graphs", "HumidexVisible", 1);
-			GraphOptions.Visible.InHum.Val = ini.GetValue("Graphs", "InHumVisible", 1);
-			GraphOptions.Visible.OutHum.Val = ini.GetValue("Graphs", "OutHumVisible", 1);
-			GraphOptions.Visible.UV.Val = ini.GetValue("Graphs", "UVVisible", 1);
-			GraphOptions.Visible.Solar.Val = ini.GetValue("Graphs", "SolarVisible", 1);
-			GraphOptions.Visible.Sunshine.Val = ini.GetValue("Graphs", "SunshineVisible", 1);
-			GraphOptions.Visible.AvgTemp.Val = ini.GetValue("Graphs", "DailyAvgTempVisible", 1);
-			GraphOptions.Visible.MaxTemp.Val = ini.GetValue("Graphs", "DailyMaxTempVisible", 1);
-			GraphOptions.Visible.MinTemp.Val = ini.GetValue("Graphs", "DailyMinTempVisible", 1);
-			GraphOptions.Visible.GrowingDegreeDays1.Val = ini.GetValue("Graphs", "GrowingDegreeDaysVisible1", 1);
-			GraphOptions.Visible.GrowingDegreeDays2.Val = ini.GetValue("Graphs", "GrowingDegreeDaysVisible2", 1);
-			GraphOptions.Visible.TempSum0.Val = ini.GetValue("Graphs", "TempSumVisible0", 1);
-			GraphOptions.Visible.TempSum1.Val = ini.GetValue("Graphs", "TempSumVisible1", 1);
-			GraphOptions.Visible.TempSum2.Val = ini.GetValue("Graphs", "TempSumVisible2", 1);
+			GraphOptions.Visible.Temp.Val = ini.GetValue("Graphs", "TempVisible", 1, 0, 2);
+			GraphOptions.Visible.InTemp.Val = ini.GetValue("Graphs", "InTempVisible", 1, 0, 2);
+			GraphOptions.Visible.HeatIndex.Val = ini.GetValue("Graphs", "HIVisible", 1, 0, 2);
+			GraphOptions.Visible.DewPoint.Val = ini.GetValue("Graphs", "DPVisible", 1, 0, 2);
+			GraphOptions.Visible.WindChill.Val = ini.GetValue("Graphs", "WCVisible", 1, 0, 2);
+			GraphOptions.Visible.AppTemp.Val = ini.GetValue("Graphs", "AppTempVisible", 1, 0, 2);
+			GraphOptions.Visible.FeelsLike.Val = ini.GetValue("Graphs", "FeelsLikeVisible", 1, 0, 2);
+			GraphOptions.Visible.Humidex.Val = ini.GetValue("Graphs", "HumidexVisible", 1, 0, 2);
+			GraphOptions.Visible.InHum.Val = ini.GetValue("Graphs", "InHumVisible", 1, 0, 2);
+			GraphOptions.Visible.OutHum.Val = ini.GetValue("Graphs", "OutHumVisible", 1, 0, 2);
+			GraphOptions.Visible.UV.Val = ini.GetValue("Graphs", "UVVisible", 1, 0, 2);
+			GraphOptions.Visible.Solar.Val = ini.GetValue("Graphs", "SolarVisible", 1, 0, 2);
+			GraphOptions.Visible.Sunshine.Val = ini.GetValue("Graphs", "SunshineVisible", 1, 0, 2);
+			GraphOptions.Visible.AvgTemp.Val = ini.GetValue("Graphs", "DailyAvgTempVisible", 1, 0, 2);
+			GraphOptions.Visible.MaxTemp.Val = ini.GetValue("Graphs", "DailyMaxTempVisible", 1, 0, 2);
+			GraphOptions.Visible.MinTemp.Val = ini.GetValue("Graphs", "DailyMinTempVisible", 1, 0, 2);
+			GraphOptions.Visible.GrowingDegreeDays1.Val = ini.GetValue("Graphs", "GrowingDegreeDaysVisible1", 1, 0, 2);
+			GraphOptions.Visible.GrowingDegreeDays2.Val = ini.GetValue("Graphs", "GrowingDegreeDaysVisible2", 1, 0, 2);
+			GraphOptions.Visible.TempSum0.Val = ini.GetValue("Graphs", "TempSumVisible0", 1, 0, 2);
+			GraphOptions.Visible.TempSum1.Val = ini.GetValue("Graphs", "TempSumVisible1", 1, 0, 2);
+			GraphOptions.Visible.TempSum2.Val = ini.GetValue("Graphs", "TempSumVisible2", 1, 0, 2);
 			GraphOptions.Visible.ExtraTemp.Vals = ini.GetValue("Graphs", "ExtraTempVisible", new int[10]);
 			GraphOptions.Visible.ExtraHum.Vals = ini.GetValue("Graphs", "ExtraHumVisible", new int[10]);
 			GraphOptions.Visible.ExtraDewPoint.Vals = ini.GetValue("Graphs", "ExtraDewPointVisible", new int[10]);
@@ -4311,14 +4255,14 @@ namespace CumulusMX
 			GraphOptions.Visible.AqSensor.PmAvg.Vals = ini.GetValue("Graphs", "Aq-PmAvgVisible", new int[4]);
 			GraphOptions.Visible.AqSensor.Temp.Vals = ini.GetValue("Graphs", "Aq-TempVisible", new int[4]);
 			GraphOptions.Visible.AqSensor.Hum.Vals = ini.GetValue("Graphs", "Aq-HumVisible", new int[4]);
-			GraphOptions.Visible.CO2Sensor.CO2.Val = ini.GetValue("Graphs", "CO2-CO2", 0);
-			GraphOptions.Visible.CO2Sensor.CO2Avg.Val = ini.GetValue("Graphs", "CO2-CO2Avg", 0);
-			GraphOptions.Visible.CO2Sensor.Pm25.Val = ini.GetValue("Graphs", "CO2-Pm25", 0);
-			GraphOptions.Visible.CO2Sensor.Pm25Avg.Val = ini.GetValue("Graphs", "CO2-Pm25Avg", 0);
-			GraphOptions.Visible.CO2Sensor.Pm10.Val = ini.GetValue("Graphs", "CO2-Pm10", 0);
-			GraphOptions.Visible.CO2Sensor.Pm10Avg.Val = ini.GetValue("Graphs", "CO2-Pm10Avg", 0);
-			GraphOptions.Visible.CO2Sensor.Temp.Val = ini.GetValue("Graphs", "CO2-Temp", 0);
-			GraphOptions.Visible.CO2Sensor.Hum.Val = ini.GetValue("Graphs", "CO2-Hum", 0);
+			GraphOptions.Visible.CO2Sensor.CO2.Val = ini.GetValue("Graphs", "CO2-CO2", 0, 0, 2);
+			GraphOptions.Visible.CO2Sensor.CO2Avg.Val = ini.GetValue("Graphs", "CO2-CO2Avg", 0, 0, 2);
+			GraphOptions.Visible.CO2Sensor.Pm25.Val = ini.GetValue("Graphs", "CO2-Pm25", 0, 0, 2);
+			GraphOptions.Visible.CO2Sensor.Pm25Avg.Val = ini.GetValue("Graphs", "CO2-Pm25Avg", 0, 0, 2);
+			GraphOptions.Visible.CO2Sensor.Pm10.Val = ini.GetValue("Graphs", "CO2-Pm10", 0, 0, 2);
+			GraphOptions.Visible.CO2Sensor.Pm10Avg.Val = ini.GetValue("Graphs", "CO2-Pm10Avg", 0, 0, 2);
+			GraphOptions.Visible.CO2Sensor.Temp.Val = ini.GetValue("Graphs", "CO2-Temp", 0, 0, 2);
+			GraphOptions.Visible.CO2Sensor.Hum.Val = ini.GetValue("Graphs", "CO2-Hum", 0, 0, 2);
 
 			GraphOptions.Colour.Temp = ini.GetValue("GraphColours", "TempColour", "#ff0000");
 			GraphOptions.Colour.InTemp = ini.GetValue("GraphColours", "InTempColour", "#50b432");
@@ -4399,17 +4343,17 @@ namespace CumulusMX
 			Wund.SendLeafWetness1 = ini.GetValue("Wunderground", "SendLeafWetness1", false);
 			Wund.SendLeafWetness2 = ini.GetValue("Wunderground", "SendLeafWetness2", false);
 			Wund.SendAirQuality = ini.GetValue("Wunderground", "SendAirQuality", false);
-			Wund.SendExtraTemp1 = ini.GetValue("Wunderground", "SendExtraTemp1", 0);
-			Wund.SendExtraTemp2 = ini.GetValue("Wunderground", "SendExtraTemp2", 0);
-			Wund.SendExtraTemp3 = ini.GetValue("Wunderground", "SendExtraTemp3", 0);
-			Wund.SendExtraTemp4 = ini.GetValue("Wunderground", "SendExtraTemp4", 0);
+			Wund.SendExtraTemp1 = ini.GetValue("Wunderground", "SendExtraTemp1", 0, 0, 10);
+			Wund.SendExtraTemp2 = ini.GetValue("Wunderground", "SendExtraTemp2", 0, 0, 10);
+			Wund.SendExtraTemp3 = ini.GetValue("Wunderground", "SendExtraTemp3", 0, 0, 10);
+			Wund.SendExtraTemp4 = ini.GetValue("Wunderground", "SendExtraTemp4", 0, 0, 10);
 			Wund.SendAverage = ini.GetValue("Wunderground", "SendAverage", false);
 			Wund.CatchUp = ini.GetValue("Wunderground", "CatchUp", true);
 
 			Wund.SynchronisedUpdate = !Wund.RapidFireEnabled;
 
 			Windy.ApiKey = ini.GetValue("Windy", "APIkey", string.Empty);
-			Windy.StationIdx = ini.GetValue("Windy", "StationIdx", 0);
+			Windy.StationIdx = ini.GetValue("Windy", "StationIdx", 0, 0);
 			Windy.Enabled = ini.GetValue("Windy", "Enabled", false);
 			Windy.Interval = ini.GetValue("Windy", "Interval", Windy.DefaultInterval);
 			if (Windy.Interval < 5)
@@ -4424,12 +4368,7 @@ namespace CumulusMX
 			AWEKAS.ID = ini.GetValue("Awekas", "User", string.Empty);
 			AWEKAS.PW = ini.GetValue("Awekas", "Password", string.Empty);
 			AWEKAS.Enabled = ini.GetValue("Awekas", "Enabled", false);
-			AWEKAS.Interval = ini.GetValue("Awekas", "Interval", AWEKAS.DefaultInterval);
-			if (AWEKAS.Interval < 15)
-			{
-				AWEKAS.Interval = 15;
-				rewriteRequired = true;
-			}
+			AWEKAS.Interval = ini.GetValue("Awekas", "Interval", AWEKAS.DefaultInterval, 15);
 			AWEKAS.Lang = ini.GetValue("Awekas", "Language", "en");
 			AWEKAS.OriginalInterval = AWEKAS.Interval;
 			AWEKAS.SendUV = ini.GetValue("Awekas", "SendUV", false);
@@ -4463,17 +4402,12 @@ namespace CumulusMX
 			WCloud.SendSoilMoisture = ini.GetValue("WeatherCloud", "SendSoilMoisture", false);
 			WCloud.SoilMoistureSensor = ini.GetValue("WeatherCloud", "SoilMoistureSensor", 1);
 			WCloud.SendLeafWetness = ini.GetValue("WeatherCloud", "SendLeafWetness", false);
-			WCloud.LeafWetnessSensor = ini.GetValue("WeatherCloud", "LeafWetnessSensor", 1);
+			WCloud.LeafWetnessSensor = ini.GetValue("WeatherCloud", "LeafWetnessSensor", 1, 1, 8);
 
 			PWS.ID = ini.GetValue("PWSweather", "ID", string.Empty);
 			PWS.PW = ini.GetValue("PWSweather", "Password", string.Empty);
 			PWS.Enabled = ini.GetValue("PWSweather", "Enabled", false);
-			PWS.Interval = ini.GetValue("PWSweather", "Interval", PWS.DefaultInterval);
-			if (PWS.Interval < 1)
-			{
-				PWS.Interval = 1;
-				rewriteRequired = true;
-			}
+			PWS.Interval = ini.GetValue("PWSweather", "Interval", PWS.DefaultInterval, 1);
 			PWS.SendUV = ini.GetValue("PWSweather", "SendUV", false);
 			PWS.SendSolar = ini.GetValue("PWSweather", "SendSR", false);
 			PWS.CatchUp = ini.GetValue("PWSweather", "CatchUp", true);
@@ -4481,16 +4415,11 @@ namespace CumulusMX
 			WOW.ID = ini.GetValue("WOW", "ID", string.Empty);
 			WOW.PW = ini.GetValue("WOW", "Password", string.Empty);
 			WOW.Enabled = ini.GetValue("WOW", "Enabled", false);
-			WOW.Interval = ini.GetValue("WOW", "Interval", WOW.DefaultInterval);
-			if (WOW.Interval < 1)
-			{
-				WOW.Interval = 1;
-				rewriteRequired = true;
-			}
+			WOW.Interval = ini.GetValue("WOW", "Interval", WOW.DefaultInterval, 1);
 			WOW.SendUV = ini.GetValue("WOW", "SendUV", false);
 			WOW.SendSolar = ini.GetValue("WOW", "SendSR", false);
 			WOW.SendSoilTemp = ini.GetValue("WOW", "SendSoilTemp", false);
-			WOW.SoilTempSensor = ini.GetValue("WOW", "SoilTempSensor", 1);
+			WOW.SoilTempSensor = ini.GetValue("WOW", "SoilTempSensor", 1, 1, 8);
 			WOW.CatchUp = false;
 
 			APRS.ID = ini.GetValue("APRS", "ID", string.Empty);
@@ -4498,12 +4427,7 @@ namespace CumulusMX
 			APRS.Server = ini.GetValue("APRS", "server", "cwop.aprs.net");
 			APRS.Port = ini.GetValue("APRS", "port", 14580);
 			APRS.Enabled = ini.GetValue("APRS", "Enabled", false);
-			APRS.Interval = ini.GetValue("APRS", "Interval", APRS.DefaultInterval);
-			if (APRS.Interval < 1)
-			{
-				APRS.Interval = 1;
-				rewriteRequired = true;
-			}
+			APRS.Interval = ini.GetValue("APRS", "Interval", APRS.DefaultInterval, 1);
 			APRS.HumidityCutoff = ini.GetValue("APRS", "APRSHumidityCutoff", false);
 			APRS.SendSolar = ini.GetValue("APRS", "SendSR", false);
 			APRS.UseUtcInWxNowFile = ini.GetValue("APRS", "UseUtcInWxNowFile", false);
@@ -4512,11 +4436,11 @@ namespace CumulusMX
 			OpenWeatherMap.CatchUp = ini.GetValue("OpenWeatherMap", "CatchUp", true);
 			OpenWeatherMap.PW = ini.GetValue("OpenWeatherMap", "APIkey", string.Empty);
 			OpenWeatherMap.ID = ini.GetValue("OpenWeatherMap", "StationId", string.Empty);
-			OpenWeatherMap.Interval = ini.GetValue("OpenWeatherMap", "Interval", OpenWeatherMap.DefaultInterval);
+			OpenWeatherMap.Interval = ini.GetValue("OpenWeatherMap", "Interval", OpenWeatherMap.DefaultInterval, 1);
 
 			MQTT.Server = ini.GetValue("MQTT", "Server", string.Empty);
-			MQTT.Port = ini.GetValue("MQTT", "Port", 1883);
-			MQTT.IpVersion = ini.GetValue("MQTT", "IPversion", 0); // 0 = unspecified, 4 = force IPv4, 6 = force IPv6
+			MQTT.Port = ini.GetValue("MQTT", "Port", 1883, 1, 65535);
+			MQTT.IpVersion = ini.GetValue("MQTT", "IPversion", 0, 0, 6); // 0 = unspecified, 4 = force IPv4, 6 = force IPv6
 			if (MQTT.IpVersion != 0 && MQTT.IpVersion != 4 && MQTT.IpVersion != 6)
 			{
 				MQTT.IpVersion = 0;
@@ -4542,7 +4466,7 @@ namespace CumulusMX
 			LowTempAlarm.Notify = ini.GetValue("Alarms", "LowTempAlarmNotify", false);
 			LowTempAlarm.Email = ini.GetValue("Alarms", "LowTempAlarmEmail", false);
 			LowTempAlarm.Latch = ini.GetValue("Alarms", "LowTempAlarmLatch", false);
-			LowTempAlarm.LatchHours = ini.GetValue("Alarms", "LowTempAlarmLatchHours", 24.0);
+			LowTempAlarm.LatchHours = ini.GetValue("Alarms", "LowTempAlarmLatchHours", 24.0, 0.0);
 			LowTempAlarm.Action = ini.GetValue("Alarms", "LowTempAlarmAction", string.Empty);
 			LowTempAlarm.ActionParams = ini.GetValue("Alarms", "LowTempAlarmActionParams", string.Empty);
 
@@ -4558,7 +4482,7 @@ namespace CumulusMX
 			HighTempAlarm.Notify = ini.GetValue("Alarms", "HighTempAlarmNotify", false);
 			HighTempAlarm.Email = ini.GetValue("Alarms", "HighTempAlarmEmail", false);
 			HighTempAlarm.Latch = ini.GetValue("Alarms", "HighTempAlarmLatch", false);
-			HighTempAlarm.LatchHours = ini.GetValue("Alarms", "HighTempAlarmLatchHours", 24.0);
+			HighTempAlarm.LatchHours = ini.GetValue("Alarms", "HighTempAlarmLatchHours", 24.0, 0.0);
 			HighTempAlarm.Action = ini.GetValue("Alarms", "HighTempAlarmAction", string.Empty);
 			HighTempAlarm.ActionParams = ini.GetValue("Alarms", "HighTempAlarmActionParams", string.Empty);
 
@@ -4574,7 +4498,7 @@ namespace CumulusMX
 			TempChangeAlarm.Notify = ini.GetValue("Alarms", "TempChangeAlarmNotify", false);
 			TempChangeAlarm.Email = ini.GetValue("Alarms", "TempChangeAlarmEmail", false);
 			TempChangeAlarm.Latch = ini.GetValue("Alarms", "TempChangeAlarmLatch", false);
-			TempChangeAlarm.LatchHours = ini.GetValue("Alarms", "TempChangeAlarmLatchHours", 24.0);
+			TempChangeAlarm.LatchHours = ini.GetValue("Alarms", "TempChangeAlarmLatchHours", 24.0, 0.0);
 			TempChangeAlarm.Action = ini.GetValue("Alarms", "TempChangeAlarmAction", string.Empty);
 			TempChangeAlarm.ActionParams = ini.GetValue("Alarms", "TempChangeAlarmActionParams", string.Empty);
 
@@ -4590,11 +4514,11 @@ namespace CumulusMX
 			LowPressAlarm.Notify = ini.GetValue("Alarms", "LowPressAlarmNotify", false);
 			LowPressAlarm.Email = ini.GetValue("Alarms", "LowPressAlarmEmail", false);
 			LowPressAlarm.Latch = ini.GetValue("Alarms", "LowPressAlarmLatch", false);
-			LowPressAlarm.LatchHours = ini.GetValue("Alarms", "LowPressAlarmLatchHours", 24.0);
+			LowPressAlarm.LatchHours = ini.GetValue("Alarms", "LowPressAlarmLatchHours", 24.0, 0.0);
 			LowPressAlarm.Action = ini.GetValue("Alarms", "LowPressAlarmAction", string.Empty);
 			LowPressAlarm.ActionParams = ini.GetValue("Alarms", "LowPressAlarmActionParams", string.Empty);
 
-			HighPressAlarm.Value = ini.GetValue("Alarms", "alarmhighpress", 0.0);
+			HighPressAlarm.Value = ini.GetValue("Alarms", "alarmhighpress", 0.0, 0.0);
 			HighPressAlarm.Enabled = ini.GetValue("Alarms", "HighPressAlarmSet", false);
 			HighPressAlarm.Sound = ini.GetValue("Alarms", "HighPressAlarmSound", false);
 			HighPressAlarm.SoundFile = ini.GetValue("Alarms", "HighPressAlarmSoundFile", DefaultSoundFile);
@@ -4606,11 +4530,11 @@ namespace CumulusMX
 			HighPressAlarm.Notify = ini.GetValue("Alarms", "HighPressAlarmNotify", false);
 			HighPressAlarm.Email = ini.GetValue("Alarms", "HighPressAlarmEmail", false);
 			HighPressAlarm.Latch = ini.GetValue("Alarms", "HighPressAlarmLatch", false);
-			HighPressAlarm.LatchHours = ini.GetValue("Alarms", "HighPressAlarmLatchHours", 24.0);
+			HighPressAlarm.LatchHours = ini.GetValue("Alarms", "HighPressAlarmLatchHours", 24.0, 0.0);
 			HighPressAlarm.Action = ini.GetValue("Alarms", "HighPressAlarmAction", string.Empty);
 			HighPressAlarm.ActionParams = ini.GetValue("Alarms", "HighPressAlarmActionParams", string.Empty);
 
-			PressChangeAlarm.Value = ini.GetValue("Alarms", "alarmpresschange", 0.0);
+			PressChangeAlarm.Value = ini.GetValue("Alarms", "alarmpresschange", 0.0, 0.0);
 			PressChangeAlarm.Enabled = ini.GetValue("Alarms", "PressChangeAlarmSet", false);
 			PressChangeAlarm.Sound = ini.GetValue("Alarms", "PressChangeAlarmSound", false);
 			PressChangeAlarm.SoundFile = ini.GetValue("Alarms", "PressChangeAlarmSoundFile", DefaultSoundFile);
@@ -4622,11 +4546,11 @@ namespace CumulusMX
 			PressChangeAlarm.Notify = ini.GetValue("Alarms", "PressChangeAlarmNotify", false);
 			PressChangeAlarm.Email = ini.GetValue("Alarms", "PressChangeAlarmEmail", false);
 			PressChangeAlarm.Latch = ini.GetValue("Alarms", "PressChangeAlarmLatch", false);
-			PressChangeAlarm.LatchHours = ini.GetValue("Alarms", "PressChangeAlarmLatchHours", 24.0);
+			PressChangeAlarm.LatchHours = ini.GetValue("Alarms", "PressChangeAlarmLatchHours", 24.0, 0.0);
 			PressChangeAlarm.Action = ini.GetValue("Alarms", "PressChangeAlarmAction", string.Empty);
 			PressChangeAlarm.ActionParams = ini.GetValue("Alarms", "PressChangeAlarmActionParams", string.Empty);
 
-			HighRainTodayAlarm.Value = ini.GetValue("Alarms", "alarmhighraintoday", 0.0);
+			HighRainTodayAlarm.Value = ini.GetValue("Alarms", "alarmhighraintoday", 0.0, 0.0);
 			HighRainTodayAlarm.Enabled = ini.GetValue("Alarms", "HighRainTodayAlarmSet", false);
 			HighRainTodayAlarm.Sound = ini.GetValue("Alarms", "HighRainTodayAlarmSound", false);
 			HighRainTodayAlarm.SoundFile = ini.GetValue("Alarms", "HighRainTodayAlarmSoundFile", DefaultSoundFile);
@@ -4638,11 +4562,11 @@ namespace CumulusMX
 			HighRainTodayAlarm.Notify = ini.GetValue("Alarms", "HighRainTodayAlarmNotify", false);
 			HighRainTodayAlarm.Email = ini.GetValue("Alarms", "HighRainTodayAlarmEmail", false);
 			HighRainTodayAlarm.Latch = ini.GetValue("Alarms", "HighRainTodayAlarmLatch", false);
-			HighRainTodayAlarm.LatchHours = ini.GetValue("Alarms", "HighRainTodayAlarmLatchHours", 24.0);
+			HighRainTodayAlarm.LatchHours = ini.GetValue("Alarms", "HighRainTodayAlarmLatchHours", 24.0, 0.0);
 			HighRainTodayAlarm.Action = ini.GetValue("Alarms", "HighRainTodayAlarmAction", string.Empty);
 			HighRainTodayAlarm.ActionParams = ini.GetValue("Alarms", "HighRainTodayAlarmActionParams", string.Empty);
 
-			HighRainRateAlarm.Value = ini.GetValue("Alarms", "alarmhighrainrate", 0.0);
+			HighRainRateAlarm.Value = ini.GetValue("Alarms", "alarmhighrainrate", 0.0, 0.0);
 			HighRainRateAlarm.Enabled = ini.GetValue("Alarms", "HighRainRateAlarmSet", false);
 			HighRainRateAlarm.Sound = ini.GetValue("Alarms", "HighRainRateAlarmSound", false);
 			HighRainRateAlarm.SoundFile = ini.GetValue("Alarms", "HighRainRateAlarmSoundFile", DefaultSoundFile);
@@ -4654,7 +4578,7 @@ namespace CumulusMX
 			HighRainRateAlarm.Notify = ini.GetValue("Alarms", "HighRainRateAlarmNotify", false);
 			HighRainRateAlarm.Email = ini.GetValue("Alarms", "HighRainRateAlarmEmail", false);
 			HighRainRateAlarm.Latch = ini.GetValue("Alarms", "HighRainRateAlarmLatch", false);
-			HighRainRateAlarm.LatchHours = ini.GetValue("Alarms", "HighRainRateAlarmLatchHours", 24.0);
+			HighRainRateAlarm.LatchHours = ini.GetValue("Alarms", "HighRainRateAlarmLatchHours", 24.0, 0.0);
 			HighRainRateAlarm.Action = ini.GetValue("Alarms", "HighRainRateAlarmAction", string.Empty);
 			HighRainRateAlarm.ActionParams = ini.GetValue("Alarms", "HighRainRateAlarmActionParams", string.Empty);
 
@@ -4664,11 +4588,11 @@ namespace CumulusMX
 			IsRainingAlarm.Notify = ini.GetValue("Alarms", "IsRainingAlarmNotify", false);
 			IsRainingAlarm.Email = ini.GetValue("Alarms", "IsRainingAlarmEmail", false);
 			IsRainingAlarm.Latch = ini.GetValue("Alarms", "IsRainingAlarmLatch", false);
-			IsRainingAlarm.LatchHours = ini.GetValue("Alarms", "IsRainingAlarmLatchHours", 1.0);
+			IsRainingAlarm.LatchHours = ini.GetValue("Alarms", "IsRainingAlarmLatchHours", 1.0, 0.0);
 			IsRainingAlarm.Action = ini.GetValue("Alarms", "IsRainingAlarmAction", string.Empty);
 			IsRainingAlarm.ActionParams = ini.GetValue("Alarms", "IsRainingAlarmActionParams", string.Empty);
 
-			HighGustAlarm.Value = ini.GetValue("Alarms", "alarmhighgust", 0.0);
+			HighGustAlarm.Value = ini.GetValue("Alarms", "alarmhighgust", 0.0, 0.0);
 			HighGustAlarm.Enabled = ini.GetValue("Alarms", "HighGustAlarmSet", false);
 			HighGustAlarm.Sound = ini.GetValue("Alarms", "HighGustAlarmSound", false);
 			HighGustAlarm.SoundFile = ini.GetValue("Alarms", "HighGustAlarmSoundFile", DefaultSoundFile);
@@ -4680,11 +4604,11 @@ namespace CumulusMX
 			HighGustAlarm.Notify = ini.GetValue("Alarms", "HighGustAlarmNotify", false);
 			HighGustAlarm.Email = ini.GetValue("Alarms", "HighGustAlarmEmail", false);
 			HighGustAlarm.Latch = ini.GetValue("Alarms", "HighGustAlarmLatch", false);
-			HighGustAlarm.LatchHours = ini.GetValue("Alarms", "HighGustAlarmLatchHours", 24.0);
+			HighGustAlarm.LatchHours = ini.GetValue("Alarms", "HighGustAlarmLatchHours", 24.0, 0.0);
 			HighGustAlarm.Action = ini.GetValue("Alarms", "HighGustAlarmAction", string.Empty);
 			HighGustAlarm.ActionParams = ini.GetValue("Alarms", "HighGustAlarmActionParams", string.Empty);
 
-			HighWindAlarm.Value = ini.GetValue("Alarms", "alarmhighwind", 0.0);
+			HighWindAlarm.Value = ini.GetValue("Alarms", "alarmhighwind", 0.0, 0.0);
 			HighWindAlarm.Enabled = ini.GetValue("Alarms", "HighWindAlarmSet", false);
 			HighWindAlarm.Sound = ini.GetValue("Alarms", "HighWindAlarmSound", false);
 			HighWindAlarm.SoundFile = ini.GetValue("Alarms", "HighWindAlarmSoundFile", DefaultSoundFile);
@@ -4696,7 +4620,7 @@ namespace CumulusMX
 			HighWindAlarm.Notify = ini.GetValue("Alarms", "HighWindAlarmNotify", false);
 			HighWindAlarm.Email = ini.GetValue("Alarms", "HighWindAlarmEmail", false);
 			HighWindAlarm.Latch = ini.GetValue("Alarms", "HighWindAlarmLatch", false);
-			HighWindAlarm.LatchHours = ini.GetValue("Alarms", "HighWindAlarmLatchHours", 24.0);
+			HighWindAlarm.LatchHours = ini.GetValue("Alarms", "HighWindAlarmLatchHours", 24.0, 0.0);
 			HighWindAlarm.Action = ini.GetValue("Alarms", "HighWindAlarmAction", string.Empty);
 			HighWindAlarm.ActionParams = ini.GetValue("Alarms", "HighWindAlarmActionParams", string.Empty);
 
@@ -4711,8 +4635,8 @@ namespace CumulusMX
 			SensorAlarm.Notify = ini.GetValue("Alarms", "SensorAlarmNotify", true);
 			SensorAlarm.Email = ini.GetValue("Alarms", "SensorAlarmEmail", false);
 			SensorAlarm.Latch = ini.GetValue("Alarms", "SensorAlarmLatch", true);
-			SensorAlarm.LatchHours = ini.GetValue("Alarms", "SensorAlarmLatchHours", 1.0);
-			SensorAlarm.TriggerThreshold = ini.GetValue("Alarms", "SensorAlarmTriggerCount", 2);
+			SensorAlarm.LatchHours = ini.GetValue("Alarms", "SensorAlarmLatchHours", 1.0, 0.0);
+			SensorAlarm.TriggerThreshold = ini.GetValue("Alarms", "SensorAlarmTriggerCount", 2, 0);
 			SensorAlarm.Action = ini.GetValue("Alarms", "SensorAlarmAction", string.Empty);
 			SensorAlarm.ActionParams = ini.GetValue("Alarms", "SensorAlarmActionParams", string.Empty);
 
@@ -4727,8 +4651,8 @@ namespace CumulusMX
 			DataStoppedAlarm.Notify = ini.GetValue("Alarms", "DataStoppedAlarmNotify", true);
 			DataStoppedAlarm.Email = ini.GetValue("Alarms", "DataStoppedAlarmEmail", false);
 			DataStoppedAlarm.Latch = ini.GetValue("Alarms", "DataStoppedAlarmLatch", true);
-			DataStoppedAlarm.LatchHours = ini.GetValue("Alarms", "DataStoppedAlarmLatchHours", 1.0);
-			DataStoppedAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataStoppedAlarmTriggerCount", 2);
+			DataStoppedAlarm.LatchHours = ini.GetValue("Alarms", "DataStoppedAlarmLatchHours", 1.0, 0.0);
+			DataStoppedAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataStoppedAlarmTriggerCount", 2, 0);
 			DataStoppedAlarm.Action = ini.GetValue("Alarms", "DataStoppedAlarmAction", string.Empty);
 			DataStoppedAlarm.ActionParams = ini.GetValue("Alarms", "DataStoppedAlarmActionParams", string.Empty);
 
@@ -4739,8 +4663,8 @@ namespace CumulusMX
 			BatteryLowAlarm.Notify = ini.GetValue("Alarms", "BatteryLowAlarmNotify", false);
 			BatteryLowAlarm.Email = ini.GetValue("Alarms", "BatteryLowAlarmEmail", false);
 			BatteryLowAlarm.Latch = ini.GetValue("Alarms", "BatteryLowAlarmLatch", false);
-			BatteryLowAlarm.LatchHours = ini.GetValue("Alarms", "BatteryLowAlarmLatchHours", 24.0);
-			BatteryLowAlarm.TriggerThreshold = ini.GetValue("Alarms", "BatteryLowAlarmTriggerCount", 1);
+			BatteryLowAlarm.LatchHours = ini.GetValue("Alarms", "BatteryLowAlarmLatchHours", 24.0, 0.0);
+			BatteryLowAlarm.TriggerThreshold = ini.GetValue("Alarms", "BatteryLowAlarmTriggerCount", 1, 0);
 			BatteryLowAlarm.Action = ini.GetValue("Alarms", "BatteryLowAlarmAction", string.Empty);
 			BatteryLowAlarm.ActionParams = ini.GetValue("Alarms", "BatteryLowAlarmActionParams", string.Empty);
 
@@ -4750,8 +4674,8 @@ namespace CumulusMX
 			SpikeAlarm.Notify = ini.GetValue("Alarms", "DataSpikeAlarmNotify", true);
 			SpikeAlarm.Email = ini.GetValue("Alarms", "DataSpikeAlarmEmail", true);
 			SpikeAlarm.Latch = ini.GetValue("Alarms", "DataSpikeAlarmLatch", true);
-			SpikeAlarm.LatchHours = ini.GetValue("Alarms", "DataSpikeAlarmLatchHours", 24.0);
-			SpikeAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataSpikeAlarmTriggerCount", 1);
+			SpikeAlarm.LatchHours = ini.GetValue("Alarms", "DataSpikeAlarmLatchHours", 24.0, 0.0);
+			SpikeAlarm.TriggerThreshold = ini.GetValue("Alarms", "DataSpikeAlarmTriggerCount", 1, 0);
 			SpikeAlarm.Action = ini.GetValue("Alarms", "DataSpikeAlarmAction", string.Empty);
 			SpikeAlarm.ActionParams = ini.GetValue("Alarms", "DataSpikeAlarmActionParams", string.Empty);
 
@@ -4761,7 +4685,7 @@ namespace CumulusMX
 			UpgradeAlarm.Notify = ini.GetValue("Alarms", "UpgradeAlarmNotify", true);
 			UpgradeAlarm.Email = ini.GetValue("Alarms", "UpgradeAlarmEmail", false);
 			UpgradeAlarm.Latch = ini.GetValue("Alarms", "UpgradeAlarmLatch", false);
-			UpgradeAlarm.LatchHours = ini.GetValue("Alarms", "UpgradeAlarmLatchHours", 24.0);
+			UpgradeAlarm.LatchHours = ini.GetValue("Alarms", "UpgradeAlarmLatchHours", 24.0, 0.0);
 			UpgradeAlarm.Action = ini.GetValue("Alarms", "UpgradeAlarmAction", string.Empty);
 			UpgradeAlarm.ActionParams = ini.GetValue("Alarms", "UpgradeAlarmActionParams", string.Empty);
 
@@ -4771,7 +4695,7 @@ namespace CumulusMX
 			FirmwareAlarm.Notify = ini.GetValue("Alarms", "FirmwareAlarmNotify", true);
 			FirmwareAlarm.Email = ini.GetValue("Alarms", "FirmwareAlarmEmail", false);
 			FirmwareAlarm.Latch = ini.GetValue("Alarms", "FirmwareAlarmLatch", false);
-			FirmwareAlarm.LatchHours = ini.GetValue("Alarms", "FirmwareAlarmLatchHours", 24.0);
+			FirmwareAlarm.LatchHours = ini.GetValue("Alarms", "FirmwareAlarmLatchHours", 24.0, 0.0);
 			FirmwareAlarm.Action = ini.GetValue("Alarms", "FirmwareAlarmAction", string.Empty);
 			FirmwareAlarm.ActionParams = ini.GetValue("Alarms", "FirmwareAlarmActionParams", string.Empty);
 
@@ -4781,8 +4705,8 @@ namespace CumulusMX
 			ThirdPartyAlarm.Notify = ini.GetValue("Alarms", "HttpUploadAlarmNotify", false);
 			ThirdPartyAlarm.Email = ini.GetValue("Alarms", "HttpUploadAlarmEmail", false);
 			ThirdPartyAlarm.Latch = ini.GetValue("Alarms", "HttpUploadAlarmLatch", false);
-			ThirdPartyAlarm.LatchHours = ini.GetValue("Alarms", "HttpUploadAlarmLatchHours", 24.0);
-			ThirdPartyAlarm.TriggerThreshold = ini.GetValue("Alarms", "HttpUploadAlarmTriggerCount", 1);
+			ThirdPartyAlarm.LatchHours = ini.GetValue("Alarms", "HttpUploadAlarmLatchHours", 24.0, 0.0);
+			ThirdPartyAlarm.TriggerThreshold = ini.GetValue("Alarms", "HttpUploadAlarmTriggerCount", 1, 0);
 			ThirdPartyAlarm.Action = ini.GetValue("Alarms", "HttpUploadAlarmAction", string.Empty);
 			ThirdPartyAlarm.ActionParams = ini.GetValue("Alarms", "HttpUploadAlarmActionParams", string.Empty);
 
@@ -4792,8 +4716,8 @@ namespace CumulusMX
 			MySqlUploadAlarm.Notify = ini.GetValue("Alarms", "MySqlUploadAlarmNotify", false);
 			MySqlUploadAlarm.Email = ini.GetValue("Alarms", "MySqlUploadAlarmEmail", false);
 			MySqlUploadAlarm.Latch = ini.GetValue("Alarms", "MySqlUploadAlarmLatch", false);
-			MySqlUploadAlarm.LatchHours = ini.GetValue("Alarms", "MySqlUploadAlarmLatchHours", 24.0);
-			MySqlUploadAlarm.TriggerThreshold = ini.GetValue("Alarms", "MySqlUploadAlarmTriggerCount", 1);
+			MySqlUploadAlarm.LatchHours = ini.GetValue("Alarms", "MySqlUploadAlarmLatchHours", 24.0, 0.0);
+			MySqlUploadAlarm.TriggerThreshold = ini.GetValue("Alarms", "MySqlUploadAlarmTriggerCount", 1, 0);
 			MySqlUploadAlarm.Action = ini.GetValue("Alarms", "MySqlUploadAlarmAction", string.Empty);
 			MySqlUploadAlarm.ActionParams = ini.GetValue("Alarms", "MySqlUploadAlarmActionParams", string.Empty);
 
@@ -4803,7 +4727,7 @@ namespace CumulusMX
 			NewRecordAlarm.Notify = ini.GetValue("Alarms", "NewRecordAlarmNotify", false);
 			NewRecordAlarm.Email = ini.GetValue("Alarms", "NewRecordAlarmEmail", false);
 			NewRecordAlarm.Latch = ini.GetValue("Alarms", "NewRecordAlarmLatch", false);
-			NewRecordAlarm.LatchHours = ini.GetValue("Alarms", "NewRecordAlarmLatchHours", 24.0);
+			NewRecordAlarm.LatchHours = ini.GetValue("Alarms", "NewRecordAlarmLatchHours", 24.0, 0.0);
 			NewRecordAlarm.Action = ini.GetValue("Alarms", "NewRecordAlarmAction", string.Empty);
 			NewRecordAlarm.ActionParams = ini.GetValue("Alarms", "NewRecordAlarmActionParams", string.Empty);
 
@@ -4813,7 +4737,7 @@ namespace CumulusMX
 			FtpAlarm.Notify = ini.GetValue("Alarms", "FtpAlarmNotify", false);
 			FtpAlarm.Email = ini.GetValue("Alarms", "FtpAlarmEmail", false);
 			FtpAlarm.Latch = ini.GetValue("Alarms", "FtpAlarmLatch", false);
-			FtpAlarm.LatchHours = ini.GetValue("Alarms", "FtpAlarmLatchHours", 24.0);
+			FtpAlarm.LatchHours = ini.GetValue("Alarms", "FtpAlarmLatchHours", 24.0, 0.0);
 			FtpAlarm.Action = ini.GetValue("Alarms", "FtpAlarmAction", string.Empty);
 			FtpAlarm.ActionParams = ini.GetValue("Alarms", "FtpAlarmActionParams", string.Empty);
 
@@ -4835,7 +4759,7 @@ namespace CumulusMX
 					var email = ini.GetValue("UserAlarms", "AlarmEmail" + i, false);
 					var emailMsg = ini.GetValue("UserAlarms", "AlarmEmailMsg" + i, string.Empty);
 					var latch = ini.GetValue("UserAlarms", "AlarmLatch" + i, false);
-					var latchHours = ini.GetValue("UserAlarms", "AlarmLatchHours" + i, 24.0);
+					var latchHours = ini.GetValue("UserAlarms", "AlarmLatchHours" + i, 24.0, 0.0);
 					var action = ini.GetValue("UserAlarms", "AlarmAction" + i, string.Empty);
 					var actionParams = ini.GetValue("UserAlarms", "AlarmActionParams" + i, string.Empty);
 
@@ -4904,18 +4828,18 @@ namespace CumulusMX
 
 			xapEnabled = ini.GetValue("xAP", "Enabled", false);
 			xapUID = ini.GetValue("xAP", "UID", "4375");
-			xapPort = ini.GetValue("xAP", "Port", 3639);
+			xapPort = ini.GetValue("xAP", "Port", 3639, 1, 65535);
 
-			SolarOptions.SunThreshold = ini.GetValue("Solar", "SunThreshold", 75);
-			SolarOptions.SolarMinimum = ini.GetValue("Solar", "SolarMinimum", 30);
+			SolarOptions.SunThreshold = ini.GetValue("Solar", "SunThreshold", 75, 1, 200);
+			SolarOptions.SolarMinimum = ini.GetValue("Solar", "SolarMinimum", 30, 0);
 			SolarOptions.LuxToWM2 = ini.GetValue("Solar", "LuxToWM2", 0.0079);
 			SolarOptions.UseBlakeLarsen = ini.GetValue("Solar", "UseBlakeLarsen", false);
-			SolarOptions.SolarCalc = ini.GetValue("Solar", "SolarCalc", 0);
+			SolarOptions.SolarCalc = ini.GetValue("Solar", "SolarCalc", 0, 0, 1);
 
 			// Migrate old single solar factors to the new dual scheme
 			if (ini.ValueExists("Solar", "RStransfactor"))
 			{
-				SolarOptions.RStransfactorJun = ini.GetValue("Solar", "RStransfactor", 0.8);
+				SolarOptions.RStransfactorJun = ini.GetValue("Solar", "RStransfactor", 0.8, 0.1);
 				SolarOptions.RStransfactorDec = SolarOptions.RStransfactorJun;
 				recreateRequired = true;
 			}
@@ -4923,14 +4847,14 @@ namespace CumulusMX
 			{
 				if (ini.ValueExists("Solar", "RStransfactorJul"))
 				{
-					SolarOptions.RStransfactorJun = ini.GetValue("Solar", "RStransfactorJul", 0.8);
+					SolarOptions.RStransfactorJun = ini.GetValue("Solar", "RStransfactorJul", 0.8, 0.1);
 					recreateRequired = true;
 				}
 				else
 				{
-					SolarOptions.RStransfactorJun = ini.GetValue("Solar", "RStransfactorJun", 0.8);
+					SolarOptions.RStransfactorJun = ini.GetValue("Solar", "RStransfactorJun", 0.8, 0.1);
 				}
-				SolarOptions.RStransfactorDec = ini.GetValue("Solar", "RStransfactorDec", 0.8);
+				SolarOptions.RStransfactorDec = ini.GetValue("Solar", "RStransfactorDec", 0.8, 0.1);
 			}
 			if (ini.ValueExists("Solar", "BrasTurbidity"))
 			{
@@ -5060,7 +4984,7 @@ namespace CumulusMX
 			HTTPProxyUser = ini.GetValue("Proxies", "HTTPProxyUser", string.Empty);
 			HTTPProxyPassword = ini.GetValue("Proxies", "HTTPProxyPassword", string.Empty);
 
-			NumWindRosePoints = ini.GetValue("Display", "NumWindRosePoints", 16);
+			NumWindRosePoints = ini.GetValue("Display", "NumWindRosePoints", 16, 4, 32);
 			WindRoseAngle = 360.0 / NumWindRosePoints;
 			DisplayOptions.UseApparent = ini.GetValue("Display", "UseApparent", false);
 			DisplayOptions.ShowSolar = ini.GetValue("Display", "DisplaySolarData", false);
@@ -5068,7 +4992,7 @@ namespace CumulusMX
 
 			// MySQL - common
 			MySqlConnSettings.Server = ini.GetValue("MySQL", "Host", "127.0.0.1");
-			MySqlConnSettings.Port = (uint) ini.GetValue("MySQL", "Port", 3306);
+			MySqlConnSettings.Port = (uint) ini.GetValue("MySQL", "Port", 3306, 1, 65535);
 			MySqlConnSettings.UserID = ini.GetValue("MySQL", "User", string.Empty);
 			MySqlConnSettings.Password = ini.GetValue("MySQL", "Pass", string.Empty);
 			MySqlConnSettings.Database = ini.GetValue("MySQL", "Database", "database");
@@ -5130,7 +5054,7 @@ namespace CumulusMX
 			{
 				MySqlSettings.CustomTimed.Commands[i] = ini.GetValue("MySQL", "CustomMySqlTimedCommandString" + i, string.Empty);
 				MySqlSettings.CustomTimed.SetStartTime(i, ini.GetValue("MySQL", "CustomMySqlTimedStartTime" + i, "00:00"));
-				MySqlSettings.CustomTimed.Intervals[i] = ini.GetValue("MySQL", "CustomMySqlTimedInterval" + i, 1440);
+				MySqlSettings.CustomTimed.Intervals[i] = ini.GetValue("MySQL", "CustomMySqlTimedInterval" + i, 1440, 1);
 
 				if (!string.IsNullOrEmpty(MySqlSettings.CustomTimed.Commands[i]) && MySqlSettings.CustomTimed.Intervals[i] < 1440)
 					MySqlSettings.CustomTimed.SetNextInterval(i, DateTime.Now);
@@ -5164,8 +5088,7 @@ namespace CumulusMX
 			}
 
 			CustomHttpSecondsEnabled = ini.GetValue("HTTP", "CustomHttpSecondsEnabled", false);
-			CustomHttpSecondsInterval = ini.GetValue("HTTP", "CustomHttpSecondsInterval", 10);
-			if (CustomHttpSecondsInterval < 1) { CustomHttpSecondsInterval = 1; }
+			CustomHttpSecondsInterval = ini.GetValue("HTTP", "CustomHttpSecondsInterval", 10, 1);
 
 			// Custom HTTP - minutes
 			CustomHttpMinutesStrings[0] = ini.GetValue("HTTP", "CustomHttpMinutesString", string.Empty);
@@ -5233,9 +5156,9 @@ namespace CumulusMX
 			// Email settings
 			SmtpOptions.Enabled = ini.GetValue("SMTP", "Enabled", false);
 			SmtpOptions.Server = ini.GetValue("SMTP", "ServerName", string.Empty);
-			SmtpOptions.Port = ini.GetValue("SMTP", "Port", 587);
+			SmtpOptions.Port = ini.GetValue("SMTP", "Port", 587, 1, 65535);
 			SmtpOptions.SslOption = ini.GetValue("SMTP", "SSLOption", 1);
-			SmtpOptions.AuthenticationMethod = ini.GetValue("SMTP", "RequiresAuthentication", 0);
+			SmtpOptions.AuthenticationMethod = ini.GetValue("SMTP", "RequiresAuthentication", 0, 0, 1);
 			SmtpOptions.User = ini.GetValue("SMTP", "User", string.Empty);
 			SmtpOptions.Password = ini.GetValue("SMTP", "Password", string.Empty);
 			SmtpOptions.IgnoreCertErrors = ini.GetValue("SMTP", "IgnoreCertErrors", false);
@@ -5243,16 +5166,11 @@ namespace CumulusMX
 			// Growing Degree Days
 			GrowingBase1 = ini.GetValue("GrowingDD", "BaseTemperature1", (Units.Temp == 0 ? 5.0 : 40.0));
 			GrowingBase2 = ini.GetValue("GrowingDD", "BaseTemperature2", (Units.Temp == 0 ? 10.0 : 50.0));
-			GrowingYearStarts = ini.GetValue("GrowingDD", "YearStarts", (Latitude >= 0 ? 1 : 7));
+			GrowingYearStarts = ini.GetValue("GrowingDD", "YearStarts", (Latitude >= 0 ? 1 : 7), 1, 12);
 			GrowingCap30C = ini.GetValue("GrowingDD", "Cap30C", true);
 
 			// Temperature Sum
-			TempSumYearStarts = ini.GetValue("TempSum", "TempSumYearStart", (Latitude >= 0 ? 1 : 7));
-			if (TempSumYearStarts < 1 || TempSumYearStarts > 12)
-			{
-				TempSumYearStarts = 1;
-				rewriteRequired = true;
-			}
+			TempSumYearStarts = ini.GetValue("TempSum", "TempSumYearStart", (Latitude >= 0 ? 1 : 7), 1, 12);
 			TempSumBase1 = ini.GetValue("TempSum", "BaseTemperature1", GrowingBase1);
 			TempSumBase2 = ini.GetValue("TempSum", "BaseTemperature2", GrowingBase2);
 
@@ -12077,8 +11995,6 @@ namespace CumulusMX
 			Windy.CatchUpIfRequired();
 
 			PWS.CatchUpIfRequired();
-
-			WOW.CatchUpIfRequired();
 
 			OpenWeatherMap.CatchUpIfRequired();
 

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3687,7 +3687,7 @@ namespace CumulusMX
 			ErrorLogSpikeRemoval = ini.GetValue("Station", "ErrorLogSpikeRemoval", true);
 			// this is now an index
 			DataLogInterval = ini.GetValue("Station", "DataLogInterval", 2, 0, 5);
-#
+
 			FineOffsetOptions.SyncReads = ini.GetValue("Station", "SyncFOReads", true);
 			FineOffsetOptions.ReadAvoidPeriod = ini.GetValue("Station", "FOReadAvoidPeriod", 3, 0);
 			FineOffsetOptions.ReadTime = ini.GetValue("Station", "FineOffsetReadTime", 150, 0);

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -77,8 +77,8 @@
     <PackageReference Include="EmbedIO" Version="3.5.2" />
     <PackageReference Include="FluentFTP" Version="50.0.1" />
     <PackageReference Include="HidSharp" Version="2.1.0" />
-    <PackageReference Include="MailKit" Version="4.5.0" />
-    <PackageReference Include="MQTTnet" Version="4.3.4.1084" />
+    <PackageReference Include="MailKit" Version="4.6.0" />
+    <PackageReference Include="MQTTnet" Version="4.3.5.1141" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="ServiceStack.Text" Version="8.2.2" />
     <PackageReference Include="SSH.NET" Version="2024.0.0" />

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="FluentFTP.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageReference Include="NReco.Logging.File" Version="1.2.0" />
@@ -78,7 +78,7 @@
     <PackageReference Include="FluentFTP" Version="50.0.1" />
     <PackageReference Include="HidSharp" Version="2.1.0" />
     <PackageReference Include="MailKit" Version="4.6.0" />
-    <PackageReference Include="MQTTnet" Version="4.3.5.1141" />
+    <PackageReference Include="MQTTnet" Version="4.3.6.1152" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="ServiceStack.Text" Version="8.2.2" />
     <PackageReference Include="SSH.NET" Version="2024.0.0" />

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>4.000.2.4024</Version>
+    <Version>4.001.0.4024</Version>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
   </PropertyGroup>
 

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -78,7 +78,7 @@
     <PackageReference Include="FluentFTP" Version="50.0.1" />
     <PackageReference Include="HidSharp" Version="2.1.0" />
     <PackageReference Include="MailKit" Version="4.5.0" />
-    <PackageReference Include="MQTTnet" Version="4.3.3.952" />
+    <PackageReference Include="MQTTnet" Version="4.3.4.1084" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="ServiceStack.Text" Version="8.2.2" />
     <PackageReference Include="SSH.NET" Version="2024.0.0" />

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>4.000.1.4023</Version>
+    <Version>4.000.2.4024</Version>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
   </PropertyGroup>
 

--- a/CumulusMX/CustomLogs.cs
+++ b/CumulusMX/CustomLogs.cs
@@ -103,7 +103,7 @@ namespace CumulusMX
 						cumulus.CustomIntvlLogSettings[i].FileName = string.IsNullOrWhiteSpace(settings.interval[i].filename) ? null : settings.interval[i].filename.Trim();
 						cumulus.CustomIntvlLogSettings[i].ContentString = string.IsNullOrWhiteSpace(settings.interval[i].content) ? null : settings.interval[i].content.Replace("\n", "").Replace("\r", "").Trim();
 						cumulus.CustomIntvlLogSettings[i].IntervalIdx = settings.interval[i].intervalidx;
-						cumulus.CustomIntvlLogSettings[i].Interval = cumulus.FactorsOf60[settings.interval[i].intervalidx];
+						cumulus.CustomIntvlLogSettings[i].Interval = Cumulus.FactorsOf60[settings.interval[i].intervalidx];
 
 						if (null == cumulus.CustomIntvlLogSettings[i].FileName || null == cumulus.CustomIntvlLogSettings[i].ContentString)
 							cumulus.CustomIntvlLogSettings[i].Enabled = false;
@@ -116,7 +116,7 @@ namespace CumulusMX
 						cumulus.CustomIntvlLogSettings[i].FileName = null;
 						cumulus.CustomIntvlLogSettings[i].ContentString = null;
 						cumulus.CustomIntvlLogSettings[i].IntervalIdx = cumulus.DataLogInterval;
-						cumulus.CustomIntvlLogSettings[i].Interval = cumulus.FactorsOf60[cumulus.DataLogInterval];
+						cumulus.CustomIntvlLogSettings[i].Interval = Cumulus.FactorsOf60[cumulus.DataLogInterval];
 					}
 				}
 

--- a/CumulusMX/DavisAirLink.cs
+++ b/CumulusMX/DavisAirLink.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
-
-using Org.BouncyCastle.Utilities.Encoders;
 
 using ServiceStack;
 

--- a/CumulusMX/DavisAirLink.cs
+++ b/CumulusMX/DavisAirLink.cs
@@ -1337,9 +1337,9 @@ namespace CumulusMX
 						Cumulus.LogConsoleMessage($" - Found WeatherLink station id = {stn.station_id}, name = {stn.station_name}, active = {stn.active}");
 					}
 
-					if ((stn.station_id == cumulus.AirLinkInStationId || stn.station_id == cumulus.AirLinkOutStationId) && stn.recording_interval != cumulus.logints[cumulus.DataLogInterval])
+					if ((stn.station_id == cumulus.AirLinkInStationId || stn.station_id == cumulus.AirLinkOutStationId) && stn.recording_interval != Cumulus.logints[cumulus.DataLogInterval])
 					{
-						cumulus.LogWarningMessage($" - Cumulus log interval {cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {stn.recording_interval}");
+						cumulus.LogWarningMessage($" - Cumulus log interval {Cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {stn.recording_interval}");
 					}
 				}
 				if (stationsObj.stations.Count > 1)

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -15,7 +15,6 @@ namespace CumulusMX
 	internal partial class DavisCloudStation : WeatherStation
 	{
 		private readonly System.Timers.Timer tmrCurrent;
-		private bool savedCalculatePeakGust;
 		private int maxArchiveRuns = 1;
 		private int wlStationArchiveInterval = 5;
 		private readonly AutoResetEvent bwDoneEvent = new(false);
@@ -379,8 +378,6 @@ namespace CumulusMX
 				cumulus.LogErrorMessage("History: Archive reading thread apparently terminated with an error: " + e.Error.Message);
 			}
 			cumulus.NormalRunning = true;
-
-			CalcRecentMaxGust = savedCalculatePeakGust;
 
 			StartLoop();
 			DoDayResetIfNeeded();
@@ -3691,9 +3688,9 @@ namespace CumulusMX
 						cumulus.LogDebugMessage($"GetStations: Setting WLL parent ID = {station.gateway_id}");
 						cumulus.WllParentId = station.gateway_id;
 
-						if (station.recording_interval != cumulus.logints[cumulus.DataLogInterval])
+						if (station.recording_interval != Cumulus.logints[cumulus.DataLogInterval])
 						{
-							cumulus.LogWarningMessage($"GetStations: - Cumulus log interval {cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {station.recording_interval}");
+							cumulus.LogWarningMessage($"GetStations: - Cumulus log interval {Cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {station.recording_interval}");
 						}
 
 						wlStationArchiveInterval = station.recording_interval;

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -7,8 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Timers;
 
-using Org.BouncyCastle.Ocsp;
-
 using ServiceStack;
 
 

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -349,7 +349,7 @@ namespace CumulusMX
 			byte[] readBuffer = new byte[40];
 
 			// default the logger interval to the CMX interval - change it later if we find different
-			loggerInterval = cumulus.logints[cumulus.DataLogInterval];
+			loggerInterval = Cumulus.logints[cumulus.DataLogInterval];
 
 			// response should be (5 mins):
 			// ACK  VAL CKS1 CKS2
@@ -440,17 +440,17 @@ namespace CumulusMX
 
 			cumulus.LogDebugMessage($"CheckLoggerInterval: Station logger interval is {readBuffer[0]} minutes");
 
-			if (bytesRead > 0 && readBuffer[0] != cumulus.logints[cumulus.DataLogInterval])
+			if (bytesRead > 0 && readBuffer[0] != Cumulus.logints[cumulus.DataLogInterval])
 			{
 				// change the logger interval to the value we just discovered
 				loggerInterval = readBuffer[0];
-				var msg = $"** WARNING: Your station logger interval {loggerInterval} mins does not match your Cumulus MX logging interval {cumulus.logints[cumulus.DataLogInterval]} mins";
+				var msg = $"** WARNING: Your station logger interval {loggerInterval} mins does not match your Cumulus MX logging interval {Cumulus.logints[cumulus.DataLogInterval]} mins";
 				Cumulus.LogConsoleMessage(msg);
 				cumulus.LogWarningMessage("CheckLoggerInterval: " + msg);
 
 				if (cumulus.DavisOptions.SetLoggerInterval)
 				{
-					SetLoggerInterval(cumulus.logints[cumulus.DataLogInterval]);
+					SetLoggerInterval(Cumulus.logints[cumulus.DataLogInterval]);
 				}
 			}
 		}

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -3046,9 +3046,9 @@ namespace CumulusMX
 						cumulus.LogDebugMessage($"WLLStations: Setting WLL parent ID = {station.gateway_id}");
 						cumulus.WllParentId = station.gateway_id;
 
-						if (station.recording_interval != cumulus.logints[cumulus.DataLogInterval])
+						if (station.recording_interval != Cumulus.logints[cumulus.DataLogInterval])
 						{
-							cumulus.LogMessage($"WLLStations: - Cumulus log interval {cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {station.recording_interval}");
+							cumulus.LogMessage($"WLLStations: - Cumulus log interval {Cumulus.logints[cumulus.DataLogInterval]} does not match this WeatherLink stations log interval {station.recording_interval}");
 						}
 					}
 				}

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -1060,7 +1060,7 @@ namespace CumulusMX
 							if (sensorContactLost[data2.txid])
 							{
 								cumulus.LogWarningMessage($"Warning: Sensor contact restored TxId {data2.txid}");
-								sensorContactLost[data1.txid] = false;
+								sensorContactLost[data2.txid] = false;
 							}
 
 							// For leaf wetness, soil temp/moisture we rely on user configuration, trap any errors

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -42,6 +42,7 @@ namespace CumulusMX
 		private readonly AutoResetEvent bwDoneEvent = new(false);
 		private readonly List<WlSensor> sensorList = [];
 		private readonly bool useWeatherLinkDotCom = true;
+		private readonly bool[] sensorContactLost = new bool[9];
 
 		public DavisWllStation(Cumulus cumulus) : base(cumulus)
 		{
@@ -694,8 +695,18 @@ namespace CumulusMX
 							if (data1.rx_state == 2)
 							{
 								localSensorContactLost = true;
-								cumulus.LogWarningMessage($"Warning: Sensor contact lost TxId {data1.txid}; ignoring data from this ISS");
+								if (!sensorContactLost[data1.txid])
+								{
+									cumulus.LogWarningMessage($"Warning: Sensor contact lost TxId {data1.txid}; ignoring data from this ISS");
+									sensorContactLost[data1.txid] = true;
+								}
 								continue;
+							}
+
+							if (sensorContactLost[data1.txid])
+							{
+								cumulus.LogWarningMessage($"Warning: Sensor contact restored TxId {data1.txid}");
+								sensorContactLost[data1.txid] = false;
 							}
 
 
@@ -1038,8 +1049,18 @@ namespace CumulusMX
 							if (data2.rx_state == 2)
 							{
 								localSensorContactLost = true;
-								cumulus.LogWarningMessage($"Warning: Sensor contact lost TxId {data2.txid}; ignoring data from this Leaf/Soil transmitter");
+								if (!sensorContactLost[data2.txid])
+								{
+									cumulus.LogWarningMessage($"Warning: Sensor contact lost TxId {data2.txid}; ignoring data from this Leaf/Soil transmitter");
+									sensorContactLost[data2.txid] = true;
+								}
 								continue;
+							}
+
+							if (sensorContactLost[data2.txid])
+							{
+								cumulus.LogWarningMessage($"Warning: Sensor contact restored TxId {data2.txid}");
+								sensorContactLost[data1.txid] = false;
 							}
 
 							// For leaf wetness, soil temp/moisture we rely on user configuration, trap any errors

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -599,12 +599,16 @@ namespace CumulusMX
 
 							if (buffer.TryGetValue(itemDate, out var value))
 							{
-								value.Pressure = item.Value;
+								// We have to request kPa values in hPa, so divide by 10
+								value.Pressure = cumulus.Units.Press == 3 ? item.Value / 10 : item.Value;
 							}
 							else
 							{
 								var newItem = new HistoricData()
-								{ Pressure = item.Value };
+								{
+									// We have to request kPa values in hPa, so divide by 10
+									Pressure = cumulus.Units.Press == 3 ? item.Value / 10 : item.Value
+								};
 								buffer.Add(itemDate, newItem);
 							}
 						}
@@ -622,12 +626,16 @@ namespace CumulusMX
 
 							if (buffer.TryGetValue(itemDate, out var value))
 							{
-								value.StationPressure = item.Value;
+								// We have to request kPa values in hPa, so divide by 10
+								value.StationPressure = cumulus.Units.Press == 3 ? item.Value / 10 : item.Value;
 							}
 							else
 							{
 								var newItem = new HistoricData()
-								{ StationPressure = item.Value };
+								{
+									// We have to request kPa values in hPa, so divide by 10
+									StationPressure = cumulus.Units.Press == 3 ? item.Value / 10 : item.Value
+								};
 								buffer.Add(itemDate, newItem);
 							}
 						}

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using ServiceStack;
 using ServiceStack.Text;
 
-using static System.Collections.Specialized.BitVector32;
 
 namespace CumulusMX
 {

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -1769,6 +1769,7 @@ namespace CumulusMX
 				if (rec.Value.AqiComboPm25.HasValue)
 				{
 					station.CO2_pm2p5 = (double) rec.Value.AqiComboPm25.Value;
+					station.CO2_pm2p5_aqi = station.GetAqi(WeatherStation.AqMeasure.pm2p5, station.CO2_pm2p5);
 				}
 			}
 			catch (Exception ex)
@@ -1782,6 +1783,8 @@ namespace CumulusMX
 				if (rec.Value.AqiComboPm10.HasValue)
 				{
 					station.CO2_pm10 = (double) rec.Value.AqiComboPm10.Value;
+					station.CO2_pm10_aqi = station.GetAqi(WeatherStation.AqMeasure.pm10, station.CO2_pm10);
+
 				}
 			}
 			catch (Exception ex)

--- a/CumulusMX/EcowittCloudStation.cs
+++ b/CumulusMX/EcowittCloudStation.cs
@@ -992,12 +992,14 @@ namespace CumulusMX
 			{
 				station.CO2_pm2p5 = data.pm25_aqi_combo.pm25.value;
 				//station.CO2_pm2p5_24h = data.pm25_aqi_combo.AqiAvg24h.value;
+				station.CO2_pm2p5_aqi = station.GetAqi(WeatherStation.AqMeasure.pm2p5, station.CO2_pm2p5);
 			}
 
 			if (data.pm10_aqi_combo != null)
 			{
 				station.CO2_pm10 = data.pm10_aqi_combo.pm10.value;
 				//station.CO2_pm10_24h = data.pm10_aqi_combo.AqiAvg24h.value;
+				station.CO2_pm10_aqi = station.GetAqi(WeatherStation.AqMeasure.pm10, station.CO2_pm10);
 			}
 
 			if (data.t_rh_aqi_combo != null)

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -89,19 +89,19 @@ namespace CumulusMX
 					{
 						int logint = data[0];
 
-						if (logint != cumulus.logints[cumulus.DataLogInterval])
+						if (logint != Cumulus.logints[cumulus.DataLogInterval])
 						{
-							var msg = $"Warning, your console logging interval ({logint} mins) does not match the Cumulus logging interval ({cumulus.logints[cumulus.DataLogInterval]} mins)";
+							var msg = $"Warning, your console logging interval ({logint} mins) does not match the Cumulus logging interval ({Cumulus.logints[cumulus.DataLogInterval]} mins)";
 							Cumulus.LogConsoleMessage(msg);
 							cumulus.LogWarningMessage(msg);
 							if (cumulus.FineOffsetOptions.SetLoggerInterval)
 							{
 								var retries = 2;
 
-								cumulus.LogMessage($"Attempting to set console logging interval to {cumulus.logints[cumulus.DataLogInterval]} mins");
+								cumulus.LogMessage($"Attempting to set console logging interval to {Cumulus.logints[cumulus.DataLogInterval]} mins");
 								do
 								{
-									WriteAddress(0x10, (byte) cumulus.logints[cumulus.DataLogInterval]); // write the logging new logging interval
+									WriteAddress(0x10, (byte) Cumulus.logints[cumulus.DataLogInterval]); // write the logging new logging interval
 									WriteAddress(0x1A, 0xAA); // tell the station to read the new parameter
 
 									int readAttempts = 3;
@@ -111,13 +111,13 @@ namespace CumulusMX
 										Thread.Sleep(1000);  // sleep to let it reconfigure
 										ReadAddress(0x10, data);
 										readAttempts--;
-									} while (data[0] != cumulus.logints[cumulus.DataLogInterval] && readAttempts >= 0);
+									} while (data[0] != Cumulus.logints[cumulus.DataLogInterval] && readAttempts >= 0);
 
 
 									retries--;
-								} while (data[0] != cumulus.logints[cumulus.DataLogInterval] && retries >= 0);
+								} while (data[0] != Cumulus.logints[cumulus.DataLogInterval] && retries >= 0);
 
-								if (data[0] == cumulus.logints[cumulus.DataLogInterval])
+								if (data[0] == Cumulus.logints[cumulus.DataLogInterval])
 								{
 									cumulus.LogMessage("Successfully set new logging interval");
 								}
@@ -249,7 +249,7 @@ namespace CumulusMX
 				if (datalist.Count == 0)
 				{
 					// number of ticks in a logging interval
-					var intTicks = TimeSpan.FromMinutes(cumulus.logints[cumulus.DataLogInterval]).Ticks;
+					var intTicks = TimeSpan.FromMinutes(Cumulus.logints[cumulus.DataLogInterval]).Ticks;
 					// date/time of the last log interval
 					var lastLogInterval = new DateTime((DateTime.Now.Ticks / intTicks) * intTicks);
 					// which log interval does this data belong to, the last or the one before that?

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -1741,6 +1741,11 @@ namespace CumulusMX
 				batteryLow = batt == "Low";
 				msg += $", Battery={batt}";
 				cumulus.LogDebugMessage(msg);
+
+				CO2_pm2p5_aqi = GetAqi(AqMeasure.pm2p5, CO2_pm2p5);
+				CO2_pm2p5_24h_aqi = GetAqi(AqMeasure.pm2p5h24, CO2_pm2p5_24h);
+				CO2_pm10_aqi = GetAqi(AqMeasure.pm10, CO2_pm10);
+				CO2_pm10_24h_aqi = GetAqi(AqMeasure.pm10h24, CO2_pm10_24h);
 			}
 			catch (Exception ex)
 			{

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -556,7 +556,7 @@ namespace CumulusMX
 							var tempVal = ConvertUnits.TempFToUser(Convert.ToDouble(data["tempinf"], invNum));
 							DoIndoorTemp(tempVal);
 
-							// user has mapped indoor humidity to outdoor
+							// user has mapped indoor temperature to outdoor
 							if (cumulus.Gw1000PrimaryTHSensor == 99)
 							{
 								DoOutdoorTemp(tempVal, recDate);

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -294,7 +294,7 @@ namespace CumulusMX
 			/*
 			 * Ecowitt doc:
 			 *
-			POST Parameters - all fields are URL escaped
+			POST/GET Parameters - all fields are URL escaped
 
 			PASSKEY=<redacted>&stationtype=GW1000A_V1.6.8&dateutc=2021-07-23+17:13:34&tempinf=80.6&humidityin=50&baromrelin=29.940&baromabsin=29.081&tempf=81.3&humidity=43&winddir=296&windspeedmph=2.46&windgustmph=4.25&maxdailygust=14.09&solarradiation=226.28&uv=1&rainratein=0.000&eventrainin=0.000&hourlyrainin=0.000&dailyrainin=0.000&weeklyrainin=0.000&monthlyrainin=4.118&yearlyrainin=29.055&totalrainin=29.055&temp1f=83.48&humidity1=39&temp2f=87.98&humidity2=40&temp3f=82.04&humidity3=40&temp4f=93.56&humidity4=34&temp5f=-11.38&temp6f=87.26&humidity6=38&temp7f=45.50&humidity7=40&soilmoisture1=51&soilmoisture2=65&soilmoisture3=72&soilmoisture4=36&soilmoisture5=48&pm25_ch1=11.0&pm25_avg_24h_ch1=10.8&pm25_ch2=13.0&pm25_avg_24h_ch2=15.0&tf_co2=80.8&humi_co2=48&pm25_co2=4.8&pm25_24h_co2=6.1&pm10_co2=4.9&pm10_24h_co2=6.5&co2=493&co2_24h=454&lightning_time=1627039348&lightning_num=3&lightning=24&wh65batt=0&wh80batt=3.06&batt1=0&batt2=0&batt3=0&batt4=0&batt5=0&batt6=0&batt7=0&soilbatt1=1.5&soilbatt2=1.4&soilbatt3=1.5&soilbatt4=1.5&soilbatt5=1.6&pm25batt1=4&pm25batt2=4&wh57batt=4&co2_batt=6&freq=868M&model=GW1000_Pro
 			PASSKEY=<redacted>&stationtype=GW1100A_V2.0.2&dateutc=2021-09-08+11:58:39&tempinf=80.8&humidityin=42&baromrelin=29.864&baromabsin=29.415&temp1f=87.8&tf_ch1=64.4&batt1=0&tf_batt1=1.48&freq=868M&model=GW1100A
@@ -320,9 +320,21 @@ namespace CumulusMX
 				// freq
 				// model
 
-				cumulus.LogDebugMessage($"{procName}: Processing posted data");
+				string text = string.Empty;
 
-				var text = new StreamReader(context.Request.InputStream).ReadToEnd();
+
+				if (context.Request.HttpVerb == HttpVerbs.Post)
+				{
+					cumulus.LogDebugMessage($"{procName}: Processing POST data");
+					text = new StreamReader(context.Request.InputStream).ReadToEnd();
+				}
+				else
+				{
+					cumulus.LogDebugMessage($"{procName}: Processing GET data");
+					//remove /station/ecowitt[extra]?
+					text = context.Request.RawUrl[(context.Request.RawUrl.IndexOf('?') + 1)..];
+				}
+
 
 				cumulus.LogDataMessage($"{procName}: Payload = {PassKeyRegex().Replace(text, "PASSKEY=<PassKey>")}");
 

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -1266,18 +1266,23 @@ namespace CumulusMX
 			if (data["pm25_co2"] != null)
 			{
 				station.CO2_pm2p5 = Convert.ToDouble(data["pm25_co2"], invNum);
+				station.CO2_pm2p5_aqi = station.GetAqi(WeatherStation.AqMeasure.pm2p5, station.CO2_pm2p5);
 			}
 			if (data["pm25_24h_co2"] != null)
 			{
 				station.CO2_pm2p5_24h = Convert.ToDouble(data["pm25_24h_co2"], invNum);
+				station.CO2_pm2p5_24h_aqi = station.GetAqi(WeatherStation.AqMeasure.pm2p5h24, station.CO2_pm2p5_24h);
+
 			}
 			if (data["pm10_co2"] != null)
 			{
 				station.CO2_pm10 = Convert.ToDouble(data["pm10_co2"], invNum);
+				station.CO2_pm10_aqi = station.GetAqi(WeatherStation.AqMeasure.pm10, station.CO2_pm10);
 			}
 			if (data["pm10_24h_co2"] != null)
 			{
 				station.CO2_pm10_24h = Convert.ToDouble(data["pm10_24h_co2"], invNum);
+				station.CO2_pm10_24h_aqi = station.GetAqi(WeatherStation.AqMeasure.pm10h24, station.CO2_pm10_24h);
 			}
 			if (data["co2"] != null)
 			{

--- a/CumulusMX/HttpStationWund.cs
+++ b/CumulusMX/HttpStationWund.cs
@@ -469,11 +469,13 @@ namespace CumulusMX
 					if (str2 != null && str2 != "-9999")
 					{
 						CO2_pm2p5 = Convert.ToDouble(str2, CultureInfo.InvariantCulture);
+						CO2_pm2p5_aqi = GetAqi(AqMeasure.pm2p5, CO2_pm2p5);
 					}
 					var str10 = data["AqPM10"];
 					if (str10 != null && str10 != "-9999")
 					{
 						CO2_pm10 = Convert.ToDouble(str10, CultureInfo.InvariantCulture);
+						CO2_pm10_aqi = GetAqi(AqMeasure.pm10, CO2_pm10);
 					}
 				}
 				catch (Exception ex)

--- a/CumulusMX/ImetStation.cs
+++ b/CumulusMX/ImetStation.cs
@@ -53,7 +53,7 @@ namespace CumulusMX
 
 			if (comport.IsOpen)
 			{
-				ImetSetLoggerInterval(cumulus.logints[cumulus.DataLogInterval]);
+				ImetSetLoggerInterval(Cumulus.logints[cumulus.DataLogInterval]);
 				if (cumulus.StationOptions.SyncTime)
 				{
 					SetStationClock();
@@ -636,7 +636,7 @@ namespace CumulusMX
 									raindiff = raintotal - prevraintotal;
 								}
 
-								double rainrate = ConvertUnits.RainMMToUser((raindiff) * (60.0 / cumulus.logints[cumulus.DataLogInterval]));
+								double rainrate = ConvertUnits.RainMMToUser((raindiff) * (60.0 / Cumulus.logints[cumulus.DataLogInterval]));
 
 								DoRain(ConvertUnits.RainMMToUser(raintotal), rainrate, timestamp);
 
@@ -736,10 +736,10 @@ namespace CumulusMX
 				while (!stop)
 				{
 					ImetGetData();
-					if (cumulus.ImetLoggerInterval != cumulus.logints[cumulus.DataLogInterval])
+					if (cumulus.ImetLoggerInterval != Cumulus.logints[cumulus.DataLogInterval])
 					{
 						// logging interval has changed; update station to match
-						ImetSetLoggerInterval(cumulus.logints[cumulus.DataLogInterval]);
+						ImetSetLoggerInterval(Cumulus.logints[cumulus.DataLogInterval]);
 					}
 					else
 					{

--- a/CumulusMX/IniFile.cs
+++ b/CumulusMX/IniFile.cs
@@ -478,27 +478,42 @@ namespace CumulusMX
 			return DefaultValue;
 		}
 
-		internal int GetValue(string SectionName, string Key, int DefaultValue)
+		internal int GetValue(string SectionName, string Key, int DefaultValue, int MinValue = int.MinValue, int MaxValue = int.MaxValue)
 		{
 			string StringValue = GetValue(SectionName, Key, DefaultValue.ToString(CultureInfo.InvariantCulture));
 			int Value;
-			if (int.TryParse(StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out Value)) return Value;
+			if (int.TryParse(StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out Value))
+			{
+				if (Value < MinValue) return MinValue;
+				if (Value > MaxValue) return MaxValue;
+				return Value;
+			}
 			return DefaultValue;
 		}
 
-		internal double GetValue(string SectionName, string Key, double DefaultValue)
+		internal double GetValue(string SectionName, string Key, double DefaultValue, double MinValue = double.MinValue, double MaxValue = double.MaxValue)
 		{
 			string StringValue = GetValue(SectionName, Key, DefaultValue.ToString(CultureInfo.InvariantCulture));
 			double Value;
-			if (double.TryParse(StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out Value)) return Value;
+			if (double.TryParse(StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out Value))
+			{
+				if (Value < MinValue) return MinValue;
+				if (Value > MaxValue) return MaxValue;
+				return Value;
+			}
 			return DefaultValue;
 		}
 
-		internal decimal GetValue(string SectionName, string Key, decimal DefaultValue)
+		internal decimal GetValue(string SectionName, string Key, decimal DefaultValue, decimal MinValue = decimal.MinValue, decimal MaxValue = decimal.MaxValue)
 		{
 			string StringValue = GetValue(SectionName, Key, DefaultValue.ToString(CultureInfo.InvariantCulture));
 			decimal Value;
-			if (decimal.TryParse(StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out Value)) return Value;
+			if (decimal.TryParse(StringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out Value))
+			{
+				if (Value < MinValue) return MinValue;
+				if (Value > MaxValue) return MaxValue;
+				return Value;
+			}
 			return DefaultValue;
 		}
 

--- a/CumulusMX/JsonStation.cs
+++ b/CumulusMX/JsonStation.cs
@@ -1,0 +1,311 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using EmbedIO;
+
+using ServiceStack;
+using ServiceStack.Text;
+
+using static System.Net.Mime.MediaTypeNames;
+
+namespace CumulusMX
+{
+	internal class JsonStation : WeatherStation
+	{
+
+
+		public JsonStation(Cumulus cumulus) : base(cumulus)
+		{
+
+			// does not provide a forecast, force MX to provide it
+			cumulus.UseCumulusForecast = true;
+
+
+			// Let's decode the Unix ts to DateTime
+			JsConfig.Init(new Config
+			{
+				DateHandler = DateHandler.UnixTime
+			});
+		}
+
+
+		public override void Start()
+		{
+
+		}
+
+
+		public override void Stop()
+		{
+
+		}
+
+
+		private void GetDataFromFile()
+		{
+
+		}
+
+
+		public string GetDataFromApi(IHttpContext context, bool main)
+		{
+			cumulus.LogDebugMessage("GetDataFromApi: Processing POST data");
+			var text = new StreamReader(context.Request.InputStream).ReadToEnd();
+
+			cumulus.LogDataMessage($"GetDataFromApi: Payload = {text}");
+
+			var retVal = ApplyData(text);
+
+			if (retVal != "")
+			{
+				context.Response.StatusCode = 500;
+				return retVal;
+			}
+
+			cumulus.LogDebugMessage("GetDataFromApi: Complete");
+
+			context.Response.StatusCode = 200;
+			return "success";
+		}
+
+		private void GetDataFromMqtt()
+		{
+
+		}
+
+		private string ApplyData(string dataString)
+		{
+			var retStr = string.Empty;
+
+			var data = dataString.FromJson<DataObject>();
+
+			if (data == null)
+			{
+				cumulus.LogErrorMessage("ApplyData: Unable to convert data string to data. String = " + dataString);
+				return "Unable to convert data string to data.";
+			}
+
+			// Temperature
+			if (data.temperature != null && data.units != null)
+			{
+				if (data.units.temperature == null)
+				{
+					cumulus.LogErrorMessage("ApplyData: No temperature units supplied!");
+					retStr = "No temperature units\n";
+				}
+				else if (data.units.temperature == "C")
+				{
+					if (data.temperature.outdoor.HasValue)
+					{
+						DoOutdoorTemp(ConvertUnits.TempCToUser(data.temperature.outdoor.Value), data.lastupdated);
+					}
+					if (data.temperature.indoor.HasValue)
+					{
+						DoIndoorTemp(ConvertUnits.TempCToUser(data.temperature.indoor.Value));
+					}
+				}
+				else if (data.units.temperature == "F")
+				{
+					if (data.temperature.outdoor.HasValue)
+					{
+						DoOutdoorTemp(ConvertUnits.TempFToUser(data.temperature.outdoor.Value), data.lastupdated);
+					}
+					if (data.temperature.indoor.HasValue)
+					{
+						DoIndoorTemp(ConvertUnits.TempFToUser(data.temperature.indoor.Value));
+					}
+				}
+			}
+
+			// Humidity
+			if (data.humidity != null)
+			{
+				if (data.humidity.outdoor != null)
+				{
+					DoOutdoorHumidity(data.humidity.outdoor.Value, data.lastupdated);
+				}
+				if (data.humidity.indoor != null)
+				{
+					DoIndoorHumidity(data.humidity.indoor.Value);
+				}
+			}
+
+			// Wind
+			if (data.wind != null && data.units != null)
+			{
+				if (data.units.windspeed == null)
+				{
+					cumulus.LogErrorMessage("ApplyData: No windspeed units supplied!");
+					retStr += "No windspeed units\n";
+				}
+				else
+				{
+					var avg = data.wind.speed ?? -1;
+					var gust = data.wind.gust10m ?? -1;
+
+					if (gust < 0)
+					{
+						cumulus.LogErrorMessage("ApplyData: No gust value supplied in wind data");
+						retStr += "No gust value in wind data\n";
+					}
+					else
+					{
+						var doit = true;
+						switch (data.units.windspeed)
+						{
+							case "mph":
+								avg = ConvertUnits.WindMPHToUser(avg);
+								gust = ConvertUnits.WindMPHToUser(gust);
+								break;
+							case "ms":
+								avg = ConvertUnits.WindMSToUser(avg);
+								gust = ConvertUnits.WindMSToUser(gust);
+								break;
+							case "kph":
+								avg = ConvertUnits.WindKPHToUser(avg);
+								gust = ConvertUnits.WindKPHToUser(gust);
+								break;
+							default:
+								cumulus.LogErrorMessage("ApplyData: Invalid windspeed units supplied: " + data.units.windspeed);
+								retStr += "Invalid windspeed units\n";
+								doit = false;
+								break;
+						}
+
+						if (doit)
+						{
+							DoWind(gust, data.wind.direction ?? 0, avg, data.lastupdated);
+						}
+					}
+				}
+			}
+
+			// Rain
+
+
+			// Pressure
+
+
+			// Solar
+
+
+			// Extra Temp/Hums
+
+
+			// User Temps
+
+
+			// Soil Temps
+
+
+			// Soil Moistures
+
+
+			// Leaf Wetness
+
+
+			// Air Quality
+
+			return retStr;
+		}
+
+
+		private sealed class DataObject
+		{
+			public UnitsObject units { get; set; }
+			public DateTime timestamp { get; set; }
+			public DateTime lastupdated { get; set; }
+			public Temperature temperature { get; set; }
+			public Humidity humidity { get; set; }
+			public Wind wind { get; set; }
+			public Rain rain { get; set; }
+			public Pressure pressure { get; set; }
+			public Solar solar { get; set; }
+			public ExtraTempHum[] extratemp { get; set; }
+			public ExtraTemp[] usertemp { get; set; }
+			public ExtraTemp[] soiltemp { get; set; }
+			public ExtraValue[] soilmoisture { get; set; }
+			public ExtraValue[] leafwetness { get; set; }
+			public AirQuality airquality { get; set; }
+		}
+
+		private sealed class UnitsObject
+		{
+			public string temperature { get; set; }
+			public string windspeed { get; set; }
+			public string rainfall { get; set; }
+			public string pressure { get; set; }
+			public string soilmoisture { get; set;}
+		}
+
+		private sealed class Temperature
+		{
+			public double? outdoor { get; set; }
+			public double? indoor { get; set;}
+			public double? dewpoint { get; set; }
+		}
+		private sealed class Humidity
+		{
+			public int? outdoor { get; set; }
+			public int? indoor { get; set; }
+		}
+		private sealed class Wind
+		{
+			public double? speed { get; set; }
+			public int? direction { get; set; }
+			public double? gust10m { get; set;}
+		}
+		private sealed class Rain
+		{
+			public double? counter { get; set; }
+			public double? year { get; set; }
+			public double? rate { get; set; }
+		}
+		private sealed class Pressure
+		{
+			public double? absolute { get; set;}
+			public double? sealevel { get; set; }
+		}
+		private sealed class Solar
+		{
+			public double? irradiation { get; set; }
+			public double? uvi { get; set;}
+		}
+		private class ExtraTemp
+		{
+			public int index { get; set; }
+			public double? temperature { get; set; }
+		}
+		private sealed class ExtraTempHum : ExtraTemp
+		{
+			public int? humidity { get; set; }
+		}
+		private sealed class ExtraValue
+		{
+			public int index { get; set; }
+			public int? value { get; set; }
+		}
+		private sealed class AirQuality
+		{
+			public PM outdoor { get; set; }
+			public PM indoor { get; set; }
+			public CO2 CO2 { get; set; }
+		}
+		private class PM
+		{
+			public double? pm2p5 { get; set; }
+			public double? pm2p5avg24h { get; set; }
+			public double? pm10 { get; set; }
+			public double? pm10avg24h { get; set;}
+		}
+		private class CO2 : PM
+		{
+			public int? co2 { get; set; }
+			public int? co2_24h { get; set; }
+		}
+	}
+}

--- a/CumulusMX/JsonStation.cs
+++ b/CumulusMX/JsonStation.cs
@@ -760,24 +760,24 @@ namespace CumulusMX
 		}
 
 
+#pragma warning disable S3459,S1144 // Unused private types or members should be removed
 		private sealed class DataObject
 		{
 			public UnitsObject units { get; set; }
-			public DateTime timestamp { get; set; }
 			public DateTime lastupdated { get; set; }
 			public Temperature temperature { get; set; }
 			public Humidity humidity { get; set; }
 			public Wind wind { get; set; }
 			public Rain rain { get; set; }
-			public Pressure pressure { get; set; }
+			public PressureJson pressure { get; set; }
 			public Solar solar { get; set; }
 			public ExtraTempHum[] extratemp { get; set; }
-			public ExtraTemp[] usertemp { get; set; }
-			public ExtraTemp[] soiltemp { get; set; }
+			public ExtraTempJson[] usertemp { get; set; }
+			public ExtraTempJson[] soiltemp { get; set; }
 			public ExtraValue[] soilmoisture { get; set; }
 			public ExtraValue[] leafwetness { get; set; }
-			public PMdata[] airquality { get; set; }
-			public CO2data co2 { get; set; }
+			public PmData[] airquality { get; set; }
+			public Co2Data co2 { get; set; }
 		}
 
 		private sealed class UnitsObject
@@ -812,7 +812,7 @@ namespace CumulusMX
 			public double? year { get; set; }
 			public double? rate { get; set; }
 		}
-		private sealed class Pressure
+		private sealed class PressureJson
 		{
 			public double? absolute { get; set;}
 			public double? sealevel { get; set; }
@@ -822,12 +822,12 @@ namespace CumulusMX
 			public int? irradiation { get; set; }
 			public double? uvi { get; set;}
 		}
-		private class ExtraTemp
+		private class ExtraTempJson
 		{
 			public int index { get; set; }
 			public double? temperature { get; set; }
 		}
-		private sealed class ExtraTempHum : ExtraTemp
+		private sealed class ExtraTempHum : ExtraTempJson
 		{
 			public int? humidity { get; set; }
 		}
@@ -836,7 +836,7 @@ namespace CumulusMX
 			public int index { get; set; }
 			public int? value { get; set; }
 		}
-		private class PMdata
+		private class PmData
 		{
 			public int index { get; set; }
 			public double? pm2p5 { get; set; }
@@ -844,7 +844,7 @@ namespace CumulusMX
 			public double? pm10 { get; set; }
 			public double? pm10avg24h { get; set;}
 		}
-		private class CO2data : PMdata
+		private sealed class Co2Data : PmData
 		{
 			public int? co2 { get; set; }
 			public int? co2_24h { get; set; }

--- a/CumulusMX/JsonStation.cs
+++ b/CumulusMX/JsonStation.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 
 using EmbedIO;
 
+using Org.BouncyCastle.Ocsp;
+
 using ServiceStack;
 using ServiceStack.Text;
 
@@ -119,6 +121,11 @@ namespace CumulusMX
 						DoIndoorTemp(ConvertUnits.TempFToUser(data.temperature.indoor.Value));
 					}
 				}
+				else
+				{
+					cumulus.LogErrorMessage("ApplyData: Invalid temperature units supplied = " + data.units.temperature);
+					retStr = $"Invalid temperature units: {data.units.temperature}\n";
+				}
 			}
 
 			// Humidity
@@ -185,30 +192,286 @@ namespace CumulusMX
 			}
 
 			// Rain
+			if (data.rain != null && data.units != null)
+			{
+				var doit = true;
+				double counter = 0;
+				if (data.rain.counter.HasValue)
+				{
+					counter = data.rain.counter.Value;
+				}
+				else if (data.rain.year.HasValue)
+				{
+					counter = data.rain.year.Value;
+				}
+				else
+				{
+					cumulus.LogErrorMessage("ApplyData: No rainfall counter/year value supplied!");
+					retStr += "No rainfall counter/year value supplied\n";
+					doit = false;
+				}
 
+				if (doit)
+				{
+					if (data.units.rainfall == null)
+					{
+						cumulus.LogErrorMessage("ApplyData: No rainfall units supplied!");
+						retStr += "No rainfall units\n";
+					}
+					else if (data.units.rainfall == "mm")
+					{
+						var rate = ConvertUnits.RainMMToUser(data.rain.rate ?? 0);
+
+						if (data.rain.counter.HasValue)
+						{
+							DoRain(ConvertUnits.RainMMToUser(counter), rate, data.lastupdated);
+						}
+					}
+					else if (data.units.temperature == "in")
+					{
+						var rate = ConvertUnits.RainINToUser(data.rain.rate ?? 0);
+
+						if (data.rain.counter.HasValue)
+						{
+							DoRain(ConvertUnits.RainINToUser(counter), rate, data.lastupdated);
+						}
+					}
+					else
+					{
+						cumulus.LogErrorMessage("ApplyData: Invalid rainfall units supplied = " + data.units.rainfall);
+						retStr = $"Invalid rainfall units: {data.units.rainfall}\n";
+					}
+				}
+			}
 
 			// Pressure
+			if (data.pressure != null && data.units != null)
+			{
+				if (data.units.pressure == null)
+				{
+					cumulus.LogErrorMessage("ApplyData: No pressure units supplied!");
+					retStr += "No pressure units\n";
+				}
+				else
+				{
+					var slp = data.pressure.sealevel ?? -1;
+					var abs = data.pressure.absolute ?? -1;
+
+					if (slp < 0 && abs < 0)
+					{
+						cumulus.LogErrorMessage("ApplyData: No pressure values in data");
+						retStr += "No pressure values in data\n";
+					}
+					else
+					{
+						var doit = true;
+
+						if (cumulus.StationOptions.CalculateSLP && abs < 0)
+						{
+							cumulus.LogErrorMessage("ApplyData: Calculate SLP is enabled, but no abosolute pressure value in data");
+							retStr += "Calculate SLP is enabled, but no abosolute pressure value in data\n";
+						}
+						else
+						{
+							switch (data.units.pressure)
+							{
+								case "hPa":
+									slp = ConvertUnits.PressMBToUser(slp);
+									StationPressure = ConvertUnits.PressMBToUser(abs);
+									break;
+								case "inHg":
+									slp = ConvertUnits.PressINHGToUser(slp);
+									StationPressure = ConvertUnits.PressINHGToUser(abs);
+									break;
+								default:
+									cumulus.LogErrorMessage("ApplyData: Invalid windspeed units supplied: " + data.units.windspeed);
+									retStr += "Invalid windspeed units\n";
+									doit = false;
+									break;
+							}
+
+							StationPressure = cumulus.Calib.Press.Calibrate(StationPressure);
+
+							if (doit)
+							{
+								if (cumulus.StationOptions.CalculateSLP)
+								{
+									slp = MeteoLib.GetSeaLevelPressure(cumulus.Altitude, ConvertUnits.UserPressToHpa(StationPressure), OutdoorTemperature);
+									slp = ConvertUnits.PressMBToUser(slp);
+								}
+
+								DoPressure(slp, data.lastupdated);
+							}
+						}
+					}
+				}
+			}
 
 
 			// Solar
+			if (data.solar != null)
+			{
+				if (data.solar.irradiation != null)
+				{
+					DoSolarRad(data.solar.irradiation.Value, data.lastupdated);
+				}
 
+				if (data.solar.uvi != null)
+				{
+					DoUV(data.solar.uvi.Value, data.lastupdated);
+				}
+			}
 
 			// Extra Temp/Hums
+			if (data.extratemp != null && data.units != null)
+			{
+				if (data.units.temperature == null)
+				{
+					cumulus.LogErrorMessage("ApplyData: No temperature units supplied!");
+					retStr = "No temperature units\n";
+				}
+				else
+				{
+					foreach (var rec in data.extratemp)
+					{
+						try
+						{
+							if (rec.temperature.HasValue)
+							{
+								var temp = data.units.temperature == "C" ? ConvertUnits.TempCToUser(rec.temperature.Value) : ConvertUnits.TempFToUser(rec.temperature.Value);
+								DoExtraTemp(temp, rec.index);
+							}
 
+							if (rec.humidity.HasValue)
+							{
+								DoExtraHum(rec.humidity.Value, rec.index);
+							}
+						}
+						catch (Exception ex)
+						{
+							cumulus.LogExceptionMessage(ex, "ApplyData: Error processing Extra Temperature/Humidity");
+							retStr = "Error processing Extra Temperature/Humidity\n";
+						}
+					}
+				}
+			}
 
 			// User Temps
-
+			if (data.usertemp != null && data.units != null)
+			{
+				if (data.units.temperature == null)
+				{
+					cumulus.LogErrorMessage("ApplyData: No temperature units supplied!");
+					retStr = "No temperature units\n";
+				}
+				else
+				{
+					foreach (var rec in data.usertemp)
+					{
+						try
+						{
+							if (rec.temperature.HasValue)
+							{
+								var temp = data.units.temperature == "C" ? ConvertUnits.TempCToUser(rec.temperature.Value) : ConvertUnits.TempFToUser(rec.temperature.Value);
+								DoUserTemp(temp, rec.index);
+							}
+						}
+						catch (Exception ex)
+						{
+							cumulus.LogExceptionMessage(ex, "ApplyData: Error processing User Temperature");
+							retStr = "Error processing User Temperature\n";
+						}
+					}
+				}
+			}
 
 			// Soil Temps
-
+			if (data.soiltemp != null && data.units != null)
+			{
+				if (data.units.temperature == null)
+				{
+					cumulus.LogErrorMessage("ApplyData: No temperature units supplied!");
+					retStr = "No temperature units\n";
+				}
+				else
+				{
+					foreach (var rec in data.soiltemp)
+					{
+						try
+						{
+							if (rec.temperature.HasValue)
+							{
+								var temp = data.units.temperature == "C" ? ConvertUnits.TempCToUser(rec.temperature.Value) : ConvertUnits.TempFToUser(rec.temperature.Value);
+								DoSoilTemp(temp, rec.index);
+							}
+						}
+						catch (Exception ex)
+						{
+							cumulus.LogExceptionMessage(ex, "ApplyData: Error processing Soil Temperature");
+							retStr = "Error processing Soil Temperature\n";
+						}
+					}
+				}
+			}
 
 			// Soil Moistures
-
+			if (data.soilmoisture != null)
+			{
+				foreach (var rec in data.soilmoisture)
+				{
+					try
+					{
+						if (rec.value.HasValue)
+						{
+							DoSoilMoisture(rec.value.Value, rec.index);
+						}
+					}
+					catch (Exception ex)
+					{
+						cumulus.LogExceptionMessage(ex, "ApplyData: Error processing Soil Moisture");
+						retStr = "Error processing Soil Moisture\n";
+					}
+				}
+			}
 
 			// Leaf Wetness
-
+			if (data.leafwetness != null)
+			{
+				foreach (var rec in data.leafwetness)
+				{
+					try
+					{
+						if (rec.value.HasValue)
+						{
+							DoLeafWetness(rec.value.Value, rec.index);
+						}
+					}
+					catch (Exception ex)
+					{
+						cumulus.LogExceptionMessage(ex, "ApplyData: Error processing Leaf Wetness");
+						retStr = "Error processing Leaf Wetness\n";
+					}
+				}
+			}
 
 			// Air Quality
+			if (data.airquality != null)
+			{
+				if (data.airquality.outdoor != null)
+				{
+
+				}
+
+				if (data.airquality.indoor != null)
+				{
+
+				}
+
+				if (data.airquality.co2 != null)
+				{
+
+				}
+			}
 
 			return retStr;
 		}
@@ -272,7 +535,7 @@ namespace CumulusMX
 		}
 		private sealed class Solar
 		{
-			public double? irradiation { get; set; }
+			public int? irradiation { get; set; }
 			public double? uvi { get; set;}
 		}
 		private class ExtraTemp
@@ -293,7 +556,7 @@ namespace CumulusMX
 		{
 			public PM outdoor { get; set; }
 			public PM indoor { get; set; }
-			public CO2 CO2 { get; set; }
+			public CO2 co2 { get; set; }
 		}
 		private class PM
 		{

--- a/CumulusMX/JsonStationMqtt.cs
+++ b/CumulusMX/JsonStationMqtt.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using MQTTnet;
+using MQTTnet.Client;
+
+using Swan.Formatters;
+
+
+namespace CumulusMX
+{
+	public static class JsonStationMqtt
+	{
+		private static Cumulus cumulus;
+		private static JsonStation station;
+
+		private static IMqttClient mqttClient;
+
+		internal static void Setup(Cumulus cmx, JsonStation stn)
+		{
+			cumulus = cmx;
+			station = stn;
+
+			var mqttFactory = new MqttFactory();
+
+			/*
+			var protocolType = cumulus.MQTT.IpVersion switch
+			{
+				4 => System.Net.Sockets.ProtocolType.IPv4,
+				6 => System.Net.Sockets.ProtocolType.IPv6,
+				_ => System.Net.Sockets.ProtocolType.Unspecified,
+			};
+			*/
+
+			var options = new MqttClientOptionsBuilder()
+				.WithClientId(Guid.NewGuid().ToString())
+				.WithTcpServer(cumulus.JsonStationOptions.MqttServer, cumulus.JsonStationOptions.MqttPort)
+				//.WithProtocolType(protocolType)
+				.WithCredentials(string.IsNullOrEmpty(cumulus.JsonStationOptions.MqttPassword) ? null : new MqttClientCredentials(cumulus.JsonStationOptions.MqttUsername, System.Text.Encoding.UTF8.GetBytes(cumulus.JsonStationOptions.MqttPassword)))
+				.WithTlsOptions(
+					new MqttClientTlsOptions()
+					{
+						UseTls = cumulus.JsonStationOptions.MqttUseTls
+					}
+				)
+				.WithoutPacketFragmentation()
+				.WithCleanSession()
+				.Build();
+
+			mqttClient = (MqttClient) mqttFactory.CreateMqttClient();
+
+			Connect(options).Wait();
+
+			SubscribeTopic(cumulus.JsonStationOptions.MqttTopic).Wait();
+
+			mqttClient.DisconnectedAsync += (async e =>
+			{
+				var delay = 10.0;
+				do
+				{
+					cumulus.LogWarningMessage("Error: JSON Station MQTT disconnected from the server");
+					await Task.Delay(TimeSpan.FromSeconds(delay));
+
+					cumulus.LogDebugMessage("JSON Station MQTT attempting to reconnect with server");
+					try
+					{
+						Connect(options).Wait();
+						cumulus.LogDebugMessage("JSON Station MQTT reconnected OK");
+					}
+					catch
+					{
+						cumulus.LogErrorMessage("Error: JSON Station MQTT reconnection to server failed");
+					}
+
+					delay = Math.Round(delay * 1.5);
+				} while (!mqttClient.IsConnected);
+			});
+
+			mqttClient.ApplicationMessageReceivedAsync += e =>
+			{
+				station.ReceiveDataFromMqtt(e.ApplicationMessage);
+
+				return Task.CompletedTask;
+			};
+		}
+
+
+		private static async Task SubscribeTopic(string topic)
+		{
+			cumulus.LogMessage("JSON Station: Waiting to receive data from MQTT topic = " + topic);
+			await mqttClient.SubscribeAsync(topic);
+		}
+
+
+		private static async Task Connect(MQTTnet.Client.MqttClientOptions options)
+		{
+			try
+			{
+				cumulus.LogMessage("JSON Station: Connecting to MQTT server = " + cumulus.JsonStationOptions.MqttServer);
+				await mqttClient.ConnectAsync(options, CancellationToken.None);
+			}
+			catch (Exception e)
+			{
+				cumulus.LogErrorMessage("JSON MQTT Error: failed to connect to the host");
+				cumulus.LogMessage(e.Message);
+			}
+		}
+
+		public static void Disconnect()
+		{
+			mqttClient.DisconnectAsync().Wait();
+			mqttClient.Dispose();
+		}
+	}
+}

--- a/CumulusMX/JsonStationMqtt.cs
+++ b/CumulusMX/JsonStationMqtt.cs
@@ -5,8 +5,6 @@ using System.Threading.Tasks;
 using MQTTnet;
 using MQTTnet.Client;
 
-using Swan.Formatters;
-
 
 namespace CumulusMX
 {
@@ -34,7 +32,7 @@ namespace CumulusMX
 			*/
 
 			var options = new MqttClientOptionsBuilder()
-				.WithClientId(Guid.NewGuid().ToString())
+				.WithClientId("CumulusMXJsonStn" + cumulus.wsPort)
 				.WithTcpServer(cumulus.JsonStationOptions.MqttServer, cumulus.JsonStationOptions.MqttPort)
 				//.WithProtocolType(protocolType)
 				.WithCredentials(string.IsNullOrEmpty(cumulus.JsonStationOptions.MqttPassword) ? null : new MqttClientCredentials(cumulus.JsonStationOptions.MqttUsername, System.Text.Encoding.UTF8.GetBytes(cumulus.JsonStationOptions.MqttPassword)))

--- a/CumulusMX/MysqlSettings.cs
+++ b/CumulusMX/MysqlSettings.cs
@@ -314,9 +314,9 @@ namespace CumulusMX
 						{
 							cumulus.MySqlSettings.CustomMins.Commands[i] = String.IsNullOrWhiteSpace(settings.customminutes.entries[i].command) ? null : settings.customminutes.entries[i].command.Trim();
 							cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] = settings.customminutes.entries[i].intervalidx;
-							if (cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] >= 0 && cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] < cumulus.FactorsOf60.Length)
+							if (cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] >= 0 && cumulus.MySqlSettings.CustomMins.IntervalIndexes[i] < Cumulus.FactorsOf60.Length)
 							{
-								cumulus.MySqlSettings.CustomMins.Intervals[i] = cumulus.FactorsOf60[cumulus.MySqlSettings.CustomMins.IntervalIndexes[i]];
+								cumulus.MySqlSettings.CustomMins.Intervals[i] = Cumulus.FactorsOf60[cumulus.MySqlSettings.CustomMins.IntervalIndexes[i]];
 							}
 							else
 							{

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -1170,6 +1170,10 @@ namespace CumulusMX
 								cumulus.Limit.PressHigh = ConvertUnits.UserPressToIN(cumulus.Limit.PressHigh);
 								cumulus.Limit.PressLow = ConvertUnits.UserPressToIN(cumulus.Limit.PressLow);
 								break;
+							case 3:
+								cumulus.Limit.PressHigh = ConvertUnits.UserPressToKpa(cumulus.Limit.PressHigh);
+								cumulus.Limit.PressLow = ConvertUnits.UserPressToKpa(cumulus.Limit.PressLow);
+								break;
 						}
 						cumulus.Units.Press = settings.general.units.pressure;
 						cumulus.ChangePressureUnits();

--- a/CumulusMX/ThirdParty/WebUploadAwekas.cs
+++ b/CumulusMX/ThirdParty/WebUploadAwekas.cs
@@ -38,7 +38,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage("AWEKAS: Not uploading, " + reason);
+				cumulus.LogDebugMessage("AWEKAS: Not uploading, " + reason);
 				return;
 			}
 

--- a/CumulusMX/ThirdParty/WebUploadAwekas.cs
+++ b/CumulusMX/ThirdParty/WebUploadAwekas.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Net;
-using System.Net.Http;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Timers;
 

--- a/CumulusMX/ThirdParty/WebUploadAwekas.cs
+++ b/CumulusMX/ThirdParty/WebUploadAwekas.cs
@@ -245,6 +245,9 @@ namespace CumulusMX.ThirdParty
 				case 2:
 					threeHourlyPressureChangeMb = station.presstrendval * 3 / 0.0295333727;
 					break;
+				case 3:
+					threeHourlyPressureChangeMb = station.presstrendval * 30;
+					break;
 			}
 
 			if (threeHourlyPressureChangeMb > 6) presstrend = 2;

--- a/CumulusMX/ThirdParty/WebUploadOWM.cs
+++ b/CumulusMX/ThirdParty/WebUploadOWM.cs
@@ -77,7 +77,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage("OpenWeatherMap: Not uploading, " + reason);
+				cumulus.LogDebugMessage("OpenWeatherMap: Not uploading, " + reason);
 				return;
 			}
 

--- a/CumulusMX/ThirdParty/WebUploadPWS.cs
+++ b/CumulusMX/ThirdParty/WebUploadPWS.cs
@@ -19,7 +19,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage("PWS: Not uploading, " + reason);
+				cumulus.LogDebugMessage("PWS: Not uploading, " + reason);
 				return;
 			}
 

--- a/CumulusMX/ThirdParty/WebUploadWCloud.cs
+++ b/CumulusMX/ThirdParty/WebUploadWCloud.cs
@@ -16,7 +16,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage("WeatherCloud: Not uploading, " + reason);
+				cumulus.LogDebugMessage("WeatherCloud: Not uploading, " + reason);
 				return;
 			}
 

--- a/CumulusMX/ThirdParty/WebUploadWindGuru.cs
+++ b/CumulusMX/ThirdParty/WebUploadWindGuru.cs
@@ -19,7 +19,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage("WindGuru: Not uploading, " + reason);
+				cumulus.LogDebugMessage("WindGuru: Not uploading, " + reason);
 				return;
 			}
 

--- a/CumulusMX/ThirdParty/WebUploadWindy.cs
+++ b/CumulusMX/ThirdParty/WebUploadWindy.cs
@@ -17,7 +17,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage("Windy: Not uploading, " + reason);
+				cumulus.LogDebugMessage("Windy: Not uploading, " + reason);
 				return;
 			}
 

--- a/CumulusMX/ThirdParty/WebUploadWow.cs
+++ b/CumulusMX/ThirdParty/WebUploadWow.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Globalization;
 using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -22,7 +20,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage("WOW: Not uploading, " + reason);
+				cumulus.LogDebugMessage("WOW: Not uploading, " + reason);
 				return;
 			}
 

--- a/CumulusMX/ThirdParty/WebUploadWund.cs
+++ b/CumulusMX/ThirdParty/WebUploadWund.cs
@@ -40,7 +40,7 @@ namespace CumulusMX.ThirdParty
 			{
 				// No data coming in, do not do anything
 				var reason = Updating ? "previous upload still in progress" : "data stopped condition";
-				cumulus.LogWarningMessage($"Wunderground: {(RapidFireEnabled ? "RapidFire " : string.Empty)}Not uploading, {reason}");
+				cumulus.LogDebugMessage($"Wunderground: {(RapidFireEnabled ? "RapidFire " : string.Empty)}Not uploading, {reason}");
 				return;
 			}
 

--- a/CumulusMX/ThirdPartySettings.cs
+++ b/CumulusMX/ThirdPartySettings.cs
@@ -309,9 +309,9 @@ namespace CumulusMX
 						}
 
 						cumulus.CustomHttpMinutesIntervalIndex = settings.customhttp.customminutes.intervalindex;
-						if (cumulus.CustomHttpMinutesIntervalIndex >= 0 && cumulus.CustomHttpMinutesIntervalIndex < cumulus.FactorsOf60.Length)
+						if (cumulus.CustomHttpMinutesIntervalIndex >= 0 && cumulus.CustomHttpMinutesIntervalIndex < Cumulus.FactorsOf60.Length)
 						{
-							cumulus.CustomHttpMinutesInterval = cumulus.FactorsOf60[cumulus.CustomHttpMinutesIntervalIndex];
+							cumulus.CustomHttpMinutesInterval = Cumulus.FactorsOf60[cumulus.CustomHttpMinutesIntervalIndex];
 						}
 						else
 						{

--- a/CumulusMX/Utils.cs
+++ b/CumulusMX/Utils.cs
@@ -7,7 +7,6 @@ using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 using ServiceStack;

--- a/CumulusMX/Utils.cs
+++ b/CumulusMX/Utils.cs
@@ -227,15 +227,15 @@ namespace CumulusMX
 		}
 
 
-		public static void RunExternalTask(string task, string parameters, bool wait, bool redirectError = false)
+		public static void RunExternalTask(string task, string parameters, bool wait, bool redirectError = false, bool createwindow = false)
 		{
 			var process = new System.Diagnostics.Process();
 			process.StartInfo.FileName = task;
 			process.StartInfo.Arguments = parameters;
 			process.StartInfo.UseShellExecute = false;
 			process.StartInfo.RedirectStandardError = redirectError;
-			process.StartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
-			process.StartInfo.CreateNoWindow = true;
+			process.StartInfo.WindowStyle = createwindow ? System.Diagnostics.ProcessWindowStyle.Normal : System.Diagnostics.ProcessWindowStyle.Hidden;
+			process.StartInfo.CreateNoWindow = !createwindow;
 			process.Start();
 
 			if (wait)

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -13542,10 +13542,7 @@ namespace CumulusMX
 				tempSumYears0.Append(tempSum0 + "]");
 
 				// add to main json
-				sb.Append("\"Sum0\":" + tempSumYears0 + "}");
-
-				if (cumulus.GraphOptions.Visible.TempSum1.IsVisible(local) || cumulus.GraphOptions.Visible.TempSum2.IsVisible(local))
-					sb.Append(',');
+				sb.Append("\"Sum0\":" + tempSumYears0 + "},");
 			}
 			if (cumulus.GraphOptions.Visible.TempSum1.IsVisible(local))
 			{

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1840,7 +1840,7 @@ namespace CumulusMX
 					}
 
 
-					if (now.Minute % cumulus.logints[cumulus.DataLogInterval] == 0)
+					if (now.Minute % Cumulus.logints[cumulus.DataLogInterval] == 0)
 					{
 						_ = cumulus.DoLogFile(now, true);
 
@@ -2852,7 +2852,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = end ?? DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = end ?? DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start
@@ -2995,7 +2995,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = end ?? DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = end ?? DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start
@@ -3138,7 +3138,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = end ?? DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = end ?? DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start
@@ -3281,7 +3281,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = end ?? DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = end ?? DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start
@@ -3429,7 +3429,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = end ?? DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = end ?? DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start
@@ -3578,7 +3578,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = end ?? DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = end ?? DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start
@@ -3722,7 +3722,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = end ?? DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = end ?? DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start
@@ -3868,7 +3868,7 @@ namespace CumulusMX
 				dateFrom = DateTime.Now.AddHours(-cumulus.GraphHours);
 			}
 
-			var dateto = DateTime.Now.AddMinutes(-(cumulus.logints[cumulus.DataLogInterval] + 1));
+			var dateto = DateTime.Now.AddMinutes(-(Cumulus.logints[cumulus.DataLogInterval] + 1));
 			var fileDate = dateFrom;
 
 			// get the log file name to start

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1176,6 +1176,9 @@ namespace CumulusMX
 				case 2:
 					threeHourlyPressureChangeMb = presstrendval * 3 / 0.0295333727;
 					break;
+				case 3:
+					threeHourlyPressureChangeMb = presstrendval * 30;
+					break;
 			}
 
 			if (threeHourlyPressureChangeMb > 6) Presstrendstr = cumulus.Trans.Risingveryrapidly;

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -1665,7 +1665,7 @@ namespace CumulusMX
 			{
 				// if we already have an update queued, don't add to the wait queue. Otherwise we get hundreds queued up during catch-up
 				// Zero wait time for the ws lock object unless wait = true
-				if (!webSocketSemaphore.Wait(wait ? 0 : 600))
+				if (!await webSocketSemaphore.WaitAsync(wait ? 0 : 600))
 				{
 					cumulus.LogDebugMessage("sendWebSocketData: Update already running, skipping this one");
 					return;
@@ -5759,7 +5759,7 @@ namespace CumulusMX
 				cumulus.LogWarningMessage($"     New values:  RaindayStart = {RainCounterDayStart}, MidnightRainCount = {MidnightRainCount}, Raincounter = {RainCounter}");
 
 				// update any data in the recent data db
-				var counterChange = RainCounter - prevraincounter;
+				//var counterChange = RainCounter - prevraincounter
 				RecentDataDb.Execute("update RecentData set raincounter=raincounter-?", counterLost);
 
 			}

--- a/CumulusMX/Wizard.cs
+++ b/CumulusMX/Wizard.cs
@@ -140,6 +140,18 @@ namespace CumulusMX
 				mac = cumulus.EcowittMacAddress
 			};
 
+			var jsonstn = new JsonJsonStation()
+			{
+				conntype = cumulus.JsonStationOptions.Connectiontype,
+				filename = cumulus.JsonStationOptions.SourceFile,
+				mqttserver = cumulus.JsonStationOptions.MqttServer,
+				mqttport = cumulus.JsonStationOptions.MqttPort,
+				mqttuser = cumulus.JsonStationOptions.MqttUsername,
+				mqttpass = cumulus.JsonStationOptions.MqttPassword,
+				mqtttopic = cumulus.JsonStationOptions.MqttTopic
+			};
+
+
 			var station = new JsonWizardStation()
 			{
 				stationtype = cumulus.StationType,
@@ -153,7 +165,8 @@ namespace CumulusMX
 				imet = imet,
 				wmr928 = wmr,
 				weatherflow = weatherflow,
-				ecowittapi = ecowittapi
+				ecowittapi = ecowittapi,
+				jsonstation = jsonstn
 			};
 
 			var copy = new JsonWizardInternetCopy()
@@ -713,6 +726,35 @@ namespace CumulusMX
 					context.Response.StatusCode = 500;
 				}
 
+				// JSON data input
+				try
+				{
+					if (settings.station.jsonstation != null)
+					{
+						cumulus.JsonStationOptions.Connectiontype = settings.station.jsonstation.conntype;
+						if (cumulus.JsonStationOptions.Connectiontype == 0)
+						{
+							cumulus.JsonStationOptions.SourceFile = settings.station.jsonstation.filename.Trim();
+						}
+						if (cumulus.JsonStationOptions.Connectiontype == 2)
+						{
+							cumulus.JsonStationOptions.MqttServer = string.IsNullOrWhiteSpace(settings.station.jsonstation.mqttserver) ? null : settings.station.jsonstation.mqttserver.Trim();
+							cumulus.JsonStationOptions.MqttPort = settings.station.jsonstation.mqttport;
+							cumulus.JsonStationOptions.MqttUsername = string.IsNullOrWhiteSpace(settings.station.jsonstation.mqttuser) ? null : settings.station.jsonstation.mqttuser.Trim();
+							cumulus.JsonStationOptions.MqttPassword = string.IsNullOrWhiteSpace(settings.station.jsonstation.mqttpass) ? null : settings.station.jsonstation.mqttpass.Trim();
+							cumulus.JsonStationOptions.MqttTopic = string.IsNullOrWhiteSpace(settings.station.jsonstation.mqtttopic) ? null : settings.station.jsonstation.mqtttopic.Trim();
+						}
+					}
+				}
+				catch (Exception ex)
+				{
+					var msg = "Error processing JSON Data Input settings: " + ex.Message;
+					cumulus.LogErrorMessage(msg);
+					errorMsg += msg + "\n\n";
+					context.Response.StatusCode = 500;
+				}
+
+
 
 				// Save the settings
 				cumulus.WriteIniFile();
@@ -794,6 +836,7 @@ namespace CumulusMX
 		public JsonStationSettingsWmr928 wmr928 { get; set; }
 		public JsonStationSettingsWeatherFlow weatherflow { get; set; }
 		public JsonStationSettingsEcowittApi ecowittapi { get; set; }
+		public JsonJsonStation jsonstation { get; set; }
 	}
 
 	internal class JsonWizardDavisVp

--- a/CumulusMX/Wizard.cs
+++ b/CumulusMX/Wizard.cs
@@ -424,6 +424,10 @@ namespace CumulusMX
 								cumulus.Limit.PressHigh = ConvertUnits.UserPressToIN(cumulus.Limit.PressHigh);
 								cumulus.Limit.PressLow = ConvertUnits.UserPressToIN(cumulus.Limit.PressLow);
 								break;
+							case 3:
+								cumulus.Limit.PressHigh = ConvertUnits.UserPressToKpa(cumulus.Limit.PressHigh);
+								cumulus.Limit.PressLow = ConvertUnits.UserPressToKpa(cumulus.Limit.PressLow);
+								break;
 						}
 						cumulus.Units.Press = settings.units.pressure;
 						cumulus.ChangePressureUnits();

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -4109,6 +4109,46 @@ namespace CumulusMX
 			return CheckRcDp(station.AirQualityAvg4, tagParams, cumulus.AirQualityDPlaces);
 		}
 
+		private string TagAirQualityIdx1(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityIdx1, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagAirQualityIdx2(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityIdx2, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagAirQualityIdx3(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityIdx3, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagAirQualityIdx4(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityIdx4, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagAirQualityAvgIdx1(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityAvgIdx1, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagAirQualityAvgIdx2(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityAvgIdx2, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagAirQualityAvgIdx3(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityAvgIdx3, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagAirQualityAvgIdx4(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.AirQualityAvgIdx4, tagParams, cumulus.AirQualityDPlaces);
+		}
+
 		private string TagCo2(Dictionary<string, string> tagParams)
 		{
 			return station.CO2.ToString();
@@ -4167,6 +4207,26 @@ namespace CumulusMX
 		private string TagCO2_pm4_24h(Dictionary<string, string> tagParams)
 		{
 			return CheckRcDp(station.CO2_pm4_24h, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagCO2_pm2p5_aqi(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.CO2_pm2p5_aqi, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagCO2_pm2p5_24h_aqi(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.CO2_pm2p5_24h_aqi, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagCO2_pm10_aqi(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.CO2_pm10_aqi, tagParams, cumulus.AirQualityDPlaces);
+		}
+
+		private string TagCO2_pm10_24h_aqi(Dictionary<string, string> tagParams)
+		{
+			return CheckRcDp(station.CO2_pm10_24h_aqi, tagParams, cumulus.AirQualityDPlaces);
 		}
 
 		private string TagLeakSensor1(Dictionary<string, string> tagParams)
@@ -6263,6 +6323,14 @@ namespace CumulusMX
 				{ "AirQualityAvg2", TagAirQualityAvg2 },
 				{ "AirQualityAvg3", TagAirQualityAvg3 },
 				{ "AirQualityAvg4", TagAirQualityAvg4 },
+				{ "AirQualityIdx1", TagAirQualityIdx1 },
+				{ "AirQualityIdx2", TagAirQualityIdx2 },
+				{ "AirQualityIdx3", TagAirQualityIdx3 },
+				{ "AirQualityIdx4", TagAirQualityIdx4 },
+				{ "AirQualityAvgIdx1", TagAirQualityAvgIdx1 },
+				{ "AirQualityAvgIdx2", TagAirQualityAvgIdx2 },
+				{ "AirQualityAvgIdx3", TagAirQualityAvgIdx3 },
+				{ "AirQualityAvgIdx4", TagAirQualityAvgIdx4 },
 				{ "CO2", TagCo2 },
 				{ "CO2_24h", TagCO2_24h },
 				{ "CO2_pm2p5", TagCO2_pm2p5 },
@@ -6275,6 +6343,10 @@ namespace CumulusMX
 				{ "CO2_pm1_24h", TagCO2_pm1_24h },
 				{ "CO2_pm4", TagCO2_pm4 },
 				{ "CO2_pm4_24h", TagCO2_pm4_24h },
+				{ "CO2_pm2p5_aqi", TagCO2_pm2p5_aqi },
+				{ "CO2_pm2p5_24h_aqi", TagCO2_pm2p5_24h_aqi },
+				{ "CO2_pm10_aqi", TagCO2_pm10_aqi },
+				{ "CO2_pm10_24_aqih", TagCO2_pm10_24h_aqi },
 				{ "LeakSensor1", TagLeakSensor1 },
 				{ "LeakSensor2", TagLeakSensor2 },
 				{ "LeakSensor3", TagLeakSensor3 },

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,13 @@
+4.0.2 - b4024
+—————————————
+New
+Changed
+- New MQTT version
+
+Fixed
+- Temperature Sum graph data when Sum0 is the only selected range
+
+
 4.0.1 - b4023
 —————————————
 New

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,6 +7,8 @@ Changed
 Fixed
 - Temperature Sum graph data when Sum0 is the only selected range
 - Fix #NewBuildAvailable and #NewBuildNumber web tags
+- Fix for Davis VP2 consoles losing todays rainfall on a full power cycle
+- Exception when enabling real-time FTP whilst running and FTP logging is enabled
 
 
 4.0.1 - b4023

--- a/Updates.txt
+++ b/Updates.txt
@@ -21,6 +21,9 @@ Fixed
 - Davis WLL now fires a single "sensor contact lost" warning message + contact restored
 - Fix for multiple realtime FTP log-ins being attempted in parallel
 
+Package Updates
+- MQTTnet
+- MailKit
 
 
 4.0.1 - b4023

--- a/Updates.txt
+++ b/Updates.txt
@@ -13,6 +13,7 @@ New
 		- Named file
 		- HTTP POST to http://[CMX_IP_Address]:8998/station/json
 		- MQTT using a named topic
+- Locale Strings now has settings for the default record date/time text
 
 
 Changed

--- a/Updates.txt
+++ b/Updates.txt
@@ -12,6 +12,8 @@ Fixed
 - Fix #NewBuildAvailable and #NewBuildNumber web tags
 - Fix for Davis VP2 consoles losing todays rainfall on a full power cycle
 - Exception when enabling real-time FTP whilst running and FTP logging is enabled
+- WLL now fires a single "sensor contact lost" warning message + contact restored
+
 
 
 4.0.1 - b4023

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,6 +6,7 @@ New
 	- New web tags:
 	<#AirQualityIdx1[-4]>, <#AirQualityAvgIdx1[-4]>
 	<#CO2_pm2p5_aqi>, <#CO2_pm2p5_24h_aqi>, <#CO2_pm10_aqi>, <#CO2_pm10_24_aqih>
+- Add new pressure units option of kilopascal (kPa)
 
 
 Changed

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,4 +1,4 @@
-4.0.2 - b4024
+4.1.0 - b4024
 —————————————
 New
 - HTTP (Ecowitt) station now accepts the data via a simple GET url as well as POST
@@ -7,11 +7,17 @@ New
 	<#AirQualityIdx1[-4]>, <#AirQualityAvgIdx1[-4]>
 	<#CO2_pm2p5_aqi>, <#CO2_pm2p5_24h_aqi>, <#CO2_pm10_aqi>, <#CO2_pm10_24_aqih>
 - Add new pressure units option of kilopascal (kPa)
+- New station type added: JSON Data Input, marked as "experimental" for now, but testing so far has been successful
+	- Accepts data in a JSON format defined in MXutils/WeatherStationInput.jsonc
+	- Input mechanism is via:
+		- Named file
+		- HTTP POST to http://[CMX_IP_Address]:8998/station/json
+		- MQTT using a named topic
 
 
 Changed
-- New MQTT version
-- Removed options for WOW catch-up, it isn't supported by WOW
+- Removed option for WOW catch-up, it isn't supported by WOW
+- Moved the log file header info files to the MXutils/fileheaders folder
 
 
 Fixed
@@ -21,6 +27,8 @@ Fixed
 - Exception when enabling real-time FTP whilst running and FTP logging is enabled
 - Davis WLL now fires a single "sensor contact lost" warning message + contact restored
 - Fix for multiple realtime FTP log-ins being attempted in parallel
+- Alarm actions errored if the action parameter field is empty
+
 
 Package Updates
 - MQTTnet

--- a/Updates.txt
+++ b/Updates.txt
@@ -12,7 +12,7 @@ Fixed
 - Fix #NewBuildAvailable and #NewBuildNumber web tags
 - Fix for Davis VP2 consoles losing todays rainfall on a full power cycle
 - Exception when enabling real-time FTP whilst running and FTP logging is enabled
-- WLL now fires a single "sensor contact lost" warning message + contact restored
+- Davis WLL now fires a single "sensor contact lost" warning message + contact restored
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -6,6 +6,7 @@ Changed
 
 Fixed
 - Temperature Sum graph data when Sum0 is the only selected range
+- Fix #NewBuildAvailable and #NewBuildNumber web tags
 
 
 4.0.1 - b4023

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,10 +2,16 @@
 —————————————
 New
 - HTTP (Ecowitt) station now accepts the data via a simple GET url as well as POST
+- Cumulus now calculates the AQi for Ecowitt PM and CO₂ sensors
+	- New web tags:
+	<#AirQualityIdx1[-4]>, <#AirQualityAvgIdx1[-4]>
+	<#CO2_pm2p5_aqi>, <#CO2_pm2p5_24h_aqi>, <#CO2_pm10_aqi>, <#CO2_pm10_24_aqih>
+
 
 Changed
 - New MQTT version
 - Removed options for WOW catch-up, it isn't supported by WOW
+
 
 Fixed
 - Temperature Sum graph data when Sum0 is the only selected range

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,6 +1,8 @@
 4.0.2 - b4024
 —————————————
 New
+- HTTP (Ecowitt) station now accepts the data via a simple GET url as well as POST
+
 Changed
 - New MQTT version
 - Removed options for WOW catch-up, it isn't supported by WOW

--- a/Updates.txt
+++ b/Updates.txt
@@ -13,6 +13,7 @@ Fixed
 - Fix for Davis VP2 consoles losing todays rainfall on a full power cycle
 - Exception when enabling real-time FTP whilst running and FTP logging is enabled
 - Davis WLL now fires a single "sensor contact lost" warning message + contact restored
+- Fix for multiple realtime FTP log-ins being attempted in parallel
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -34,6 +34,7 @@ Fixed
 Package Updates
 - MQTTnet
 - MailKit
+- BouncyCastle
 
 
 4.0.1 - b4023

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,6 +3,7 @@
 New
 Changed
 - New MQTT version
+- Removed options for WOW catch-up, it isn't supported by WOW
 
 Fixed
 - Temperature Sum graph data when Sum0 is the only selected range


### PR DESCRIPTION
New
- HTTP (Ecowitt) station now accepts the data via a simple GET url as well as POST
- Cumulus now calculates the AQi for Ecowitt PM and CO₂ sensors
	- New web tags:
	<#AirQualityIdx1[-4]>, <#AirQualityAvgIdx1[-4]>
	<#CO2_pm2p5_aqi>, <#CO2_pm2p5_24h_aqi>, <#CO2_pm10_aqi>, <#CO2_pm10_24_aqih>
- Add new pressure units option of kilopascal (kPa)
- New station type added: JSON Data Input, marked as "experimental" for now, but testing so far has been successful
	- Accepts data in a JSON format defined in MXutils/WeatherStationInput.jsonc
	- Input mechanism is via:
		- Named file
		- HTTP POST to http://[CMX_IP_Address]:8998/station/json
		- MQTT using a named topic
- Locale Strings now has settings for the default record date/time text


Changed
- Removed option for WOW catch-up, it isn't supported by WOW
- Moved the log file header info files to the MXutils/fileheaders folder


Fixed
- Temperature Sum graph data when Sum0 is the only selected range
- Fix #NewBuildAvailable and #NewBuildNumber web tags
- Fix for Davis VP2 consoles losing todays rainfall on a full power cycle
- Exception when enabling real-time FTP whilst running and FTP logging is enabled
- Davis WLL now fires a single "sensor contact lost" warning message + contact restored
- Fix for multiple realtime FTP log-ins being attempted in parallel
- Alarm actions errored if the action parameter field is empty


Package Updates
- MQTTnet
- MailKit
- BouncyCastle