### PR TITLE
Fix null wind_dir_scalar_avg_last_10_min crash on Davis Cloud stations

### DIFF
--- a/CumulusMX/Stations/DavisCloudStation.cs
+++ b/CumulusMX/Stations/DavisCloudStation.cs
@@ -1846,7 +1846,7 @@ namespace CumulusMX.Stations
 													}
 													else
 													{
-														bearing = rec.wind_dir_scalar_avg_last_10_min;
+														bearing = rec.wind_dir_scalar_avg_last_10_min ?? 0;
 													}
 
 													if (cumulus.StationOptions.PeakGustMinutes < 10)

--- a/CumulusMX/Stations/WeatherLinkDotCom.cs
+++ b/CumulusMX/Stations/WeatherLinkDotCom.cs
@@ -653,7 +653,7 @@ namespace CumulusMX.Stations
 		public double? wind_speed_hi_last_2_min { get; set; }
 		public int? wind_dir_at_hi_speed_last_2_min { get; set; }
 		public double? wind_speed_avg_last_10_min { get; set; }
-		public int wind_dir_scalar_avg_last_10_min { get; set; }
+		public int? wind_dir_scalar_avg_last_10_min { get; set; }
 		public double? wind_speed_hi_last_10_min { get; set; }
 		public int? wind_dir_at_hi_speed_last_10_min { get; set; }
 		public double? wind_run_day { get; set; }  // Type 23 only


### PR DESCRIPTION
## Summary

- Make `wind_dir_scalar_avg_last_10_min` nullable (`int?`) in `WlCurrentSensor23` (WeatherLinkDotCom.cs), consistent with all other wind direction fields in the same class
- Add null-coalescing (`?? 0`) at the usage site in `DavisCloudStation.DecodeCurrent()`

## Problem

The WeatherLink API returns `null` for `wind_dir_scalar_avg_last_10_min` during calm/no-wind conditions. Since the property is typed as non-nullable `int`, `System.Text.Json` deserialization throws:

```
Error, DecodeCurrent, DataType=23, SensorType=43 - Exception Type: System.Text.Json.JsonException
Message: The JSON value could not be converted to System.Int32.
Path: $[0].wind_dir_scalar_avg_last_10_min
Inner Exception: Cannot get the value of a token type 'Null' as a number.
```

This causes CumulusMX to crash-loop on Davis Cloud (WLC) stations whenever the weather station reports calm winds (null wind direction).

## Fix

Two-line change:
1. `WeatherLinkDotCom.cs:656` — `int` → `int?` (matches `wind_dir_scalar_avg_last_2_min`, `wind_dir_at_hi_speed_last_10_min`, etc.)
2. `DavisCloudStation.cs:1849` — add `?? 0` null coalescing (matches line 1845's pattern for the 2-min field)

## Test plan

- Verified fix on a live Davis Vantage Vue connected via WeatherLink Cloud
- CumulusMX was crash-looping every ~5 seconds before the fix
- After applying the patched DLL, CumulusMX runs stable through calm wind periods