### PR TITLE
v4.1.3 - b4028

### DIFF
--- a/CumulusMX.sln
+++ b/CumulusMX.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33205.214
@@ -13,13 +12,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Debug|x86.ActiveCfg = Debug|x86
+		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Debug|x86.Build.0 = Debug|x86
 		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Release|x86.ActiveCfg = Release|x86
+		{67A70E28-25C7-4C7F-BD7B-959AE6834B2C}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -12502,7 +12502,6 @@ namespace CumulusMX
 				Credentials = new NetworkCredential(FtpOptions.Username, FtpOptions.Password),
 			};
 
-			RealtimeFTP.Config.SocketPollInterval = 20000; // increase beyond the timeout value
 			RealtimeFTP.Config.LogPassword = false;
 
 			SetRealTimeFtpLogging(FtpOptions.Logging);

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -588,6 +588,8 @@ namespace CumulusMX
 
 			boolWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+			LogMessage("Dotnet Version: " + RuntimeInformation.FrameworkDescription);
+
 			// Some .NET 8 clutures use a non-"standard" minus symbol, this causes all sorts of parsing issues down the line and for external scripts
 			// the simplest solution is to override this and set all cultures to use the hypen-minus
 			if (CultureInfo.CurrentCulture.NumberFormat.NegativeSign != "-")

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -3912,6 +3912,7 @@ namespace CumulusMX
 			WllApiKey = ini.GetValue("WLL", "WLv2ApiKey", string.Empty);
 			WllApiSecret = ini.GetValue("WLL", "WLv2ApiSecret", string.Empty);
 			WllStationId = ini.GetValue("WLL", "WLStationId", -1, -1);
+			WllStationUuid = ini.GetValue("WLL", "WLStationUuid", "");
 			WllTriggerDataStoppedOnBroadcast = ini.GetValue("WLL", "DataStoppedOnBroadcast", true);
 			WLLAutoUpdateIpAddress = ini.GetValue("WLL", "AutoUpdateIpAddress", true);
 			WllBroadcastDuration = ini.GetValue("WLL", "BroadcastDuration", WllBroadcastDuration);
@@ -5609,6 +5610,7 @@ namespace CumulusMX
 			ini.SetValue("WLL", "WLv2ApiKey", Crypto.EncryptString(WllApiKey, Program.InstanceId, "WllApiKey"));
 			ini.SetValue("WLL", "WLv2ApiSecret", Crypto.EncryptString(WllApiSecret, Program.InstanceId, "WllApiSecret"));
 			ini.SetValue("WLL", "WLStationId", WllStationId);
+			ini.SetValue("WLL", "WLStationUuid", WllStationUuid);
 			ini.SetValue("WLL", "DataStoppedOnBroadcast", WllTriggerDataStoppedOnBroadcast);
 			ini.SetValue("WLL", "PrimaryRainTxId", WllPrimaryRain);
 			ini.SetValue("WLL", "PrimaryTempHumTxId", WllPrimaryTempHum);
@@ -7302,6 +7304,7 @@ namespace CumulusMX
 		internal string WllApiKey;
 		internal string WllApiSecret;
 		internal int WllStationId;
+		internal string WllStationUuid;
 		internal int WllParentId;
 		internal bool WllTriggerDataStoppedOnBroadcast; // trigger a data stopped state if broadcasts stop being received but current data is OK
 		/// <value>Read-only setting, default 20 minutes (1200 sec)</value>

--- a/CumulusMX/Cumulus.cs
+++ b/CumulusMX/Cumulus.cs
@@ -12914,7 +12914,11 @@ namespace CumulusMX
 				var latestBeta = releases.Find(x => !x.draft && x.prerelease);
 				var latestLive = releases.Find(x => !x.draft && !x.prerelease);
 				var cmxBuild = int.Parse(Build);
-				var veryLatest = Math.Max(int.Parse(latestBeta.tag_name[1..]), int.Parse(latestLive.tag_name[1..]));
+				int veryLatest;
+				if (latestBeta == null)
+					veryLatest = int.Parse(latestLive.tag_name[1..]);
+				else
+					veryLatest = Math.Max(int.Parse(latestBeta.tag_name[1..]), int.Parse(latestLive.tag_name[1..]));
 
 				if (string.IsNullOrEmpty(latestLive.name))
 				{
@@ -12924,7 +12928,7 @@ namespace CumulusMX
 					}
 					return;
 				}
-				else if (string.IsNullOrEmpty(latestBeta.name))
+				else if (latestBeta != null && string.IsNullOrEmpty(latestBeta.name))
 				{
 					LogMessage("Failed to get the latest beta build version from GitHub");
 					return;
@@ -12941,13 +12945,13 @@ namespace CumulusMX
 						UpgradeAlarm.Triggered = true;
 						LatestBuild = latestLive.tag_name[1..];
 					}
-					else if (int.Parse(latestBeta.tag_name[1..]) == cmxBuild)
+					else if (latestBeta != null && int.Parse(latestBeta.tag_name[1..]) == cmxBuild)
 					{
 						LogMessage($"This Cumulus MX instance is running the latest beta version");
 						UpgradeAlarm.Triggered = false;
 						LatestBuild = latestLive.tag_name[1..];
 					}
-					else if (int.Parse(latestBeta.tag_name[1..]) > cmxBuild)
+					else if (latestBeta != null && int.Parse(latestBeta.tag_name[1..]) > cmxBuild)
 					{
 						LogMessage($"This Cumulus MX beta instance is not running the latest beta version of Cumulsus MX, build {latestBeta.name} is available.");
 						UpgradeAlarm.Triggered = false;
@@ -12968,13 +12972,13 @@ namespace CumulusMX
 						LogWarningMessage(msg);
 						UpgradeAlarm.LastMessage = $"Release build {latestLive.name} is available";
 						UpgradeAlarm.Triggered = true;
-						LatestBuild = latestBeta.tag_name[1..];
+						LatestBuild = latestBeta != null ? latestBeta.tag_name[1..] : latestLive.tag_name[1..];
 					}
 					else if (int.Parse(latestLive.tag_name[1..]) == cmxBuild)
 					{
 						LogMessage($"This Cumulus MX instance is running the latest release version");
 						UpgradeAlarm.Triggered = false;
-						LatestBuild = latestBeta.tag_name[1..];
+						LatestBuild = latestBeta != null ? latestBeta.tag_name[1..] : latestLive.tag_name[1..];
 					}
 					else
 					{

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -15,6 +15,7 @@
     <IsPublishable>False</IsPublishable>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <Nullable>annotations</Nullable>
+    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -25,8 +26,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">
+    <OutputPath />
+    <DefineConstants>TRACE;DEBUG;USE_SQLITEPCL_RAW</DefineConstants>
+    <NoWarn>1701;1702</NoWarn>
+    <WarningsAsErrors>NU1605</WarningsAsErrors>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath></OutputPath>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <DefineConstants>TRACE;USE_SQLITEPCL_RAW</DefineConstants>
+    <NoWarn>1701;1702</NoWarn>
+    <WarningsAsErrors>NU1605</WarningsAsErrors>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'">
+    <OutputPath />
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
     <DefineConstants>TRACE;USE_SQLITEPCL_RAW</DefineConstants>

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -71,11 +71,11 @@
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageReference Include="NReco.Logging.File" Version="1.2.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.8" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.9" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
     <PackageReference Include="EmbedIO" Version="3.5.2" />
-    <PackageReference Include="FluentFTP" Version="50.1.0" />
+    <PackageReference Include="FluentFTP" Version="51.0.0" />
     <PackageReference Include="HidSharp" Version="2.1.0" />
     <PackageReference Include="MailKit" Version="4.7.1.1" />
     <PackageReference Include="MQTTnet" Version="4.3.6.1152" />

--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>4.1.2.4027</Version>
+    <Version>4.1.3.4028</Version>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
   </PropertyGroup>
 
@@ -69,19 +69,19 @@
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
     <PackageReference Include="FluentFTP.Logging" Version="1.0.0" />
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
-    <PackageReference Include="NReco.Logging.File" Version="1.2.0" />
+    <PackageReference Include="NReco.Logging.File" Version="1.2.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.8" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
     <PackageReference Include="EmbedIO" Version="3.5.2" />
-    <PackageReference Include="FluentFTP" Version="50.0.1" />
+    <PackageReference Include="FluentFTP" Version="50.1.0" />
     <PackageReference Include="HidSharp" Version="2.1.0" />
-    <PackageReference Include="MailKit" Version="4.6.0" />
+    <PackageReference Include="MailKit" Version="4.7.1.1" />
     <PackageReference Include="MQTTnet" Version="4.3.6.1152" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
-    <PackageReference Include="ServiceStack.Text" Version="8.2.2" />
-    <PackageReference Include="SSH.NET" Version="2024.0.0" />
+    <PackageReference Include="ServiceStack.Text" Version="8.3.0" />
+    <PackageReference Include="SSH.NET" Version="2024.1.0" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
   </ItemGroup>

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -3652,6 +3652,7 @@ namespace CumulusMX
 			var stationsUrl = "https://api.weatherlink.com/v2/stations?api-key=" + cumulus.WllApiKey;
 
 			cumulus.LogDebugMessage($"GetStations: URL = {stationsUrl.ToString().Replace(cumulus.WllApiKey, "API_KEY")}");
+			cumulus.LogDebugMessage($"GetStations: Looking for station id = {cumulus.WllStationId}");
 
 			try
 			{
@@ -3697,7 +3698,7 @@ namespace CumulusMX
 						}
 
 						wlStationArchiveInterval = station.recording_interval;
-						DataTimeoutMins = wlStationArchiveInterval + 3;
+						SetDataTimeout(station.subscription_type);
 					}
 				}
 				if (stationsObj.stations.Count > 1 && cumulus.WllStationId < 10)
@@ -3715,6 +3716,7 @@ namespace CumulusMX
 					cumulus.LogDebugMessage($"GetStations: Setting WLL parent ID = {stationsObj.stations[0].gateway_id}");
 					cumulus.WllParentId = stationsObj.stations[0].gateway_id;
 					wlStationArchiveInterval = stationsObj.stations[0].recording_interval;
+					SetDataTimeout(stationsObj.stations[0].subscription_type);
 					return;
 				}
 			}
@@ -3722,6 +3724,19 @@ namespace CumulusMX
 			{
 				cumulus.LogDebugMessage("GetStations: WeatherLink API exception: " + ex.Message);
 			}
+		}
+
+		private void SetDataTimeout(string subscription)
+		{
+			subscription = (subscription ?? "basic").ToLower();
+
+			DataTimeoutMins = subscription switch
+			{
+				"basic" => 15 + 3,
+				"pro" => 5 + 3,
+				"pro+" => 1 + 3,
+				_ => 15 + 3,
+			};
 		}
 
 		private void GetAvailableSensors()

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -43,6 +43,7 @@ namespace CumulusMX
 		private readonly List<WlSensor> sensorList = [];
 		private readonly bool useWeatherLinkDotCom = true;
 		private readonly bool[] sensorContactLost = new bool[9];
+		private DateTime lastHistoricData;
 
 		public DavisWllStation(Cumulus cumulus) : base(cumulus)
 		{
@@ -1427,7 +1428,8 @@ namespace CumulusMX
 		public override void startReadingHistoryData()
 		{
 			cumulus.LogMessage("WLL history: Reading history data from log files");
-			LoadLastHoursFromDataLogs(cumulus.LastUpdateTime);
+			lastHistoricData = cumulus.LastUpdateTime;
+			LoadLastHoursFromDataLogs(lastHistoricData);
 
 			cumulus.LogMessage("WLL history: Reading archive data from WeatherLink API");
 			bw = new BackgroundWorker { WorkerSupportsCancellation = true };
@@ -1496,7 +1498,7 @@ namespace CumulusMX
 			if (cumulus.WllApiKey == string.Empty || cumulus.WllApiSecret == string.Empty)
 			{
 				cumulus.LogMessage("GetWlHistoricData: Missing WeatherLink API data in the configuration, aborting!");
-				cumulus.LastUpdateTime = DateTime.Now;
+				lastHistoricData = DateTime.Now;
 				return;
 			}
 
@@ -1505,11 +1507,10 @@ namespace CumulusMX
 				const string msg = "No WeatherLink API station ID in the configuration";
 				cumulus.LogWarningMessage(msg);
 				Cumulus.LogConsoleMessage("GetWlHistoricData: " + msg);
-
 			}
 
 			var unixDateTime = Utils.ToUnixTime(DateTime.Now);
-			var startTime = Utils.ToUnixTime(cumulus.LastUpdateTime);
+			var startTime = Utils.ToUnixTime(lastHistoricData);
 			long endTime = unixDateTime;
 			int unix24hrs = 24 * 60 * 60;
 
@@ -1521,8 +1522,8 @@ namespace CumulusMX
 				maxArchiveRuns++;
 			}
 
-			Cumulus.LogConsoleMessage($"Downloading Historic Data from WL.com from: {cumulus.LastUpdateTime:s} to: {Utils.FromUnixTime(endTime):s}");
-			cumulus.LogMessage($"GetWlHistoricData: Downloading Historic Data from WL.com from: {cumulus.LastUpdateTime:s} to: {Utils.FromUnixTime(endTime):s}");
+			Cumulus.LogConsoleMessage($"Downloading Historic Data from WL.com from: {lastHistoricData:s} to: {Utils.FromUnixTime(endTime):s}");
+			cumulus.LogMessage($"GetWlHistoricData: Downloading Historic Data from WL.com from: {lastHistoricData:s} to: {Utils.FromUnixTime(endTime):s}");
 
 			StringBuilder historicUrl = new StringBuilder("https://api.weatherlink.com/v2/historic/" + cumulus.WllStationId);
 			historicUrl.Append("?api-key=" + cumulus.WllApiKey);
@@ -1531,10 +1532,10 @@ namespace CumulusMX
 
 			cumulus.LogDebugMessage($"WeatherLink URL = {historicUrl.ToString().Replace(cumulus.WllApiKey, "API_KEY")}");
 
-			lastDataReadTime = cumulus.LastUpdateTime;
+			lastDataReadTime = lastHistoricData;
 			int luhour = lastDataReadTime.Hour;
 
-			int rollHour = Math.Abs(cumulus.GetHourInc(cumulus.LastUpdateTime));
+			int rollHour = Math.Abs(cumulus.GetHourInc(lastHistoricData));
 
 			cumulus.LogMessage($"Roll over hour = {rollHour}");
 
@@ -1568,7 +1569,7 @@ namespace CumulusMX
 					var historyError = responseBody.FromJson<WlErrorResponse>();
 					cumulus.LogWarningMessage($"GetWlHistoricData: WeatherLink API Historic Error: {historyError.code}, {historyError.message}");
 					Cumulus.LogConsoleMessage($" - Error {historyError.code}: {historyError.message}", ConsoleColor.Red);
-					cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
+					lastHistoricData = Utils.FromUnixTime(endTime);
 					return;
 				}
 
@@ -1576,7 +1577,7 @@ namespace CumulusMX
 				{
 					cumulus.LogWarningMessage("GetWlHistoricData: WeatherLink API Historic: No data was returned. Check your Device Id.");
 					Cumulus.LogConsoleMessage(" - No historic data available");
-					cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
+					lastHistoricData = Utils.FromUnixTime(endTime);
 					return;
 				}
 				else if (responseBody.StartsWith("{\"")) // basic sanity check
@@ -1604,7 +1605,7 @@ namespace CumulusMX
 					{
 						cumulus.LogMessage("GetWlHistoricData: No historic data available");
 						Cumulus.LogConsoleMessage(" - No historic data available");
-						cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
+						lastHistoricData = Utils.FromUnixTime(endTime);
 						return;
 					}
 					else
@@ -1616,7 +1617,7 @@ namespace CumulusMX
 				{
 					cumulus.LogErrorMessage("GetWlHistoricData: Invalid historic message received");
 					cumulus.LogMessage("GetWlHistoricData: Received: " + responseBody);
-					cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
+					lastHistoricData = Utils.FromUnixTime(endTime);
 					return;
 				}
 			}
@@ -1629,7 +1630,7 @@ namespace CumulusMX
 					cumulus.LogMessage($"GetWlHistoricData: Base exception - {ex.Message}");
 				}
 
-				cumulus.LastUpdateTime = Utils.FromUnixTime(endTime);
+				lastHistoricData = Utils.FromUnixTime(endTime);
 				return;
 			}
 
@@ -1818,6 +1819,8 @@ namespace CumulusMX
 
 			if (!Program.service)
 				Console.WriteLine(""); // flush the progress line
+
+			lastHistoricData = Utils.FromUnixTime(endTime);
 		}
 
 		private void DecodeHistoric(int dataType, int sensorType, string json)

--- a/CumulusMX/EcowittApi.cs
+++ b/CumulusMX/EcowittApi.cs
@@ -2612,10 +2612,19 @@ namespace CumulusMX
 					}
 					else if (retObj.code == 0)
 					{
-						cumulus.FirmwareAlarm.LastMessage = $"A new firmware version is available: {retObj.data.name}.\nChange log:\n{retObj.data.content}";
-						cumulus.FirmwareAlarm.Triggered = true;
-						cumulus.LogWarningMessage($"API.GetLatestFirmwareVersion: Latest Version {retObj.data.name}, Change log:\n{retObj.data.content}");
-						return retObj.data.name;
+						if (retObj.data.content.Contains("test"))  // "- This is a test firmware."
+						{
+							cumulus.LogMessage($"(\"API.GetLatestFirmwareVersion: You are running on test firmware: {retObj.data.name}");
+							cumulus.FirmwareAlarm.Triggered = false;
+							return null;
+						}
+						else
+						{
+							cumulus.FirmwareAlarm.LastMessage = $"A new firmware version is available: {retObj.data.name}.\nChange log:\n{retObj.data.content}";
+							cumulus.FirmwareAlarm.Triggered = true;
+							cumulus.LogWarningMessage($"API.GetLatestFirmwareVersion: Latest Version {retObj.data.name}, Change log:\n{retObj.data.content}");
+							return retObj.data.name;
+						}
 					}
 					else
 					{

--- a/CumulusMX/GW1000Station.cs
+++ b/CumulusMX/GW1000Station.cs
@@ -775,7 +775,7 @@ namespace CumulusMX
 						else
 						{
 							batt = $"{battV:f2}V ({TestBatteryWh40(data[battPos], battV)})"; // low = 1.2V
-							if (battV == 1.6)
+							if (battV >= 1.59)
 							{
 								batt += " dummy value?";
 							}

--- a/CumulusMX/StationSettings.cs
+++ b/CumulusMX/StationSettings.cs
@@ -329,7 +329,8 @@ namespace CumulusMX
 			{
 				apiKey = cumulus.WllApiKey,
 				apiSecret = cumulus.WllApiSecret,
-				apiStationId = cumulus.WllStationId
+				apiStationId = cumulus.WllStationId,
+				apiStationUuid = cumulus.WllStationUuid
 			};
 
 			var wllPrimary = new JsonStationSettingsWllPrimary()
@@ -795,6 +796,7 @@ namespace CumulusMX
 						cumulus.WllApiKey = string.IsNullOrWhiteSpace(settings.daviswll.api.apiKey) ? null : settings.daviswll.api.apiKey.Trim();
 						cumulus.WllApiSecret = string.IsNullOrWhiteSpace(settings.daviswll.api.apiSecret) ? null : settings.daviswll.api.apiSecret.Trim();
 						cumulus.WllStationId = settings.daviswll.api.apiStationId;
+						cumulus.WllStationUuid = settings.daviswll.api.apiStationUuid;
 
 						if (settings.general.stationtype == 11 || settings.general.stationtype == 19) // WLL & Cloud WLL/WLC only
 						{
@@ -1908,6 +1910,7 @@ namespace CumulusMX
 		public string apiKey { get; set; }
 		public string apiSecret { get; set; }
 		public int apiStationId { get; set; }
+		public string apiStationUuid { get; set; }
 	}
 
 	internal class JsonStationSettingsWllPrimary

--- a/CumulusMX/WeatherLinkDotCom.cs
+++ b/CumulusMX/WeatherLinkDotCom.cs
@@ -834,6 +834,7 @@ namespace CumulusMX
 	public class WlStationListStations
 	{
 		public int station_id { get; set; }
+		public string station_id_uuid { get; set; }
 		public string station_name { get; set; }
 		public int gateway_id { get; set; }
 		public string gateway_id_hex { get; set; }
@@ -854,6 +855,9 @@ namespace CumulusMX
 		public double latitude { get; set; }
 		public double longitude { get; set; }
 		public double elevation { get; set; }
+		public string gateway_type { get; set; }
+		public string relationship_type { get; set; }
+		public string subscription_type { get; set; }
 	}
 
 	public class WlSensor(int sensorType, int lsid, int parentId, string name, string parentName)

--- a/CumulusMX/webtags.cs
+++ b/CumulusMX/webtags.cs
@@ -3006,6 +3006,11 @@ namespace CumulusMX
 			return cumulus.StationType == -1 ? "undefined" : EncodeForJs(cumulus.StationDesc[cumulus.StationType]);
 		}
 
+		private string TagstationId(Dictionary<string, string> tagParams)
+		{
+			return cumulus.StationType == -1 ? "undefined" : cumulus.StationType.ToString();
+		}
+
 		private string Taglatitude(Dictionary<string, string> tagParams)
 		{
 			var dpstr = tagParams.Get("dp");
@@ -6185,6 +6190,7 @@ namespace CumulusMX
 				{ "graphperiod", Taggraphperiod },
 				{ "stationtype", Tagstationtype },
 				{ "stationtypeJsEnc", TagstationtypeJsEnc },
+				{ "stationId", TagstationId	},
 				{ "latitude", Taglatitude },
 				{ "latitudeJsEnc", TaglatitudeJsEnc },
 				{ "longitude", Taglongitude },

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,6 +3,8 @@
 —————————————
 New
 - New web tag <#stationId> which returns the internal station number used by CMX to determine the station type
+- For Davis WLL and WeatherLink Cloud stations you can now specify the station identifier using the stations UUID instead of the numeric Id. The UUID is simplier to find
+	as it forms part of the URL of every web page related to your station on weatherlink.com
 
 Changed
 
@@ -13,8 +15,7 @@ Fixed
 - AI2 Davis reception stats display incorrectly
 - Davis Cloud Station (VP2) now correctly displays the Davis ET values when "Cumulus calculates ET" is not enabled
 	- Note: If "Cumulus calculates ET" is not enabled, the last hours ET every day, will be accumulated in the first hour of the following day
--
- Davis WLL, and Davis Cloud stations, fixed a problem where the rollover would not be performed if historic data was not available and MX was stopped before the rollover and restarted after
+- Davis WLL, and Davis Cloud stations, fixed a problem where the rollover would not be performed if historic data was not available and MX was stopped before the rollover and restarted after
 
 Package Updates
 - SixLabors.ImageSharp
@@ -23,6 +24,7 @@ Package Updates
 - NReco.Logging.File
 - ServiceStack.Text
 - SSH.Net
+- SQLite
 
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -16,6 +16,7 @@ Fixed
 - Davis Cloud Station (VP2) now correctly displays the Davis ET values when "Cumulus calculates ET" is not enabled
 	- Note: If "Cumulus calculates ET" is not enabled, the last hours ET every day, will be accumulated in the first hour of the following day
 - Davis WLL, and Davis Cloud stations, fixed a problem where the rollover would not be performed if historic data was not available and MX was stopped before the rollover and restarted after
+- Improved Ctrl-C shutdown of Cumulus MX for Davis VP2 stations when they are failing to connect with the station
 
 Package Updates
 - SixLabors.ImageSharp

--- a/Updates.txt
+++ b/Updates.txt
@@ -17,6 +17,9 @@ Fixed
 	- Note: If "Cumulus calculates ET" is not enabled, the last hours ET every day, will be accumulated in the first hour of the following day
 - Davis WLL, and Davis Cloud stations, fixed a problem where the rollover would not be performed if historic data was not available and MX was stopped before the rollover and restarted after
 - Improved Ctrl-C shutdown of Cumulus MX for Davis VP2 stations when they are failing to connect with the station
+- Fix CMX version check when no betas are available on Github repo
+- Fix Ecowitt firmware check when running test firmware
+
 
 Package Updates
 - SixLabors.ImageSharp

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,8 +2,12 @@
 4.1.3 - b4028
 —————————————
 New
+
 Changed
+
 Fixed
+- The Cumulus MX version comparison with latest online at startup and daily
+
 
 Package Updates
 - SixLabors.ImageSharp
@@ -12,6 +16,7 @@ Package Updates
 - NReco.Logging.File
 - ServiceStack.Text
 - SSH.Net
+
 
 
 4.1.2 - b4027

--- a/Updates.txt
+++ b/Updates.txt
@@ -10,14 +10,14 @@ Changed
 
 Fixed
 - The Cumulus MX version comparison with latest online at startup and daily
+- Fix CMX version check when no betas are available on Github repo
 - Davis Cloud Station can now accurately determine the current conditions update rate
 - Fix Davis WLL (and others) creating erroneous wind speed spike warnings
-- AI2 Davis reception stats display incorrectly
+- Alternative Interface 2 - Davis reception stats display incorrectly
 - Davis Cloud Station (VP2) now correctly displays the Davis ET values when "Cumulus calculates ET" is not enabled
 	- Note: If "Cumulus calculates ET" is not enabled, the last hours ET every day, will be accumulated in the first hour of the following day
 - Davis WLL, and Davis Cloud stations, fixed a problem where the rollover would not be performed if historic data was not available and MX was stopped before the rollover and restarted after
 - Improved Ctrl-C shutdown of Cumulus MX for Davis VP2 stations when they are failing to connect with the station
-- Fix CMX version check when no betas are available on Github repo
 - Fix Ecowitt firmware check when running test firmware
 
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -7,6 +7,8 @@ Changed
 
 Fixed
 - The Cumulus MX version comparison with latest online at startup and daily
+- Davis Cloud Station can now accurately determine the current conditions update rate
+- Fix Davis WLL (and others) creating erroneous wind speed spike warnings
 
 
 Package Updates

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,19 @@
+
+4.1.3 - b4028
+—————————————
+New
+Changed
+Fixed
+
+Package Updates
+- SixLabors.ImageSharp
+- FluentFTP
+- MailKit
+- NReco.Logging.File
+- ServiceStack.Text
+- SSH.Net
+
+
 4.1.2 - b4027
 —————————————
 New

--- a/Updates.txt
+++ b/Updates.txt
@@ -2,6 +2,7 @@
 4.1.3 - b4028
 —————————————
 New
+- New web tag <#stationId> which returns the internal station number used by CMX to determine the station type
 
 Changed
 
@@ -9,6 +10,7 @@ Fixed
 - The Cumulus MX version comparison with latest online at startup and daily
 - Davis Cloud Station can now accurately determine the current conditions update rate
 - Fix Davis WLL (and others) creating erroneous wind speed spike warnings
+- AI2 Davis reception stats
 
 
 Package Updates

--- a/Updates.txt
+++ b/Updates.txt
@@ -10,8 +10,11 @@ Fixed
 - The Cumulus MX version comparison with latest online at startup and daily
 - Davis Cloud Station can now accurately determine the current conditions update rate
 - Fix Davis WLL (and others) creating erroneous wind speed spike warnings
-- AI2 Davis reception stats
-
+- AI2 Davis reception stats display incorrectly
+- Davis Cloud Station (VP2) now correctly displays the Davis ET values when "Cumulus calculates ET" is not enabled
+	- Note: If "Cumulus calculates ET" is not enabled, the last hours ET every day, will be accumulated in the first hour of the following day
+-
+ Davis WLL, and Davis Cloud stations, fixed a problem where the rollover would not be performed if historic data was not available and MX was stopped before the rollover and restarted after
 
 Package Updates
 - SixLabors.ImageSharp
@@ -71,7 +74,7 @@ New
 - Cumulus now calculates the AQi for Ecowitt PM and CO₂ sensors
 	- New web tags:
 	<#AirQualityIdx1[-4]>, <#AirQualityAvgIdx1[-4]>
-	<#CO2_pm2p5_aqi>, <#CO2_pm2p5_24h_aqi>, <#CO2_pm10_aqi>, <#CO2_pm10_24_aqih>
+	<#CO2_pm2p5_aqi>, <#CO2_pm2p5_24h_aqi>, <#CO2_pm10_aqi>, <#CO2_pm10_24_aqi>
 - Add new pressure units option of kilopascal (kPa)
 - New station type added: JSON Data Input, marked as "experimental" for now, but testing so far has been successful
 	- Accepts data in a JSON format defined in MXutils/WeatherStationInput.jsonc


### PR DESCRIPTION
New
- New web tag <#stationId> which returns the internal station number used by CMX to determine the station type
- For Davis WLL and WeatherLink Cloud stations you can now specify the station identifier using the stations UUID instead of the numeric Id. The UUID is simplier to find
	as it forms part of the URL of every web page related to your station on weatherlink.com

Changed

Fixed
- The Cumulus MX version comparison with latest online at startup and daily
- Fix CMX version check when no betas are available on Github repo
- Davis Cloud Station can now accurately determine the current conditions update rate
- Fix Davis WLL (and others) creating erroneous wind speed spike warnings
- Alternative Interface 2 - Davis reception stats display incorrectly
- Davis Cloud Station (VP2) now correctly displays the Davis ET values when "Cumulus calculates ET" is not enabled
	- Note: If "Cumulus calculates ET" is not enabled, the last hours ET every day, will be accumulated in the first hour of the following day
- Davis WLL, and Davis Cloud stations, fixed a problem where the rollover would not be performed if historic data was not available and MX was stopped before the rollover and restarted after
- Improved Ctrl-C shutdown of Cumulus MX for Davis VP2 stations when they are failing to connect with the station
- Fix Ecowitt firmware check when running test firmware