### PR TITLE
4.1.4 - b4029

### DIFF
--- a/CumulusMX/CumulusMX.csproj
+++ b/CumulusMX/CumulusMX.csproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>4.1.3.4028</Version>
+    <Version>4.1.4.4029</Version>
     <Copyright>Copyright ©  2015-$([System.DateTime]::Now.ToString('yyyy')) Cumulus MX</Copyright>
   </PropertyGroup>
 
@@ -90,7 +90,7 @@
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="8.0.0" />
     <PackageReference Include="NReco.Logging.File" Version="1.2.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.8" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
     <PackageReference Include="EmbedIO" Version="3.5.2" />

--- a/CumulusMX/DavisCloudStation.cs
+++ b/CumulusMX/DavisCloudStation.cs
@@ -3763,7 +3763,7 @@ namespace CumulusMX
 				_ => 15 + 3,
 			};
 
-			cumulus.LogMessage($"GetStations: Subscription type = {subscription}, update rate = {DataTimeoutMins} minutes");
+			cumulus.LogMessage($"GetStations: Subscription type = {subscription}, data timeout = {DataTimeoutMins} minutes");
 		}
 
 		private void GetAvailableSensors()

--- a/CumulusMX/DavisStation.cs
+++ b/CumulusMX/DavisStation.cs
@@ -789,7 +789,7 @@ namespace CumulusMX
 
 					GetArchiveData();
 
-					// The VP" seems to need a nudge after a DMPAFT command
+					// The VP2 seems to need a nudge after a DMPAFT command
 					if (isSerial)
 					{
 						WakeVP(comport, true);

--- a/CumulusMX/DavisWllStation.cs
+++ b/CumulusMX/DavisWllStation.cs
@@ -44,6 +44,7 @@ namespace CumulusMX
 		private readonly bool useWeatherLinkDotCom = true;
 		private readonly bool[] sensorContactLost = new bool[9];
 		private DateTime lastHistoricData;
+		private string subscriptionType = string.Empty;
 
 		public DavisWllStation(Cumulus cumulus) : base(cumulus)
 		{
@@ -3039,10 +3040,10 @@ namespace CumulusMX
 
 				foreach (var station in stationsObj.stations)
 				{
-					cumulus.LogMessage($"WLLStations: Found WeatherLink station id = {station.station_id}, name = {station.station_name}");
+					cumulus.LogMessage($"WLLStations: WeatherLink station id = {station.station_id}, name = {station.station_name}, active = {station.active}, subscription = {station.subscription_type}");
 					if (stationsObj.stations.Count > 1 && logToConsole)
 					{
-						Cumulus.LogConsoleMessage($" - Found WeatherLink station id = {station.station_id}, name = {station.station_name}, active = {station.active}");
+						Cumulus.LogConsoleMessage($" - Found WeatherLink station id = {station.station_id}, name = {station.station_name}, active = {station.active}, subscription = {station.subscription_type}");
 					}
 					if (station.station_id == cumulus.WllStationId || cumulus.WllStationUuid == station.station_id_uuid)
 					{
@@ -3063,6 +3064,8 @@ namespace CumulusMX
 							cumulus.WllStationUuid = station.station_id_uuid;
 						}
 
+						subscriptionType = station.subscription_type.ToLower();
+
 						cumulus.WriteIniFile();
 					}
 				}
@@ -3078,6 +3081,8 @@ namespace CumulusMX
 					cumulus.LogMessage($"WLLStations: Only found 1 WeatherLink station, using id = {usedId}");
 					cumulus.WllStationId = stationsObj.stations[0].station_id;
 					cumulus.WllStationUuid = stationsObj.stations[0].station_id_uuid;
+					subscriptionType = stationsObj.stations[0].subscription_type.ToLower();
+
 					// And save it to the config file
 					cumulus.WriteIniFile();
 

--- a/Updates.txt
+++ b/Updates.txt
@@ -3,14 +3,14 @@
 —————————————
 New
 - New web tag <#stationId> which returns the internal station number used by CMX to determine the station type
-- For Davis WLL and WeatherLink Cloud stations you can now specify the station identifier using the stations UUID instead of the numeric Id. The UUID is simplier to find
+- For Davis WLL and WeatherLink Cloud stations you can now specify the station identifier using the stations UUID instead of the numeric Id. The UUID is simpler to find
 	as it forms part of the URL of every web page related to your station on weatherlink.com
 
 Changed
 
 Fixed
 - The Cumulus MX version comparison with latest online at startup and daily
-- Fix CMX version check when no betas are available on Github repo
+- Fix CMX version check when no betas are available on GitHub repo
 - Davis Cloud Station can now accurately determine the current conditions update rate
 - Fix Davis WLL (and others) creating erroneous wind speed spike warnings
 - Alternative Interface 2 - Davis reception stats display incorrectly

--- a/Updates.txt
+++ b/Updates.txt
@@ -1,3 +1,16 @@
+4.1.4 - b4029
+—————————————
+Fixed
+- Davis Cloud stations in endless loop at startup if there is no historic data to process or access is denied
+
+Changed
+- Davis WLL/DAvis Cloud stations now use the WL.com subscription level to determine if they use WL.com as a logger
+
+
+Package Updates
+- SQLite: Reverted to v2.1.8 pending fix from author
+
+
 
 4.1.3 - b4028
 —————————————


### PR DESCRIPTION
Fixed
- Davis Cloud stations in endless loop at startup if there is no historic data to process or access is denied

Changed
- Davis WLL/DAvis Cloud stations now use the WL.com subscription level to determine if they use WL.com as a logger


Package Updates
- SQLite: Reverted to v2.1.8 pending fix from author