### PR TITLE
4.1.2 - b4026

### DIFF
--- a/CumulusMX/ConvertUnits.cs
+++ b/CumulusMX/ConvertUnits.cs
@@ -115,6 +115,23 @@
 		}
 
 		/// <summary>
+		///  Converts wind supplied in knots to user units
+		/// </summary>
+		/// <param name="value">Wind in knots</param>
+		/// <returns>Wind in configured units</returns>
+		public static double WindKnotsToUser(double value)
+		{
+			return Program.cumulus.Units.Wind switch
+			{
+				0 => value * 0.5144444,
+				1 => value * 1.150779,
+				2 => value * 1.852,
+				3 => value,
+				_ => 0,
+			};
+		}
+
+		/// <summary>
 		///  Converts wind supplied in kph to user units
 		/// </summary>
 		/// <param name="value">Wind in kph</param>

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -11126,17 +11126,17 @@ namespace CumulusMX
 							if (FtpOptions.PhpCompression == "gzip")
 							{
 								using var zipped = new System.IO.Compression.GZipStream(ms, System.IO.Compression.CompressionMode.Compress, true);
-								await zipped.WriteAsync(byteData, 0, byteData.Length);
+								await zipped.WriteAsync(byteData, 0, byteData.Length, cancellationToken);
 							}
 							else if (FtpOptions.PhpCompression == "deflate")
 							{
 								using var zipped = new System.IO.Compression.DeflateStream(ms, System.IO.Compression.CompressionMode.Compress, true);
-								await zipped.WriteAsync(byteData, 0, byteData.Length);
+								await zipped.WriteAsync(byteData, 0, byteData.Length, cancellationToken);
 							}
 
 							ms.Position = 0;
 							byte[] compressed = new byte[ms.Length];
-							await ms.ReadAsync(compressed, 0, compressed.Length);
+							await ms.ReadAsync(compressed, 0, compressed.Length, cancellationToken);
 
 							outStream = new MemoryStream(compressed);
 							streamContent = new StreamContent(outStream);

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -8231,165 +8231,179 @@ namespace CumulusMX
 				if (!File.Exists(dirpath + DirectorySeparator + filename))
 				{
 					// create a zip archive file for the backup
-					using (FileStream zipFile = new FileStream(dirpath + DirectorySeparator + filename, FileMode.Create))
+					try
 					{
-						using ZipArchive archive = new ZipArchive(zipFile, ZipArchiveMode.Create);
-						try
+						using (FileStream zipFile = new FileStream(dirpath + DirectorySeparator + filename, FileMode.Create))
 						{
-							if (File.Exists(AlltimeIniFile))
-								archive.CreateEntryFromFile(AlltimeIniFile, alltimebackup);
-							if (File.Exists(MonthlyAlltimeIniFile))
-								archive.CreateEntryFromFile(MonthlyAlltimeIniFile, monthlyAlltimebackup);
-							if (File.Exists(DayFileName))
-								archive.CreateEntryFromFile(DayFileName, daybackup);
-							if (File.Exists(TodayIniFile))
-								archive.CreateEntryFromFile(TodayIniFile, todaybackup);
-							if (File.Exists(YesterdayFile))
-								archive.CreateEntryFromFile(YesterdayFile, yesterdaybackup);
-							if (File.Exists(LogFile))
-								archive.CreateEntryFromFile(LogFile, logbackup);
-							if (File.Exists(MonthIniFile))
-								archive.CreateEntryFromFile(MonthIniFile, monthbackup);
-							if (File.Exists(YearIniFile))
-								archive.CreateEntryFromFile(YearIniFile, yearbackup);
-							if (File.Exists("Cumulus.ini"))
-								archive.CreateEntryFromFile("Cumulus.ini", configbackup);
-							if (File.Exists("UniqueId.txt"))
-								archive.CreateEntryFromFile("UniqueId.txt", uniquebackup);
-							if (File.Exists("strings.ini"))
-								archive.CreateEntryFromFile("strings.ini", stringsbackup);
-						}
-						catch (Exception ex)
-						{
-							LogExceptionMessage(ex, "Backup: Error backing up the data files");
-						}
-
-						if (daily)
-						{
-							// for daily backup the db is in use, so use an online backup
+							using ZipArchive archive = new ZipArchive(zipFile, ZipArchiveMode.Create);
 							try
 							{
-								var backUpDest = dirpath + "cumulusmx.db";
-								var zipLocation = datafolder + "cumulusmx.db";
-								LogDebugMessage("Making backup copy of the database");
-								station.RecentDataDb.Backup(backUpDest);
-								LogDebugMessage("Completed backup copy of the database");
-
-								LogDebugMessage("Archiving backup copy of the database");
-								archive.CreateEntryFromFile(backUpDest, zipLocation);
-								LogDebugMessage("Completed backup copy of the database");
-
-								LogDebugMessage("Deleting backup copy of the database");
-								File.Delete(backUpDest);
-
-								backUpDest = dirpath + "diary.db";
-								zipLocation = datafolder + "diary.db";
-								LogDebugMessage("Making backup copy of the diary");
-								DiaryDB.Backup(backUpDest);
-								LogDebugMessage("Completed backup copy of the diary");
-
-								LogDebugMessage("Archiving backup copy of the diary");
-								archive.CreateEntryFromFile(backUpDest, zipLocation);
-								LogDebugMessage("Completed backup copy of the diary");
-
-								LogDebugMessage("Deleting backup copy of the diary");
-								File.Delete(backUpDest);
+								if (File.Exists(AlltimeIniFile))
+									archive.CreateEntryFromFile(AlltimeIniFile, alltimebackup);
+								if (File.Exists(MonthlyAlltimeIniFile))
+									archive.CreateEntryFromFile(MonthlyAlltimeIniFile, monthlyAlltimebackup);
+								if (File.Exists(DayFileName))
+									archive.CreateEntryFromFile(DayFileName, daybackup);
+								if (File.Exists(TodayIniFile))
+									archive.CreateEntryFromFile(TodayIniFile, todaybackup);
+								if (File.Exists(YesterdayFile))
+									archive.CreateEntryFromFile(YesterdayFile, yesterdaybackup);
+								if (File.Exists(LogFile))
+									archive.CreateEntryFromFile(LogFile, logbackup);
+								if (File.Exists(MonthIniFile))
+									archive.CreateEntryFromFile(MonthIniFile, monthbackup);
+								if (File.Exists(YearIniFile))
+									archive.CreateEntryFromFile(YearIniFile, yearbackup);
+								if (File.Exists("Cumulus.ini"))
+									archive.CreateEntryFromFile("Cumulus.ini", configbackup);
+								if (File.Exists("UniqueId.txt"))
+									archive.CreateEntryFromFile("UniqueId.txt", uniquebackup);
+								if (File.Exists("strings.ini"))
+									archive.CreateEntryFromFile("strings.ini", stringsbackup);
 							}
 							catch (Exception ex)
 							{
-								LogExceptionMessage(ex, "Error making db backup");
+								LogExceptionMessage(ex, "Backup: Error backing up the data files");
 							}
-						}
-						else
-						{
-							// start-up backup - the db is not yet in use, do a file copy including any recovery files
+
+							if (daily)
+							{
+								// for daily backup the db is in use, so use an online backup
+								try
+								{
+									var backUpDest = dirpath + "cumulusmx.db";
+									var zipLocation = datafolder + "cumulusmx.db";
+									LogDebugMessage("Making backup copy of the database");
+									station.RecentDataDb.Backup(backUpDest);
+									LogDebugMessage("Completed backup copy of the database");
+
+									LogDebugMessage("Archiving backup copy of the database");
+									archive.CreateEntryFromFile(backUpDest, zipLocation);
+									LogDebugMessage("Completed backup copy of the database");
+
+									LogDebugMessage("Deleting backup copy of the database");
+									File.Delete(backUpDest);
+
+									backUpDest = dirpath + "diary.db";
+									zipLocation = datafolder + "diary.db";
+									LogDebugMessage("Making backup copy of the diary");
+									DiaryDB.Backup(backUpDest);
+									LogDebugMessage("Completed backup copy of the diary");
+
+									LogDebugMessage("Archiving backup copy of the diary");
+									archive.CreateEntryFromFile(backUpDest, zipLocation);
+									LogDebugMessage("Completed backup copy of the diary");
+
+									LogDebugMessage("Deleting backup copy of the diary");
+									File.Delete(backUpDest);
+								}
+								catch (Exception ex)
+								{
+									LogExceptionMessage(ex, "Error making db backup");
+								}
+							}
+							else
+							{
+								// start-up backup - the db is not yet in use, do a file copy including any recovery files
+								try
+								{
+									LogDebugMessage("Archiving the database");
+									if (File.Exists(dbfile))
+										archive.CreateEntryFromFile(dbfile, dbBackup);
+
+									if (File.Exists(dbfile + "-journal"))
+										archive.CreateEntryFromFile(dbfile + "-journal", dbBackup + "-journal");
+
+									if (File.Exists(diaryfile))
+										archive.CreateEntryFromFile(diaryfile, diarybackup);
+
+									if (File.Exists(diaryfile + "-journal"))
+										archive.CreateEntryFromFile(diaryfile + "-journal", diarybackup + "-journal");
+
+									LogDebugMessage("Completed archive of the database");
+								}
+								catch (Exception ex)
+								{
+									LogExceptionMessage(ex, "Backup: Error backing up the database files");
+								}
+							}
+
 							try
 							{
-								LogDebugMessage("Archiving the database");
-								if (File.Exists(dbfile))
-									archive.CreateEntryFromFile(dbfile, dbBackup);
+								if (File.Exists(extraFile))
+									archive.CreateEntryFromFile(extraFile, extraBackup);
+								if (File.Exists(AirLinkFile))
+									archive.CreateEntryFromFile(AirLinkFile, AirLinkBackup);
 
-								if (File.Exists(dbfile + "-journal"))
-									archive.CreateEntryFromFile(dbfile + "-journal", dbBackup + "-journal");
-
-								if (File.Exists(diaryfile))
-									archive.CreateEntryFromFile(diaryfile, diarybackup);
-
-								if (File.Exists(diaryfile + "-journal"))
-									archive.CreateEntryFromFile(diaryfile + "-journal", diarybackup + "-journal");
-
-								LogDebugMessage("Completed archive of the database");
-							}
-							catch (Exception ex)
-							{
-								LogExceptionMessage(ex, "Backup: Error backing up the database files");
-							}
-						}
-
-						try
-						{
-							if (File.Exists(extraFile))
-								archive.CreateEntryFromFile(extraFile, extraBackup);
-							if (File.Exists(AirLinkFile))
-								archive.CreateEntryFromFile(AirLinkFile, AirLinkBackup);
-
-							// custom logs
-							for (var i = 0; i < 10; i++)
-							{
-								if (CustomIntvlLogSettings[i].Enabled)
-								{
-									var custfilename = GetCustomIntvlLogFileName(i, timestamp);
-									if (File.Exists(custfilename))
-										archive.CreateEntryFromFile(custfilename, datafolder + Path.GetFileName(custfilename));
-								}
-
-								if (CustomDailyLogSettings[i].Enabled)
-								{
-									var custfilename = GetCustomDailyLogFileName(i);
-									if (File.Exists(custfilename))
-										archive.CreateEntryFromFile(custfilename, datafolder + Path.GetFileName(custfilename));
-								}
-							}
-
-							// Do not do this extra backup between 00:00 & Roll-over hour on the first of the month
-							// as the month has not yet rolled over - only applies for start-up backups
-							if (timestamp.Day == 1 && timestamp.Hour >= RolloverHour)
-							{
-								var newTime = timestamp.AddDays(-1);
-								// on the first of month, we also need to backup last months files as well
-								var LogFile2 = GetLogFileName(newTime);
-								var logbackup2 = datafolder + Path.GetFileName(LogFile2);
-
-								var extraFile2 = GetExtraLogFileName(newTime);
-								var extraBackup2 = datafolder + Path.GetFileName(extraFile2);
-
-								var AirLinkFile2 = GetAirLinkLogFileName(timestamp.AddDays(-1));
-								var AirLinkBackup2 = datafolder + Path.GetFileName(AirLinkFile2);
-
-								if (File.Exists(LogFile2))
-									archive.CreateEntryFromFile(LogFile2, logbackup2);
-								if (File.Exists(extraFile2))
-									archive.CreateEntryFromFile(extraFile2, extraBackup2);
-								if (File.Exists(AirLinkFile2))
-									archive.CreateEntryFromFile(AirLinkFile2, AirLinkBackup2);
-
+								// custom logs
 								for (var i = 0; i < 10; i++)
 								{
 									if (CustomIntvlLogSettings[i].Enabled)
 									{
-										var custfilename = GetCustomIntvlLogFileName(i, newTime);
+										var custfilename = GetCustomIntvlLogFileName(i, timestamp);
+										if (File.Exists(custfilename))
+											archive.CreateEntryFromFile(custfilename, datafolder + Path.GetFileName(custfilename));
+									}
+
+									if (CustomDailyLogSettings[i].Enabled)
+									{
+										var custfilename = GetCustomDailyLogFileName(i);
 										if (File.Exists(custfilename))
 											archive.CreateEntryFromFile(custfilename, datafolder + Path.GetFileName(custfilename));
 									}
 								}
+
+								// Do not do this extra backup between 00:00 & Roll-over hour on the first of the month
+								// as the month has not yet rolled over - only applies for start-up backups
+								if (timestamp.Day == 1 && timestamp.Hour >= RolloverHour)
+								{
+									var newTime = timestamp.AddDays(-1);
+									// on the first of month, we also need to backup last months files as well
+									var LogFile2 = GetLogFileName(newTime);
+									var logbackup2 = datafolder + Path.GetFileName(LogFile2);
+
+									var extraFile2 = GetExtraLogFileName(newTime);
+									var extraBackup2 = datafolder + Path.GetFileName(extraFile2);
+
+									var AirLinkFile2 = GetAirLinkLogFileName(timestamp.AddDays(-1));
+									var AirLinkBackup2 = datafolder + Path.GetFileName(AirLinkFile2);
+
+									if (File.Exists(LogFile2))
+										archive.CreateEntryFromFile(LogFile2, logbackup2);
+									if (File.Exists(extraFile2))
+										archive.CreateEntryFromFile(extraFile2, extraBackup2);
+									if (File.Exists(AirLinkFile2))
+										archive.CreateEntryFromFile(AirLinkFile2, AirLinkBackup2);
+
+									for (var i = 0; i < 10; i++)
+									{
+										if (CustomIntvlLogSettings[i].Enabled)
+										{
+											var custfilename = GetCustomIntvlLogFileName(i, newTime);
+											if (File.Exists(custfilename))
+												archive.CreateEntryFromFile(custfilename, datafolder + Path.GetFileName(custfilename));
+										}
+									}
+								}
+							}
+							catch (Exception ex)
+							{
+								LogExceptionMessage(ex, "Backup: Error backing up extra log files");
 							}
 						}
-						catch (Exception ex)
-						{
-							LogExceptionMessage(ex, "Backup: Error backing up extra log files");
-						}
+
+						LogMessage("Created backup file " + filename);
 					}
-					LogMessage("Created backup file " + filename);
+					catch (UnauthorizedAccessException)
+					{
+						LogErrorMessage("BackupData: Error, no permission to create/write file: " + dirpath + DirectorySeparator + filename);
+						LogConsoleMessage("Error, no permission to create/write file: " + dirpath + DirectorySeparator + filename, ConsoleColor.Yellow);
+					}
+					catch (Exception ex)
+					{
+						LogErrorMessage($"BackupData: Error while attempting to create/write file: {dirpath + DirectorySeparator + filename}, error message: {ex.Message}");
+						LogConsoleMessage($"Error while attempting to create/write file: {dirpath + DirectorySeparator + filename}, error message: {ex.Message}", ConsoleColor.Yellow);
+					}
 				}
 				else
 				{

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -4963,54 +4963,63 @@ namespace CumulusMX
 			NOAAconf.HeatThreshold = ini.GetValue("NOAA", "HeatingThreshold", -1000.0);
 			if (NOAAconf.HeatThreshold < -99 || NOAAconf.HeatThreshold > 150)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.HeatThreshold, resetting it");
 				NOAAconf.HeatThreshold = Units.Temp == 0 ? 18.3 : 65;
 				rewriteRequired = true;
 			}
 			NOAAconf.CoolThreshold = ini.GetValue("NOAA", "CoolingThreshold", -1000.0);
 			if (NOAAconf.CoolThreshold < -99 || NOAAconf.CoolThreshold > 150)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.CoolThreshold, resetting it");
 				NOAAconf.CoolThreshold = Units.Temp == 0 ? 18.3 : 65;
 				rewriteRequired = true;
 			}
 			NOAAconf.MaxTempComp1 = ini.GetValue("NOAA", "MaxTempComp1", -1000.0);
 			if (NOAAconf.MaxTempComp1 < -99 || NOAAconf.MaxTempComp1 > 150)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.MaxTempComp1, resetting it");
 				NOAAconf.MaxTempComp1 = Units.Temp == 0 ? 27 : 80;
 				rewriteRequired = true;
 			}
 			NOAAconf.MaxTempComp2 = ini.GetValue("NOAA", "MaxTempComp2", -1000.0);
 			if (NOAAconf.MaxTempComp2 < -99 || NOAAconf.MaxTempComp2 > 99)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.MaxTempComp2, resetting it");
 				NOAAconf.MaxTempComp2 = Units.Temp == 0 ? 0 : 32;
 				rewriteRequired = true;
 			}
 			NOAAconf.MinTempComp1 = ini.GetValue("NOAA", "MinTempComp1", -1000.0);
 			if (NOAAconf.MinTempComp1 < -99 || NOAAconf.MinTempComp1 > 99)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.MinTempComp1, resetting it");
 				NOAAconf.MinTempComp1 = Units.Temp == 0 ? 0 : 32;
 				rewriteRequired = true;
 			}
 			NOAAconf.MinTempComp2 = ini.GetValue("NOAA", "MinTempComp2", -1000.0);
 			if (NOAAconf.MinTempComp2 < -99 || NOAAconf.MinTempComp2 > 99)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.MinTempComp2, resetting it");
 				NOAAconf.MinTempComp2 = Units.Temp == 0 ? -18 : 0;
 				rewriteRequired = true;
 			}
 			NOAAconf.RainComp1 = ini.GetValue("NOAA", "RainComp1", -1000.0);
 			if (NOAAconf.RainComp1 < 0 || NOAAconf.RainComp1 > 99)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.RainComp1, resetting it");
 				NOAAconf.RainComp1 = Units.Rain == 0 ? 0.2 : 0.01;
 				rewriteRequired = true;
 			}
 			NOAAconf.RainComp2 = ini.GetValue("NOAA", "RainComp2", -1000.0);
 			if (NOAAconf.RainComp2 < 0 || NOAAconf.RainComp2 > 99)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.RainComp2, resetting it");
 				NOAAconf.RainComp2 = Units.Rain == 0 ? 2 : 0.1;
 				rewriteRequired = true;
 			}
 			NOAAconf.RainComp3 = ini.GetValue("NOAA", "RainComp3", -1000.0);
 			if (NOAAconf.RainComp3 < 0 || NOAAconf.RainComp3 > 99)
 			{
+				LogMessage("Cumulus.ini: Invalid NOAAconf.RainComp3, resetting it");
 				NOAAconf.RainComp3 = Units.Rain == 0 ? 20 : 1;
 				rewriteRequired = true;
 			}
@@ -5024,6 +5033,7 @@ namespace CumulusMX
 			// Check for Cumulus 1 default format - and update
 			if (NOAAconf.MonthFile == "'NOAAMO'mmyy'.txt'" || NOAAconf.MonthFile == "\"NOAAMO\"mmyy\".txt\"")
 			{
+				LogMessage("Cumulus.ini: Updating old Cumulus 1 NOAA monthly file name");
 				NOAAconf.MonthFile = "'NOAAMO'MMyy'.txt'";
 				rewriteRequired = true;
 			}

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3820,7 +3820,7 @@ namespace CumulusMX
 				{
 					RecordsBeganDateTime = DateTime.Parse(RecordsBeganDate, CultureInfo.CurrentCulture);
 					recreateRequired = true;
-					LogMessage($"Cumulus.ini: Changing old StartDate [{RecordsBeganDate}] to StartDateIso [{RecordsBeganDateTime.ToString("yyyy-MM-dd")}]");
+					LogMessage($"Cumulus.ini: Changing old StartDate [{RecordsBeganDate}] to StartDateIso [{RecordsBeganDateTime:yyyy-MM-dd}]");
 				}
 				catch (Exception ex)
 				{
@@ -11602,7 +11602,9 @@ namespace CumulusMX
 
 			if (FtpOptions.Logging)
 			{
+#pragma warning disable CA2254 // Template should be a static expression
 				FtpLoggerMX.LogInformation(message);
+#pragma warning restore CA2254 // Template should be a static expression
 			}
 		}
 
@@ -11612,7 +11614,9 @@ namespace CumulusMX
 			{
 				if (!string.IsNullOrEmpty(message))
 					LogDebugMessage(message);
+#pragma warning disable CA2254 // Template should be a static expression
 				FtpLoggerMX.LogInformation(message);
+#pragma warning restore CA2254 // Template should be a static expression
 			}
 		}
 

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>4.001.1.4025</Version>
+    <Version>4.1.2.4026</Version>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
   </PropertyGroup>
 

--- a/CumulusMX/DataStruct.cs
+++ b/CumulusMX/DataStruct.cs
@@ -9,7 +9,7 @@ namespace CumulusMX
 						int indoorHum, double pressure, double windLatest, double windAverage, double recentmaxgust, double windRunToday, int bearing, int avgbearing,
 						double rainToday, double rainYesterday, double rainMonth, double rainYear, double rainRate, double rainLastHour, double heatIndex, double humidex,
 						double appTemp, double tempTrend, double pressTrend, double highGustToday, string highGustTodayTime, double highWindToday, int highGustBearingToday,
-						string windUnit, int bearingRangeFrom10, int bearingRangeTo10, string windRoseData, double highTempToday, double lowTempToday, string highTempTodayToday,
+						string windUnit, string windRunUnit, int bearingRangeFrom10, int bearingRangeTo10, string windRoseData, double highTempToday, double lowTempToday, string highTempTodayToday,
 						string lowTempTodayTime, double highPressToday, double lowPressToday, string highPressTodayTime, string lowPressTodayTime, double highRainRateToday,
 						string highRainRateTodayTime, int highHumToday, int lowHumToday, string highHumTodayTime, string lowHumTodayTime, string pressUnit, string tempUnit,
 						string rainUnit, double highDewpointToday, double lowDewpointToday, string highDewpointTodayTime, string lowDewpointTodayTime, double lowWindChillToday,
@@ -161,6 +161,9 @@ namespace CumulusMX
 
 		[DataMember]
 		public string WindUnit { get; } = windUnit;
+
+		[DataMember]
+		public string WindRunUnit { get; } = windRunUnit;
 
 		[DataMember]
 		public string RainUnit { get; } = rainUnit;

--- a/CumulusMX/DataStruct.cs
+++ b/CumulusMX/DataStruct.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -17,7 +18,7 @@ namespace CumulusMX
 						string highUVindexTodayTime, string forecast, string sunrise, string sunset, string moonrise, string moonset, double highHeatIndexToday,
 						string highHeatIndexTodayTime, double highAppTempToday, double lowAppTempToday, string highAppTempTodayTime, string lowAppTempTodayTime,
 						int currentSolarMax, double alltimeHighPressure, double alltimeLowPressure, double sunshineHours, string domWindDir, string lastRainTipISO,
-						double highHourlyRainToday, string highHourlyRainTodayTime, string highBeaufortToday, string beaufort, string beaufortDesc, string lastDataRead,
+						double highHourlyRainToday, string highHourlyRainTodayTime, string highBeaufortToday, string beaufort, string beaufortDesc, DateTime lastDataRead,
 						bool dataStopped, double stormRain, string stormRainStart, int cloudbase, string cloudbaseUnit, double last24hourRain,
 						double feelsLike, double highFeelsLikeToday, string highFeelsLikeTodayTime, double lowFeelsLikeToday, string lowFeelsLikeTodayTime,
 						double highHumidexToday, string highHumidexTodayTime, List<DashboardAlarms> alarms)
@@ -603,7 +604,14 @@ namespace CumulusMX
 		public string BeaufortDesc { get; } = beaufortDesc;
 
 		[DataMember]
-		public string LastDataRead { get; } = lastDataRead;
+		public string LastDataRead { get; } = lastDataRead.ToLocalTime().ToString(cumulus.ProgramOptions.TimeFormatLong);
+
+		[DataMember]
+		public string LastDataReadDate
+		{
+			get => lastDataRead.ToLocalTime().ToString("d");
+		}
+
 
 		[DataMember]
 		public bool DataStopped { get; } = dataStopped;

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -1251,7 +1251,7 @@ namespace CumulusMX
 											}
 											else
 											{
-												cumulus.LogErrorMessage("DecodeCurrent: Warning, no valid Humidity data");
+												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Humidity data");
 											}
 										}
 										catch (Exception ex)
@@ -1264,7 +1264,7 @@ namespace CumulusMX
 										{
 											if (data.temp_out.HasValue && data.temp_out < -98)
 											{
-												cumulus.LogErrorMessage("DecodeCurrent: Warning, no valid Primary temperature value found [-99]");
+												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Primary temperature value found [-99]");
 											}
 											else
 											{
@@ -1277,7 +1277,7 @@ namespace CumulusMX
 												}
 												else
 												{
-													cumulus.LogErrorMessage("DecodeCurrent: Warning, no valid Temperature data");
+													cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Temperature data");
 												}
 											}
 										}
@@ -1296,7 +1296,7 @@ namespace CumulusMX
 											}
 											else
 											{
-												cumulus.LogErrorMessage("DecodeCurrent: Warning, no valid Dew Point data");
+												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Dew Point data");
 											}
 										}
 										catch (Exception ex)
@@ -1378,7 +1378,7 @@ namespace CumulusMX
 											}
 											else
 											{
-												cumulus.LogDebugMessage("DecodeCurrent: Warning, no valid Wind data");
+												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Wind data");
 											}
 										}
 										catch (Exception ex)
@@ -1471,10 +1471,6 @@ namespace CumulusMX
 
 												DoUV(data.uv.Value, lastRecordTime);
 											}
-											else
-											{
-												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid UV data");
-											}
 										}
 										catch (Exception ex)
 										{
@@ -1495,15 +1491,11 @@ namespace CumulusMX
 											{
 												cumulus.LogDebugMessage("DecodeCurrent: using solar data");
 												DoSolarRad(data.solar_rad.Value, lastRecordTime);
-											}
-											else
-											{
-												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Solar data");
-											}
 
-											if (data.et_year.HasValue && !cumulus.StationOptions.CalculatedET && (data.et_year.Value >= 0) && (data.et_year.Value < 32000))
-											{
-												DoET(ConvertUnits.RainINToUser(data.et_year.Value), lastRecordTime);
+												if (data.et_year.HasValue && !cumulus.StationOptions.CalculatedET && (data.et_year.Value >= 0) && (data.et_year.Value < 32000))
+												{
+													DoET(ConvertUnits.RainINToUser(data.et_year.Value), lastRecordTime);
+												}
 											}
 										}
 										catch (Exception ex)

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -696,6 +696,13 @@ namespace CumulusMX
 					DoHumidex(timestamp);
 					DoCloudBaseHeatIndex(timestamp);
 
+					if (cumulus.StationOptions.CalculateSLP && StationPressure > 0)
+					{
+						var abs = cumulus.Calib.Press.Calibrate(StationPressure);
+						var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToHpa(abs), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
+						DoPressure(ConvertUnits.PressMBToUser(slp), timestamp);
+					}
+
 					// Log all the data
 					_ = cumulus.DoLogFile(timestamp, false);
 					cumulus.MySqlRealtimeFile(999, false, timestamp);
@@ -1006,21 +1013,7 @@ namespace CumulusMX
 										lsidLastUpdate[sensor.lsid] = rec.ts;
 										var ts = Utils.FromUnixTime(rec.ts);
 
-										if (cumulus.StationOptions.CalculateSLP)
-										{
-											if (rec.bar_absolute.HasValue)
-											{
-												var abs = ConvertUnits.PressINHGToHpa(rec.bar_absolute.Value);
-												abs = cumulus.Calib.Press.Calibrate(abs);
-												var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), abs, ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
-												DoPressure(ConvertUnits.PressMBToUser(slp), ts);
-											}
-											else
-											{
-												cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Baro data (absolute)");
-											}
-										}
-										else
+										if (!cumulus.StationOptions.CalculateSLP)
 										{
 											if (rec.bar_sea_level.HasValue)
 											{
@@ -2079,6 +2072,20 @@ namespace CumulusMX
 			DoFeelsLike(dateTime);
 			DoHumidex(dateTime);
 			DoCloudBaseHeatIndex(dateTime);
+
+			if (cumulus.StationOptions.CalculateSLP)
+			{
+				if (StationPressure > 0)
+				{
+					var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToHpa(StationPressure), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
+					DoPressure(ConvertUnits.PressMBToUser(slp), dateTime);
+				}
+				else
+				{
+					cumulus.LogWarningMessage("DecodeCurrent: Warning, no valid Baro data (absolute)");
+				}
+			}
+
 
 			DoForecast(string.Empty, false);
 
@@ -3281,14 +3288,6 @@ namespace CumulusMX
 										{
 											cumulus.LogWarningMessage("DecodeHistoric: Warning, no valid Baro data (sea level)");
 										}
-									}
-									else if (data13baro.bar_absolute != null)
-									{
-										ts = Utils.FromUnixTime(data13baro.ts);
-										var abs = ConvertUnits.PressINHGToHpa((double) data13baro.bar_absolute);
-										abs = cumulus.Calib.Press.Calibrate(abs);
-										var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), abs, ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
-										DoPressure(ConvertUnits.PressMBToUser(slp), ts);
 									}
 									else
 									{

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -2047,9 +2047,9 @@ namespace CumulusMX
 
 								try
 								{
-									if (data11.temp_last == -99 || data11.temp_last == null)
+									if (data11.temp_last < -98 || data11.temp_last == null)
 									{
-										cumulus.LogDebugMessage($"WL.com historic: Warning, no valid Extra temperature value on TxId {data11.tx_id}");
+										cumulus.LogDebugMessage($"WL.com historic: Warning, no valid Extra temperature value [-99] on TxId {data11.tx_id}");
 									}
 									else
 									{

--- a/CumulusMX/EcowittCloudStation.cs
+++ b/CumulusMX/EcowittCloudStation.cs
@@ -372,13 +372,9 @@ namespace CumulusMX
 						{
 							StationPressure = data.pressure.absolute.value;
 
-							if (cumulus.StationOptions.CalculateSLP)
-							{
-								StationPressure = cumulus.Calib.Press.Calibrate(StationPressure);
-								var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), StationPressure, ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
-								DoPressure(slp, Utils.FromUnixTime(data.pressure.absolute.time));
-							}
-							else
+							// leave cmx calculated SLP until the end as it depends on temperature
+
+							if (!cumulus.StationOptions.CalculateSLP)
 							{
 								DoPressure(data.pressure.relative.value, Utils.FromUnixTime(data.pressure.relative.time));
 							}
@@ -592,6 +588,12 @@ namespace CumulusMX
 					cumulus.LogErrorMessage($"ProcessCurrentData: Error in Camera data - {ex.Message}");
 				}
 
+				if (cumulus.StationOptions.CalculateSLP)
+				{
+					var abs = cumulus.Calib.Press.Calibrate(StationPressure);
+					var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToHpa(abs), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
+					DoPressure(ConvertUnits.PressMBToUser(slp), Utils.FromUnixTime(data.pressure.absolute.time));
+				}
 
 				thisStation.DoForecast("", false);
 

--- a/CumulusMX/EcowittCloudStation.cs
+++ b/CumulusMX/EcowittCloudStation.cs
@@ -962,23 +962,23 @@ namespace CumulusMX
 			if (data.pm25_ch1 != null)
 			{
 				station.DoAirQuality(data.pm25_ch1.pm25.value, 1);
-				//station.DoAirQualityAvg(data.pm25_ch1.AqiAvg24h.value, 1);
+				//station.DoAirQualityAvg(data.pm25_ch1.AqiAvg24h.value, 1)
 			}
 
 			if (data.pm25_ch2 != null)
 			{
 				station.DoAirQuality(data.pm25_ch2.pm25.value, 2);
-				//station.DoAirQualityAvg(data.pm25_ch2.AqiAvg24h.value, 2);
+				//station.DoAirQualityAvg(data.pm25_ch2.AqiAvg24h.value, 2)
 			}
 			if (data.pm25_ch3 != null)
 			{
 				station.DoAirQuality(data.pm25_ch3.pm25.value, 3);
-				//station.DoAirQualityAvg(data.pm25_ch3.AqiAvg24h.value, 3);
+				//station.DoAirQualityAvg(data.pm25_ch3.AqiAvg24h.value, 3)
 			}
 			if (data.pm25_ch4 != null)
 			{
 				station.DoAirQuality(data.pm25_ch4.pm25.value, 4);
-				//station.DoAirQualityAvg(data.pm25_ch1.AqiAvg24h.value, 4);
+				//station.DoAirQualityAvg(data.pm25_ch1.AqiAvg24h.value, 4)
 			}
 		}
 
@@ -993,14 +993,14 @@ namespace CumulusMX
 			if (data.pm25_aqi_combo != null)
 			{
 				station.CO2_pm2p5 = data.pm25_aqi_combo.pm25.value;
-				//station.CO2_pm2p5_24h = data.pm25_aqi_combo.AqiAvg24h.value;
+				//station.CO2_pm2p5_24h = data.pm25_aqi_combo.AqiAvg24h.value
 				station.CO2_pm2p5_aqi = station.GetAqi(WeatherStation.AqMeasure.pm2p5, station.CO2_pm2p5);
 			}
 
 			if (data.pm10_aqi_combo != null)
 			{
 				station.CO2_pm10 = data.pm10_aqi_combo.pm10.value;
-				//station.CO2_pm10_24h = data.pm10_aqi_combo.AqiAvg24h.value;
+				//station.CO2_pm10_24h = data.pm10_aqi_combo.AqiAvg24h.value
 				station.CO2_pm10_aqi = station.GetAqi(WeatherStation.AqMeasure.pm10, station.CO2_pm10);
 			}
 

--- a/CumulusMX/FOStation.cs
+++ b/CumulusMX/FOStation.cs
@@ -861,15 +861,15 @@ namespace CumulusMX
 
 			if (cumulus.FineOffsetOptions.SyncReads && !synchronising)
 			{
-				var doSensorSync = DateTime.Now.Subtract(FOSensorClockTime).TotalDays > 1;
-				var doStationSync = DateTime.Now.Subtract(FOStationClockTime).TotalDays > 1;
-				doSolarSync = hasSolar && DateTime.Now.Subtract(FOSolarClockTime).TotalDays > 1;
+				var doSensorSync = DateTime.UtcNow.Subtract(FOSensorClockTime.ToUniversalTime()).TotalDays > 1;
+				var doStationSync = DateTime.UtcNow.Subtract(FOStationClockTime.ToUniversalTime()).TotalDays > 1;
+				doSolarSync = hasSolar && DateTime.UtcNow.Subtract(FOSolarClockTime.ToUniversalTime()).TotalDays > 1;
 
 				if (doSensorSync || doStationSync || doSolarSync)
 				{
 					doSolarSync = hasSolar;
 
-					if (hasSolar && DateTime.Now.Subtract(FOSolarClockTime).TotalDays > 1)
+					if (hasSolar && DateTime.UtcNow.Subtract(FOSolarClockTime.ToUniversalTime()).TotalDays > 1)
 					{
 						if (DateTime.Now.CompareTo(cumulus.SunRiseTime.AddMinutes(30)) > 0)
 						{
@@ -1111,7 +1111,7 @@ namespace CumulusMX
 					StopSynchronising();
 					FinaliseSync();
 				}
-				else if (DateTime.Now.Subtract(syncStart).TotalMinutes > 1)
+				else if (DateTime.UtcNow.Subtract(syncStart.ToUniversalTime()).TotalMinutes > 1)
 				{
 					StopSynchronising();
 

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -1348,7 +1348,7 @@ namespace CumulusMX
 					if (newLightningTime > LightningTime)
 					{
 						LightningTime = newLightningTime;
-						if (newLightningDistance != 999)
+						if (newLightningDistance < 999)
 							LightningDistance = newLightningDistance;
 					}
 

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -982,13 +982,7 @@ namespace CumulusMX
 								tempUint16 = GW1000Api.ConvertBigEndianUInt16(data, idx);
 								StationPressure = ConvertUnits.PressMBToUser(tempUint16 / 10.0);
 								AltimeterPressure = ConvertUnits.PressMBToUser(MeteoLib.StationToAltimeter(tempUint16 / 10.0, AltitudeM(cumulus.Altitude)));
-
-								if (cumulus.StationOptions.CalculateSLP)
-								{
-									StationPressure = cumulus.Calib.Press.Calibrate(StationPressure);
-									var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToMB(StationPressure), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
-									DoPressure(ConvertUnits.PressMBToUser(slp), dateTime);
-								}
+								// Leave calculate SLP until the end as it depends on temperature
 								idx += 2;
 								break;
 							case 0x09: //Relative Barometric (hPa)
@@ -1389,6 +1383,13 @@ namespace CumulusMX
 						DoFeelsLike(dateTime);
 						DoHumidex(dateTime);
 						DoCloudBaseHeatIndex(dateTime);
+
+						if (cumulus.StationOptions.CalculateSLP)
+						{
+							var abs = cumulus.Calib.Press.Calibrate(StationPressure);
+							var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToMB(abs), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
+							DoPressure(ConvertUnits.PressMBToUser(slp), dateTime);
+						}
 					}
 
 					DoForecast("", false);

--- a/CumulusMX/HttpStationAmbient.cs
+++ b/CumulusMX/HttpStationAmbient.cs
@@ -194,53 +194,6 @@ namespace CumulusMX
 					}
 
 
-					// === Pressure ===
-					try
-					{
-						// baromabsin
-						// baromrelin
-
-						var press = data["baromrelin"];
-						var stnPress = data["baromabsin"];
-
-						if (press == null)
-						{
-							cumulus.LogWarningMessage($"{procName}: Error, missing baro pressure");
-						}
-						else
-						{
-							if (!cumulus.StationOptions.CalculateSLP)
-							{
-								var pressVal = ConvertUnits.PressINHGToUser(Convert.ToDouble(press, CultureInfo.InvariantCulture));
-								DoPressure(pressVal, recDate);
-							}
-						}
-
-						if (stnPress == null)
-						{
-							cumulus.LogDebugMessage($"{procName}: Error, missing absolute baro pressure");
-						}
-						else
-						{
-							StationPressure = ConvertUnits.PressINHGToUser(Convert.ToDouble(stnPress, CultureInfo.InvariantCulture));
-
-							if (cumulus.StationOptions.CalculateSLP)
-							{
-								StationPressure = cumulus.Calib.Press.Calibrate(StationPressure);
-								var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToMB(StationPressure), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
-
-								DoPressure(ConvertUnits.PressMBToUser(slp), recDate);
-							}
-						}
-					}
-					catch (Exception ex)
-					{
-						cumulus.LogErrorMessage("ProcessData: Error in Pressure data - " + ex.Message);
-						context.Response.StatusCode = 500;
-						return "Failed: Error in baro pressure data - " + ex.Message;
-					}
-
-
 					// === Indoor temp ===
 					try
 					{
@@ -289,6 +242,53 @@ namespace CumulusMX
 						context.Response.StatusCode = 500;
 						return "Failed: Error in outdoor temp data - " + ex.Message;
 					}
+
+					// === Pressure ===
+					try
+					{
+						// baromabsin
+						// baromrelin
+
+						var press = data["baromrelin"];
+						var stnPress = data["baromabsin"];
+
+						if (press == null)
+						{
+							cumulus.LogWarningMessage($"{procName}: Error, missing baro pressure");
+						}
+						else
+						{
+							if (!cumulus.StationOptions.CalculateSLP)
+							{
+								var pressVal = ConvertUnits.PressINHGToUser(Convert.ToDouble(press, CultureInfo.InvariantCulture));
+								DoPressure(pressVal, recDate);
+							}
+						}
+
+						if (stnPress == null)
+						{
+							cumulus.LogDebugMessage($"{procName}: Error, missing absolute baro pressure");
+						}
+						else
+						{
+							StationPressure = ConvertUnits.PressINHGToUser(Convert.ToDouble(stnPress, CultureInfo.InvariantCulture));
+
+							if (cumulus.StationOptions.CalculateSLP)
+							{
+								StationPressure = cumulus.Calib.Press.Calibrate(StationPressure);
+								var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToMB(StationPressure), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
+
+								DoPressure(ConvertUnits.PressMBToUser(slp), recDate);
+							}
+						}
+					}
+					catch (Exception ex)
+					{
+						cumulus.LogErrorMessage("ProcessData: Error in Pressure data - " + ex.Message);
+						context.Response.StatusCode = 500;
+						return "Failed: Error in baro pressure data - " + ex.Message;
+					}
+
 
 
 					// === Rain ===

--- a/CumulusMX/HttpStationEcowitt.cs
+++ b/CumulusMX/HttpStationEcowitt.cs
@@ -494,55 +494,6 @@ namespace CumulusMX
 					}
 
 
-					// === Pressure ===
-					try
-					{
-						// baromabsin
-						// baromrelin
-
-						var press = data["baromrelin"];
-						var stnPress = data["baromabsin"];
-
-						if (press == null)
-						{
-							cumulus.LogWarningMessage($"{procName}: Error, missing baro pressure");
-						}
-						else
-						{
-							if (!cumulus.StationOptions.CalculateSLP)
-							{
-								var pressVal = ConvertUnits.PressINHGToUser(Convert.ToDouble(press, invNum));
-								DoPressure(pressVal, recDate);
-							}
-						}
-
-						if (stnPress == null)
-						{
-							cumulus.LogDebugMessage($"{procName}: Error, missing absolute baro pressure");
-						}
-						else
-						{
-							StationPressure = ConvertUnits.PressINHGToUser(Convert.ToDouble(stnPress, invNum));
-
-							if (cumulus.StationOptions.CalculateSLP)
-							{
-								StationPressure = cumulus.Calib.Press.Calibrate(StationPressure);
-
-								var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToMB(StationPressure), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
-
-								DoPressure(ConvertUnits.PressMBToUser(slp), recDate);
-							}
-
-							AltimeterPressure = ConvertUnits.PressMBToUser(MeteoLib.StationToAltimeter(ConvertUnits.UserPressToHpa(StationPressure), AltitudeM(cumulus.Altitude)));
-						}
-					}
-					catch (Exception ex)
-					{
-						cumulus.LogErrorMessage($"{procName}: Error in Pressure data - {ex.Message}");
-						return "Failed: Error in baro pressure data - " + ex.Message;
-					}
-
-
 					// === Indoor temp ===
 					try
 					{
@@ -593,6 +544,55 @@ namespace CumulusMX
 					{
 						cumulus.LogErrorMessage($"{procName}: Error in Outdoor temp data - {ex.Message}");
 						return "Failed: Error in outdoor temp data - " + ex.Message;
+					}
+
+
+					// === Pressure ===
+					try
+					{
+						// baromabsin
+						// baromrelin
+
+						var press = data["baromrelin"];
+						var stnPress = data["baromabsin"];
+
+						if (press == null)
+						{
+							cumulus.LogWarningMessage($"{procName}: Error, missing baro pressure");
+						}
+						else
+						{
+							if (!cumulus.StationOptions.CalculateSLP)
+							{
+								var pressVal = ConvertUnits.PressINHGToUser(Convert.ToDouble(press, invNum));
+								DoPressure(pressVal, recDate);
+							}
+						}
+
+						if (stnPress == null)
+						{
+							cumulus.LogDebugMessage($"{procName}: Error, missing absolute baro pressure");
+						}
+						else
+						{
+							StationPressure = ConvertUnits.PressINHGToUser(Convert.ToDouble(stnPress, invNum));
+
+							if (cumulus.StationOptions.CalculateSLP)
+							{
+								StationPressure = cumulus.Calib.Press.Calibrate(StationPressure);
+
+								var slp = MeteoLib.GetSeaLevelPressure(AltitudeM(cumulus.Altitude), ConvertUnits.UserPressToMB(StationPressure), ConvertUnits.UserTempToC(OutdoorTemperature), cumulus.Latitude);
+
+								DoPressure(ConvertUnits.PressMBToUser(slp), recDate);
+							}
+
+							AltimeterPressure = ConvertUnits.PressMBToUser(MeteoLib.StationToAltimeter(ConvertUnits.UserPressToHpa(StationPressure), AltitudeM(cumulus.Altitude)));
+						}
+					}
+					catch (Exception ex)
+					{
+						cumulus.LogErrorMessage($"{procName}: Error in Pressure data - {ex.Message}");
+						return "Failed: Error in baro pressure data - " + ex.Message;
 					}
 
 

--- a/CumulusMX/JsonStation.cs
+++ b/CumulusMX/JsonStation.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 using EmbedIO;
-
-using FluentFTP.Helpers;
 
 using MQTTnet;
 

--- a/CumulusMX/JsonStation.cs
+++ b/CumulusMX/JsonStation.cs
@@ -331,6 +331,10 @@ namespace CumulusMX
 								avg = ConvertUnits.WindKPHToUser(avg);
 								gust = ConvertUnits.WindKPHToUser(gust);
 								break;
+							case "knots":
+									avg = ConvertUnits.WindKnotsToUser(avg);
+									gust = ConvertUnits.WindKnotsToUser(gust);
+									break;
 							default:
 								cumulus.LogErrorMessage("ApplyData: Invalid windspeed units supplied: " + data.units.windspeed);
 								retStr.AppendLine("Invalid windspeed units");

--- a/CumulusMX/MeteoLib.cs
+++ b/CumulusMX/MeteoLib.cs
@@ -356,8 +356,8 @@ namespace CumulusMX
 		}
 
 		/// <summary>
-		/// Calculates the sea leavel pressure
-		/// https://www.wind101.net/sea-level-pressure-advanced/LAPLACE%20GENERAL%20EQUATION%20THE%20REDUCTION%20OF%20BAROMETRIC%20PRESSURE%20DrKFS_net.pdf
+		/// Calculates the sea leavel pressure.
+		/// See: https://www.wind101.net/sea-level-pressure-advanced/LAPLACE%20GENERAL%20EQUATION%20THE%20REDUCTION%20OF%20BAROMETRIC%20PRESSURE%20DrKFS_net.pdf
 		/// </summary>
 		/// <param name="altitudeM">Station altitude in metres</param>
 		/// <param name="pressureHpa">Station pressure in inHg</param>

--- a/CumulusMX/Program.cs
+++ b/CumulusMX/Program.cs
@@ -129,9 +129,10 @@ namespace CumulusMX
 			var lang = string.Empty;
 			var servicename = string.Empty;
 
-			for (int i = 0; i < args.Length; i++)
+			try
 			{
-				try
+				int i = 0;
+				while (i < args.Length)
 				{
 					switch (args[i])
 					{
@@ -184,11 +185,13 @@ namespace CumulusMX
 							Usage();
 							break;
 					}
+
+					i++;
 				}
-				catch
-				{
-					Usage();
-				}
+			}
+			catch
+			{
+				Usage();
 			}
 
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -11867,12 +11867,12 @@ namespace CumulusMX
 
 			json.Append("[\"High Solar Radiation\",\"");
 			json.Append(HiLoToday.HighSolar.ToString("F0"));
-			json.Append("&nbsp;W/m2");
+			json.Append("&nbsp;W/m<sup>2</sup>");
 			json.Append(sepStr);
 			json.Append(HiLoToday.HighSolarTime.ToString(cumulus.ProgramOptions.TimeFormat));
 			json.Append(sepStr);
 			json.Append(HiLoYest.HighSolar.ToString("F0"));
-			json.Append("&nbsp;W/m2");
+			json.Append("&nbsp;W/m<sup>2</sup>");
 			json.Append(sepStr);
 			json.Append(HiLoYest.HighSolarTime.ToString(cumulus.ProgramOptions.TimeFormat));
 			json.Append("\"],");

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2078,7 +2078,7 @@ namespace CumulusMX
 			if (now.Hour == rollHour)
 			{
 				DayReset(now);
-				cumulus.BackupData(true, now);
+				Task.Run(() => cumulus.BackupData(true, now));
 			}
 
 			if (now.Hour == 0)
@@ -5887,6 +5887,8 @@ namespace CumulusMX
 
 				// Calculate today"s rainfall
 				RainToday = (RainCounter - RainCounterDayStart) * cumulus.Calib.Rain.Mult;
+				// Allow for rounding errors
+				if (RainToday < 0) RainToday = 0;
 
 				// Calculate rain since midnight for Wunderground etc
 				double trendval = RainCounter - MidnightRainCount;

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -2057,9 +2057,6 @@ namespace CumulusMX
 			cumulus.RotateLogFiles();
 
 			ClearAlarms();
-
-			System.Runtime.GCSettings.LargeObjectHeapCompactionMode = System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
-			GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, false);
 		}
 
 		private void HourChanged(DateTime now)
@@ -2089,6 +2086,9 @@ namespace CumulusMX
 			}
 
 			RemoveOldRecentData(now);
+
+			System.Runtime.GCSettings.LargeObjectHeapCompactionMode = System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
+			//GC.Collect(GC.MaxGeneration, GCCollectionMode.Optimized, false)
 		}
 
 		private void CheckForDataStopped()
@@ -2112,7 +2112,7 @@ namespace CumulusMX
 				{
 					cumulus.LogErrorMessage("*** Data input appears to have stopped");
 				}
-			}
+			}		// Calculates evapotranspiration based on the data for the last hour and updates the running annual total.
 			else
 			{
 				DataStopped = false;
@@ -2146,6 +2146,8 @@ namespace CumulusMX
 			}
 		}
 
+
+		// Calculates evapotranspiration based on the data for the last hour and updates the running annual total.
 		public void CalculateEvapotranspiration(DateTime date)
 		{
 			cumulus.LogDebugMessage("Calculating ET from data");
@@ -13797,7 +13799,7 @@ namespace CumulusMX
 				HiLoToday.LowAppTemp, HiLoToday.HighAppTempTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.LowAppTempTime.ToString(cumulus.ProgramOptions.TimeFormat), CurrentSolarMax,
 				AllTime.HighPress.Val, AllTime.LowPress.Val, SunshineHours, CompassPoint(DominantWindBearing), LastRainTip,
 				HiLoToday.HighHourlyRain, HiLoToday.HighHourlyRainTime.ToString(cumulus.ProgramOptions.TimeFormat), "F" + Cumulus.Beaufort(HiLoToday.HighWind), "F" + Cumulus.Beaufort(WindAverage),
-				cumulus.BeaufortDesc(WindAverage), LastDataReadTimestamp.ToLocalTime().ToString(cumulus.ProgramOptions.TimeFormatLong), DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
+				cumulus.BeaufortDesc(WindAverage), LastDataReadTimestamp, DataStopped, StormRain, stormRainStart, CloudBase, cumulus.CloudBaseInFeet ? "ft" : "m", RainLast24Hour,
 				FeelsLike, HiLoToday.HighFeelsLike, HiLoToday.HighFeelsLikeTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.LowFeelsLike, HiLoToday.LowFeelsLikeTime.ToString(cumulus.ProgramOptions.TimeFormat),
 				HiLoToday.HighHumidex, HiLoToday.HighHumidexTime.ToString(cumulus.ProgramOptions.TimeFormat), alarms);
 

--- a/CumulusMX/WeatherStation.cs
+++ b/CumulusMX/WeatherStation.cs
@@ -13784,7 +13784,7 @@ namespace CumulusMX
 			var data = new DataStruct(cumulus, OutdoorTemperature, OutdoorHumidity, TempTotalToday / tempsamplestoday, IndoorTemperature, OutdoorDewpoint, WindChill, IndoorHumidity,
 				Pressure, WindLatest, WindAverage, RecentMaxGust, WindRunToday, Bearing, AvgBearing, RainToday, RainYesterday, RainMonth, RainYear, RainRate,
 				RainLastHour, HeatIndex, Humidex, ApparentTemperature, temptrendval, presstrendval, HiLoToday.HighGust, HiLoToday.HighGustTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.HighWind,
-				HiLoToday.HighGustBearing, cumulus.Units.WindText, BearingRangeFrom10, BearingRangeTo10, windRoseData.ToString(), HiLoToday.HighTemp, HiLoToday.LowTemp,
+				HiLoToday.HighGustBearing, cumulus.Units.WindText, cumulus.Units.WindRunText, BearingRangeFrom10, BearingRangeTo10, windRoseData.ToString(), HiLoToday.HighTemp, HiLoToday.LowTemp,
 				HiLoToday.HighTempTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.LowTempTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.HighPress, HiLoToday.LowPress, HiLoToday.HighPressTime.ToString(cumulus.ProgramOptions.TimeFormat),
 				HiLoToday.LowPressTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.HighRainRate, HiLoToday.HighRainRateTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.HighHumidity, HiLoToday.LowHumidity,
 				HiLoToday.HighHumidityTime.ToString(cumulus.ProgramOptions.TimeFormat), HiLoToday.LowHumidityTime.ToString(cumulus.ProgramOptions.TimeFormat), cumulus.Units.PressText, cumulus.Units.TempText, cumulus.Units.RainText,

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -3598,7 +3599,7 @@ namespace CumulusMX
 
 			if (start.Date == DateTime.Now.AddHours(cumulus.GetHourInc()).Date)
 			{
-				// first day of the currebt month, there are no dayfile entries
+				// first day of the current month, there are no dayfile entries
 				// so return the average temp so far today
 				return Tagavgtemp(tagParams);
 			}
@@ -3636,6 +3637,34 @@ namespace CumulusMX
 
 			var avg = station.DayFile.Where(x => x.Date >= start && x.Date < end).Average(rec => rec.AvgTemp);
 			return CheckRcDp(CheckTempUnit(avg, tagParams), tagParams, cumulus.TempDPlaces);
+		}
+
+		private string TagAnnualRainfall(Dictionary<string, string> tagParams)
+		{
+			var year = tagParams.Get("y");
+			DateTime start;
+			DateTime end;
+			double total;
+
+			if (year != null)
+			{
+				if (int.Parse(year) == DateTime.Now.Year)
+				{
+					total = station.RainYear;
+				}
+				else
+				{
+					start = new DateTime(int.Parse(year), 1, 1, 0, 0, 0, DateTimeKind.Local);
+					end = start.AddYears(1);
+					total = station.DayFile.Where(x => x.Date >= start && x.Date < end).Sum(x => x.TotalRain);
+				}
+			}
+			else
+			{
+				total = station.RainYear;
+			}
+
+			return CheckRcDp(CheckRainUnit(total, tagParams), tagParams, cumulus.RainDPlaces);
 		}
 
 		private string TagThwIndex(Dictionary<string, string> tagParams)
@@ -6752,6 +6781,7 @@ namespace CumulusMX
 				// Specifc Month/Year values
 				{ "MonthTempAvg", TagMonthTempAvg },
 				{ "YearTempAvg", TagYearTempAvg },
+				{ "AnnualRainfall", TagAnnualRainfall },
 				// Options
 				{ "Option_useApparent", TagOption_useApparent },
 				{ "Option_showSolar", TagOption_showSolar },

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -414,6 +414,12 @@ namespace CumulusMX
 			return GetFormattedDateTime(dt, defaultFormat, tagParams);
 		}
 
+		private static string GetFormattedTimeSpan(TimeSpan ts, string defaultFormat, Dictionary<string, string> tagParams)
+		{
+			string dtformat = tagParams.Get("format") ?? defaultFormat;
+			return String.Format(dtformat, ts);
+		}
+
 		private string GetMonthlyAlltimeValueStr(AllTimeRec rec, Dictionary<string, string> tagParams, int decimals)
 		{
 			if (rec.Ts <= cumulus.defaultRecordTS)
@@ -5350,7 +5356,7 @@ namespace CumulusMX
 
 				TimeSpan ts = TimeSpan.FromSeconds(upTime);
 
-				return string.Format($"{ts.Days} days {ts.Hours} hours");
+				return GetFormattedTimeSpan(ts, "{0:%d} days {0:%h} hours", tagParams);
 			}
 			catch (Exception ex)
 			{
@@ -5363,7 +5369,7 @@ namespace CumulusMX
 		private static string TagProgramUpTime(Dictionary<string, string> tagParams)
 		{
 			TimeSpan ts = DateTime.Now.ToUniversalTime() - Program.StartTime.ToUniversalTime();
-			return string.Format($"{ts.Days} days {ts.Hours} hours");
+			return GetFormattedTimeSpan(ts, "{0:%d} days {0:%h} hours", tagParams);
 		}
 
 		private static string TagProgramUpTimeMs(Dictionary<string, string> tagParams)

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,11 @@
+4.1.2 - b4026
+—————————————
+Fixed
+- Davis VP2 connection type being decoded from Cumulus.ini incorrectly
+- Add missing knots input to JSON station
+
+
+
 4.1.1 - b4025
 —————————————
 Fixed

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,6 +2,12 @@
 —————————————
 New
 - Adds wind run to the dashboard "now" page
+- Adds support for the format parameter to the <#ProgramUpTime> and <#SystemUpTime> web tags
+	- The format syntax is different from date/time web tags as these two tags use a elapsed time.
+	- For Custom format specifiers see: https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-timespan-format-strings
+	- For Standard format specifiers see: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings
+	- The default output is generated using the format string "{0:%d} days {0:%h} hours"
+	- You can customise this like this example: <#SystemUpTime format="{0:%d}d {0:%h}h {0:%m}m">  --> "12d 9h 46m"
 
 Fixed
 - Davis VP2 connection type being decoded from Cumulus.ini incorrectly

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,7 +3,8 @@
 Fixed
 - Davis VP2 connection type being decoded from Cumulus.ini incorrectly
 - Add missing knots input to JSON station
-
+- Solar W/m2 should use superscript
+- Cumulus Calculates SLP giving a spike on start-up with the following stations: Ecowitt Local API, Davis Cloud Station, Ecowitt Cloud Station, HTTP Ambient, HTTP Ecowitt
 
 
 4.1.1 - b4025

--- a/Updates.txt
+++ b/Updates.txt
@@ -9,6 +9,9 @@ New
 	- The default output is generated using the format string "{0:%d} days {0:%h} hours"
 	- You can customise this like this example: <#SystemUpTime format="{0:%d}d {0:%h}h {0:%m}m">  --> "12d 9h 46m"
 
+Changed
+- Daily backup now runs asynchronously to prevent it stopping MX continue to run
+
 Fixed
 - Davis VP2 connection type being decoded from Cumulus.ini incorrectly
 - Add missing knots input to JSON station
@@ -16,6 +19,8 @@ Fixed
 - Cumulus Calculates SLP giving a spike on start-up with the following stations: Ecowitt Local API, Davis Cloud Station, Ecowitt Cloud Station, HTTP Ambient, HTTP Ecowitt
 - Add missing wind run units and extra space in humidity % in ai2 dashboard
 - Remove UV/Solar missing data messages from Davis Cloud (VP2)
+- A new version of MigrateData3to4 (1.0.3) to fix issues migrating the day file
+- Negative 0.0 appearing when no rainfall has occurred
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -14,7 +14,8 @@ Fixed
 - Add missing knots input to JSON station
 - Solar W/m2 should use superscript
 - Cumulus Calculates SLP giving a spike on start-up with the following stations: Ecowitt Local API, Davis Cloud Station, Ecowitt Cloud Station, HTTP Ambient, HTTP Ecowitt
-- Fix missing wind run units and humidity % in ai2 dashboard
+- Add missing wind run units and extra space in humidity % in ai2 dashboard
+- Remove UV/Solar missing data messages from Davis Cloud (VP2)
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -14,6 +14,8 @@ Fixed
 - Add missing knots input to JSON station
 - Solar W/m2 should use superscript
 - Cumulus Calculates SLP giving a spike on start-up with the following stations: Ecowitt Local API, Davis Cloud Station, Ecowitt Cloud Station, HTTP Ambient, HTTP Ecowitt
+- Fix missing wind run units and humidity % in ai2 dashboard
+
 
 
 4.1.1 - b4025

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,5 +1,8 @@
 4.1.2 - b4026
 —————————————
+New
+- Adds wind run to the dashboard "now" page
+
 Fixed
 - Davis VP2 connection type being decoded from Cumulus.ini incorrectly
 - Add missing knots input to JSON station

--- a/Updates.txt
+++ b/Updates.txt
@@ -12,7 +12,7 @@ New
 Fixed
 - Davis VP2 connection type being decoded from Cumulus.ini incorrectly
 - Add missing knots input to JSON station
-- Solar W/m2 should use superscript
+- Solar W/m2 should use superscript in dashboard
 - Cumulus Calculates SLP giving a spike on start-up with the following stations: Ecowitt Local API, Davis Cloud Station, Ecowitt Cloud Station, HTTP Ambient, HTTP Ecowitt
 - Add missing wind run units and extra space in humidity % in ai2 dashboard
 - Remove UV/Solar missing data messages from Davis Cloud (VP2)

--- a/Updates.txt
+++ b/Updates.txt
@@ -8,6 +8,9 @@ New
 	- For Standard format specifiers see: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings
 	- The default output is generated using the format string "{0:%d} days {0:%h} hours"
 	- You can customise this like this example: <#SystemUpTime format="{0:%d}d {0:%h}h {0:%m}m">  --> "12d 9h 46m"
+- New web tag <#AnnualRainfall>
+	- Defaults to the current year if no year is specified, so = <#ryear>
+	- Accepts a tag parameter of y=nnnn, which will return the total rainfall for the specified year. Eg. <#AnnualRainfall y=2021>
 
 Changed
 - Daily backup now runs asynchronously to prevent it stopping MX continue to run


### PR DESCRIPTION
New
- Adds wind run to the dashboard "now" page
- Adds support for the format parameter to the <#ProgramUpTime> and <#SystemUpTime> web tags
	- The format syntax is different from date/time web tags as these two tags use a elapsed time.
	- For Custom format specifiers see: https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-timespan-format-strings
	- For Standard format specifiers see: https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-timespan-format-strings
	- The default output is generated using the format string "{0:%d} days {0:%h} hours"
	- You can customise this like this example: <#SystemUpTime format="{0:%d}d {0:%h}h {0:%m}m">  --> "12d 9h 46m"
- New web tag <#AnnualRainfall>
	- Defaults to the current year if no year is specified, so = <#ryear>
	- Accepts a tag parameter of y=nnnn, which will return the total rainfall for the specified year. Eg. <#AnnualRainfall y=2021>

Changed
- Daily backup now runs asynchronously to prevent it stopping MX continue to run

Fixed
- Davis VP2 connection type being decoded from Cumulus.ini incorrectly
- Add missing knots input to JSON station
- Solar W/m2 should use superscript in dashboard
- Cumulus Calculates SLP giving a spike on start-up with the following stations: Ecowitt Local API, Davis Cloud Station, Ecowitt Cloud Station, HTTP Ambient, HTTP Ecowitt
- Add missing wind run units and extra space in humidity % in ai2 dashboard
- Remove UV/Solar missing data messages from Davis Cloud (VP2)
- A new version of MigrateData3to4 (1.0.3) to fix issues migrating the day file
- Negative 0.0 appearing when no rainfall has occurred
